### PR TITLE
chore: rewrite docs index to drop upstream marketing voice (closes #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ image copy 2.png
 # Platform-specific binaries fetched by npm postinstall
 /npm/bin/ccmux
 /npm/bin/ccmux.exe
+.claude/scheduled_tasks.lock

--- a/docs/content/en/index.mdx
+++ b/docs/content/en/index.mdx
@@ -1,20 +1,22 @@
-# ccmux
+# ccmux-fork
 
-**Claude Code Multiplexer** — manage multiple Claude Code instances in TUI split panes.
+**Claude Code Multiplexer (fork)** — a Rust TUI tool for managing multiple Claude Code instances in split panes.
+
+> This is a fork ([happy-ryo/ccmux](https://github.com/happy-ryo/ccmux)) of [Shin-sibainu/ccmux](https://github.com/Shin-sibainu/ccmux). It periodically syncs upstream while developing independent features, and is distributed on npm as `ccmux-fork`. See [`BRANCHING.md`](https://github.com/happy-ryo/ccmux/blob/main/BRANCHING.md) for the fork policy.
 
 ![ccmux screenshot](/screenshot.png)
 
-## What is ccmux?
+## Overview
 
-ccmux is a lightweight terminal multiplexer built specifically for running multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions side-by-side. Think of it as tmux, but designed around the Claude Code workflow.
+ccmux is a lightweight terminal multiplexer focused on running multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions in parallel. It's a thin layer on top of PTYs with a vt100 emulator, offering split panes, tabs, and a file tree.
 
-## Why ccmux?
+## Highlights
 
-- **Run multiple Claude Code agents simultaneously** in split panes
-- **See your project files** with syntax-highlighted preview while coding
-- **Stay in the terminal** — no editor needed, just your shell and Claude
-- **Blazingly fast & lightweight** — single ~2MB binary, 0.5s startup, ~0% idle CPU
-- **Built in Rust** — zero-allocation cell rendering, dirty-flag diff updates, PTY resize caching
+- Run multiple Claude Code sessions side-by-side in split panes
+- File tree with syntax-highlighted preview
+- Independent workspaces per tab
+- Single binary (~2 MB), no runtime dependencies
+- Windows / macOS / Linux
 
 ## Quick Start
 
@@ -33,9 +35,3 @@ Once running, type `claude` in the terminal pane to start Claude Code.
 - [**Claude detection**](/en/features#claude-detection) — Pane border turns orange when Claude is running
 - [**Text selection**](/en/features#text-selection--copy) — Drag to select, auto-copy to clipboard
 - [**Scrollback**](/en/features#terminal-scrollback) — 10,000 lines of history per pane
-
----
-
-## Learn Claude Code
-
-Want to learn Claude Code systematically? Check out [**Claude Code Academy**](https://claude-code-academy.dev).

--- a/docs/content/en/index.mdx
+++ b/docs/content/en/index.mdx
@@ -1,6 +1,6 @@
-# ccmux-fork
+# ccmux
 
-**Claude Code Multiplexer (fork)** — a Rust TUI tool for managing multiple Claude Code instances in split panes.
+**Claude Code Multiplexer** — a Rust TUI tool for managing multiple Claude Code instances in split panes.
 
 > This is a fork ([happy-ryo/ccmux](https://github.com/happy-ryo/ccmux)) of [Shin-sibainu/ccmux](https://github.com/Shin-sibainu/ccmux). It periodically syncs upstream while developing independent features, and is distributed on npm as `ccmux-fork`. See [`BRANCHING.md`](https://github.com/happy-ryo/ccmux/blob/main/BRANCHING.md) for the fork policy.
 
@@ -8,7 +8,7 @@
 
 ## Overview
 
-ccmux is a lightweight terminal multiplexer focused on running multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions in parallel. It's a thin layer on top of PTYs with a vt100 emulator, offering split panes, tabs, and a file tree.
+ccmux is a lightweight terminal multiplexer focused on running multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions in parallel. It's a thin layer on top of PTYs with a vt100 emulator, offering split panes, tabs, and a file tree. Think of it as tmux shaped around the Claude Code workflow.
 
 ## Highlights
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,20 +1,22 @@
-# ccmux
+# ccmux-fork
 
-**Claude Code Multiplexer** — 複数の Claude Code インスタンスを TUI 分割ペインで管理。
+**Claude Code Multiplexer (fork)** — 複数の Claude Code インスタンスを TUI 分割ペインで管理する Rust 製 TUI ツール。
+
+> これは [Shin-sibainu/ccmux](https://github.com/Shin-sibainu/ccmux) のフォーク ([happy-ryo/ccmux](https://github.com/happy-ryo/ccmux)) です。上流の変更を取り込みつつ独自機能を先行して開発しており、npm では `ccmux-fork` として配布しています。ブランチ運用方針は [`BRANCHING.md`](https://github.com/happy-ryo/ccmux/blob/main/BRANCHING.md) を参照してください。
 
 ![ccmux スクリーンショット](/screenshot.png)
 
-## ccmux とは？
+## 概要
 
-ccmux は、複数の [Claude Code](https://docs.anthropic.com/en/docs/claude-code) セッションを並べて実行するための軽量ターミナルマルチプレクサです。tmux の Claude Code 特化版と考えてください。
+ccmux は [Claude Code](https://docs.anthropic.com/en/docs/claude-code) セッションを複数並列で動かすことに特化した軽量ターミナルマルチプレクサです。PTY の上に vt100 エミュレータを挟んだ薄いレイヤーで、分割ペイン・タブ・ファイルツリーを提供します。
 
-## なぜ ccmux？
+## 特徴
 
-- **複数の Claude Code エージェントを同時実行** — 分割ペインで並列作業
-- **プロジェクトファイルを確認** — シンタックスハイライト付きプレビュー
-- **ターミナルだけで完結** — エディタ不要、シェルと Claude だけ
-- **爆速・軽量** — 単一バイナリ約 2MB、起動 0.5 秒、アイドル時 CPU ほぼ 0%
-- **Rust 製** — ゼロアロケーション描画、dirty フラグ差分更新、PTY リサイズキャッシュで最適化
+- 複数の Claude Code セッションを分割ペインで並列実行
+- ファイルツリーとシンタックスハイライト付きプレビュー
+- タブごとに独立したワークスペース
+- 単一バイナリ (約 2MB)、追加ランタイム不要
+- Windows / macOS / Linux 対応
 
 ## クイックスタート
 
@@ -33,9 +35,3 @@ ccmux
 - [**Claude 検出**](/ja/features#claude-検出) — Claude Code 実行中はペイン枠がオレンジに変化
 - [**テキスト選択**](/ja/features#テキスト選択とコピー) — ドラッグで選択、自動クリップボードコピー
 - [**スクロールバック**](/ja/features#ターミナルスクロールバック) — ペインごと 10,000 行の履歴
-
----
-
-## Claude Code を学ぶ
-
-Claude Code の使い方を体系的に学びたい方は [**Claude Code Academy**](https://claude-code-academy.dev) をご覧ください。

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,6 +1,6 @@
-# ccmux-fork
+# ccmux
 
-**Claude Code Multiplexer (fork)** — 複数の Claude Code インスタンスを TUI 分割ペインで管理する Rust 製 TUI ツール。
+**Claude Code Multiplexer** — 複数の Claude Code インスタンスを TUI 分割ペインで管理する Rust 製 TUI ツール。
 
 > これは [Shin-sibainu/ccmux](https://github.com/Shin-sibainu/ccmux) のフォーク ([happy-ryo/ccmux](https://github.com/happy-ryo/ccmux)) です。上流の変更を取り込みつつ独自機能を先行して開発しており、npm では `ccmux-fork` として配布しています。ブランチ運用方針は [`BRANCHING.md`](https://github.com/happy-ryo/ccmux/blob/main/BRANCHING.md) を参照してください。
 
@@ -8,7 +8,7 @@
 
 ## 概要
 
-ccmux は [Claude Code](https://docs.anthropic.com/en/docs/claude-code) セッションを複数並列で動かすことに特化した軽量ターミナルマルチプレクサです。PTY の上に vt100 エミュレータを挟んだ薄いレイヤーで、分割ペイン・タブ・ファイルツリーを提供します。
+ccmux は [Claude Code](https://docs.anthropic.com/en/docs/claude-code) セッションを複数並列で動かすことに特化した軽量ターミナルマルチプレクサです。PTY の上に vt100 エミュレータを挟んだ薄いレイヤーで、分割ペイン・タブ・ファイルツリーを提供します。tmux の Claude Code ワークフローに寄せた版、と考えるとイメージしやすいかもしれません。
 
 ## 特徴
 


### PR DESCRIPTION
## Summary
docs index (ja/en) に残っていた上流のマーケティング調の表現を中立的な技術記述に差し替え、フォークであることを明示する。

## 変更内容
- \`docs/content/index.mdx\` / \`docs/content/en/index.mdx\`
  - 冒頭にフォーク注記 + \`BRANCHING.md\` へのリンクを追加
  - \"Blazingly fast\" / \"爆速・軽量\" 等のマーケ調表現を削除
  - 「なぜ ccmux？」「Why ccmux?」セクションを中立的な「概要」「Overview」にリライト
  - 外部プロモ導線 \"Claude Code Academy\" セクションを削除
- \`.gitignore\`: \`.claude/scheduled_tasks.lock\` セッション成果物を除外

## 対象外 (現状中立な文体のため据え置き)
- \`features.mdx\` / \`architecture.mdx\` / \`keybindings.mdx\` (ja/en 両方)
- \`getting-started.mdx\` (install コマンド更新済み、以降の文面は技術手順)

## Test plan
- [x] \`grep -rE '(Blazingly|爆速|しませんか|Academy)' docs/\` で残存ゼロ
- [ ] マージ後 docs workflow が https://happy-ryo.github.io/ccmux/docs/ にデプロイ

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)