### PR TITLE
chore: bump version to 0.5.5-fork.1 (test release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             artifacts/ccmux-windows-x64.exe/ccmux-windows-x64.exe
             artifacts/ccmux-macos-x64/ccmux-macos-x64
@@ -102,6 +103,15 @@ jobs:
       - name: Verify npm version
         run: npm --version
 
+      - name: Determine npm dist-tag
+        id: disttag
+        run: |
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm via Trusted Publishing
         working-directory: npm
-        run: npm publish --access public
+        run: npm publish --access public --tag ${{ steps.disttag.outputs.tag }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.4"
+version = "0.5.5-fork.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccmux"
-version = "0.5.4"
+version = "0.5.5-fork.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.4",
+  "version": "0.5.5-fork.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -59,9 +59,14 @@ fn fetch_latest() -> Result<String, Box<dyn std::error::Error>> {
 }
 
 /// Compare semver-like versions (simple major.minor.patch).
+/// Prerelease suffix (e.g. "-fork.1") is stripped before comparison, matching
+/// what the npm `latest` tag tracks — we never surface a prerelease as an update.
 fn is_newer(latest: &str, current: &str) -> bool {
     let parse = |s: &str| -> Vec<u32> {
         s.trim_start_matches('v')
+            .split('-')
+            .next()
+            .unwrap_or("")
             .split('.')
             .filter_map(|p| p.parse().ok())
             .collect()
@@ -80,5 +85,14 @@ mod tests {
         assert!(is_newer("0.3.1", "0.3.0"));
         assert!(!is_newer("0.3.0", "0.3.0"));
         assert!(!is_newer("0.2.0", "0.3.0"));
+    }
+
+    #[test]
+    fn test_is_newer_with_prerelease() {
+        // Prerelease suffix is ignored; only major.minor.patch is compared.
+        assert!(!is_newer("0.5.5-fork.1", "0.5.5"));
+        assert!(!is_newer("0.5.5", "0.5.5-fork.1"));
+        assert!(is_newer("0.6.0-fork.1", "0.5.9"));
+        assert!(!is_newer("0.5.4-fork.1", "0.5.5"));
     }
 }


### PR DESCRIPTION
## Summary
`ccmux-fork` 名義での初回 CI リリースを検証する prerelease (Issue #3)。

- Cargo.toml / npm/package.json / Cargo.lock のバージョンを \`0.5.5-fork.1\` に統一
- マージ後に \`v0.5.5-fork.1\` タグを打ち、release.yml が以下を自動化することを確認する:
  - 4 プラットフォームのバイナリビルド
  - GitHub Release 作成 + checksums.txt
  - npm Trusted Publishing 経由の publish

## Test plan
- [ ] マージ後 \`git tag v0.5.5-fork.1 && git push origin v0.5.5-fork.1\`
- [ ] Actions で release workflow が成功
- [ ] GitHub Release に 4 バイナリ + checksums.txt が存在
- [ ] \`npm view ccmux-fork@0.5.5-fork.1\` が返る
- [ ] 別マシンで \`npm install -g ccmux-fork@0.5.5-fork.1\` が成功

Refs #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)