### PR TITLE
feat: cherry-pick upstream PR #4 (--exec / --layout / IPC subcommands)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,12 +214,17 @@ version = "0.5.5-fork.1"
 dependencies = [
  "anyhow",
  "arboard",
+ "clap",
  "crossterm",
  "dirs",
+ "interprocess",
+ "oneshot",
  "portable-pty",
  "ratatui",
+ "serde",
  "serde_json",
  "syntect",
+ "toml",
  "unicode-width",
  "ureq",
  "vt100",
@@ -188,6 +243,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +290,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -412,6 +513,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -839,6 +946,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +966,12 @@ checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1201,6 +1327,18 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "onig"
@@ -1605,6 +1743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,6 +1942,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2193,6 +2346,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +3001,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ syntect = "5.3"
 ureq = { version = "2", default-features = false, features = ["tls", "json"] }
 serde_json = "1"
 dirs = "5"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+interprocess = "2"
+oneshot = "0.1"

--- a/ccmux-layouts/cc-campany.toml
+++ b/ccmux-layouts/cc-campany.toml
@@ -1,0 +1,15 @@
+# cc-campany default layout — secretary only. The secretary pane uses
+# the bash shortcut `ccs` from ~/.bashrc to launch Claude Code with the
+# `/company` persona. Department panes (engineering, research, etc.)
+# are spawned on demand via `ccmux split …` from inside the secretary
+# pane once the secretary decides they're needed.
+#
+# Usage: from the cc-campany root, run: ccmux --layout cc-campany
+
+version = 1
+name = "cc-campany"
+
+[root]
+type = "pane"
+id = "secretary"
+command = "ccc-claude"

--- a/ccmux-layouts/test.toml
+++ b/ccmux-layouts/test.toml
@@ -1,0 +1,20 @@
+# Test layout — quick 2-pane sanity check
+# Usage: from this ccmux directory, run: cargo run -- --layout test
+
+version = 1
+name = "test"
+
+[root]
+type = "split"
+direction = "vertical"
+ratio = 0.5
+
+  [root.first]
+  type = "pane"
+  id = "left"
+  command = "echo LeftPaneOK"
+
+  [root.second]
+  type = "pane"
+  id = "right"
+  command = "echo RightPaneOK"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::Instant;
@@ -8,8 +8,75 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use ratatui::layout::Rect;
 
 use crate::filetree::FileTree;
+use crate::ipc::{self, PaneInfo, PaneRef};
+use crate::layout_config::{DirectionSpec, LayoutConfig, LayoutNodeSpec};
 use crate::pane::Pane;
 use crate::preview::Preview;
+
+/// Commands that flow from the IPC server thread into the App's event
+/// loop. Each variant carries a `oneshot::Sender` so the server thread
+/// can block-wait for the App to finish processing.
+#[allow(dead_code)] // constructed by the IPC server (wired in Step 3.3)
+#[derive(Debug)]
+pub enum AppCommand {
+    /// Snapshot the pane list of the active workspace.
+    List {
+        reply: oneshot::Sender<Vec<PaneInfo>>,
+    },
+    /// Write `data` to the target pane's PTY.
+    Send {
+        target: PaneRef,
+        data: Vec<u8>,
+        append_enter: bool,
+        reply: oneshot::Sender<std::result::Result<(), String>>,
+    },
+    /// Move keyboard focus to the target pane in the active workspace.
+    Focus {
+        target: PaneRef,
+        reply: oneshot::Sender<std::result::Result<(), String>>,
+    },
+    /// Split the target pane. If `command` is given, it's queued on the
+    /// new pane and flushed when its shell prompt appears. If `name` is
+    /// given, it's registered so later IPC calls can address the pane by
+    /// name. Returns the new pane's id on success.
+    Split {
+        target: PaneRef,
+        direction: ipc::Direction,
+        command: Option<String>,
+        name: Option<String>,
+        reply: oneshot::Sender<std::result::Result<usize, String>>,
+    },
+    /// Open a new tab with a fresh single pane. Focus switches to the
+    /// new tab (mirrors the Alt+T keybinding). Returns the new pane's
+    /// id on success.
+    NewTab {
+        command: Option<String>,
+        name: Option<String>,
+        label: Option<String>,
+        reply: oneshot::Sender<std::result::Result<usize, String>>,
+    },
+}
+
+/// Resolve a [`PaneRef`] to a concrete pane id.
+///
+/// Pure helper separated from `Workspace` so it can be unit-tested
+/// without spawning real PTYs. Returns `None` when the reference points
+/// at a pane that no longer exists (e.g. a stale name or a closed id).
+pub(crate) fn resolve_pane_ref_impl(
+    r: &PaneRef,
+    pane_names: &HashMap<String, usize>,
+    known_ids: &HashSet<usize>,
+    focused: usize,
+) -> Option<usize> {
+    match r {
+        PaneRef::Focused => known_ids.contains(&focused).then_some(focused),
+        PaneRef::Id(id) => known_ids.contains(id).then_some(*id),
+        PaneRef::Name(name) => pane_names
+            .get(name)
+            .copied()
+            .filter(|id| known_ids.contains(id)),
+    }
+}
 
 /// Events dispatched within the app.
 pub enum AppEvent {
@@ -48,8 +115,11 @@ pub enum DragTarget {
 // ─── Layout Tree ──────────────────────────────────────────
 
 /// Binary tree node for pane layout.
+#[derive(Debug)]
 pub enum LayoutNode {
-    Leaf { pane_id: usize },
+    Leaf {
+        pane_id: usize,
+    },
     Split {
         direction: SplitDirection,
         ratio: f32, // 0.0..1.0, portion allocated to first child
@@ -73,7 +143,12 @@ impl LayoutNode {
     pub fn calculate_rects(&self, area: Rect) -> Vec<(usize, Rect)> {
         match self {
             LayoutNode::Leaf { pane_id } => vec![(*pane_id, area)],
-            LayoutNode::Split { direction, ratio, first, second } => {
+            LayoutNode::Split {
+                direction,
+                ratio,
+                first,
+                second,
+            } => {
                 let (first_area, second_area) = split_rect(area, *direction, *ratio);
                 let mut result = first.calculate_rects(first_area);
                 result.extend(second.calculate_rects(second_area));
@@ -82,7 +157,12 @@ impl LayoutNode {
         }
     }
 
-    pub fn split_pane(&mut self, target_id: usize, new_id: usize, direction: SplitDirection) -> bool {
+    pub fn split_pane(
+        &mut self,
+        target_id: usize,
+        new_id: usize,
+        direction: SplitDirection,
+    ) -> bool {
         match self {
             LayoutNode::Leaf { pane_id } => {
                 if *pane_id == target_id {
@@ -111,14 +191,16 @@ impl LayoutNode {
             LayoutNode::Split { first, second, .. } => {
                 if let LayoutNode::Leaf { pane_id } = first.as_ref() {
                     if *pane_id == target_id {
-                        let second = std::mem::replace(second.as_mut(), LayoutNode::Leaf { pane_id: 0 });
+                        let second =
+                            std::mem::replace(second.as_mut(), LayoutNode::Leaf { pane_id: 0 });
                         *self = second;
                         return true;
                     }
                 }
                 if let LayoutNode::Leaf { pane_id } = second.as_ref() {
                     if *pane_id == target_id {
-                        let first = std::mem::replace(first.as_mut(), LayoutNode::Leaf { pane_id: 0 });
+                        let first =
+                            std::mem::replace(first.as_mut(), LayoutNode::Leaf { pane_id: 0 });
                         *self = first;
                         return true;
                     }
@@ -142,7 +224,13 @@ impl LayoutNode {
         path: &mut Vec<bool>, // false=first, true=second
         result: &mut Vec<(u16, SplitDirection, Vec<bool>)>,
     ) {
-        if let LayoutNode::Split { direction, ratio, first, second } = self {
+        if let LayoutNode::Split {
+            direction,
+            ratio,
+            first,
+            second,
+        } = self
+        {
             let (first_area, second_area) = split_rect(area, *direction, *ratio);
 
             // The boundary is at the edge between first and second
@@ -285,6 +373,12 @@ pub struct Workspace {
     pub panes: HashMap<usize, Pane>,
     pub layout: LayoutNode,
     pub focused_pane_id: usize,
+    /// Stable human-friendly name → pane id map, populated by layout
+    /// files (Phase 2) and by IPC `Split { id: Some(name), .. }` calls
+    /// (Phase 3). Never shrinks automatically; closing a pane leaves the
+    /// name entry dangling and `resolve_pane_ref_impl` treats it as
+    /// unknown.
+    pub pane_names: HashMap<String, usize>,
     pub file_tree: FileTree,
     pub file_tree_visible: bool,
     pub preview: Preview,
@@ -316,6 +410,7 @@ impl Workspace {
             panes,
             layout: LayoutNode::Leaf { pane_id },
             focused_pane_id: pane_id,
+            pane_names: HashMap::new(),
             file_tree_visible: true,
             preview: Preview::new(),
             focus_target: FocusTarget::Pane,
@@ -323,6 +418,12 @@ impl Workspace {
             last_file_tree_rect: None,
             last_preview_rect: None,
         })
+    }
+
+    /// Resolve a [`PaneRef`] against this workspace's panes and names.
+    pub fn resolve_pane_ref(&self, r: &PaneRef) -> Option<usize> {
+        let known: HashSet<usize> = self.panes.keys().copied().collect();
+        resolve_pane_ref_impl(r, &self.pane_names, &known, self.focused_pane_id)
     }
 
     fn shutdown(&mut self) {
@@ -346,6 +447,10 @@ pub struct App {
     pub should_quit: bool,
     pub event_tx: Sender<AppEvent>,
     pub event_rx: Receiver<AppEvent>,
+    /// Clonable sender for the IPC server thread. Drop the server thread
+    /// to stop producing commands; the receiver lives on the App side.
+    pub command_tx: Sender<AppCommand>,
+    command_rx: Receiver<AppCommand>,
     next_pane_id: usize,
     pub dirty: bool,
     pub paste_cooldown: u8, // frames to skip rendering after paste
@@ -392,6 +497,7 @@ pub struct App {
 impl App {
     pub fn new(rows: u16, cols: u16) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::channel();
+        let (command_tx, command_rx) = mpsc::channel();
 
         let pane_rows = rows.saturating_sub(5); // title + tab bar + status + borders
         let pane_cols = cols.saturating_sub(2);
@@ -407,6 +513,8 @@ impl App {
             should_quit: false,
             event_tx,
             event_rx,
+            command_tx,
+            command_rx,
             next_pane_id: 2,
             dirty: true,
             paste_cooldown: 0,
@@ -473,7 +581,11 @@ impl App {
         // PTY size drift from the actually-painted pane size.
         const MIN_PANE_AREA_WIDTH: u16 = 20;
         let tab_h = 1u16;
-        let status_h: u16 = if self.status_bar_visible || self.rename_input.is_some() { 1 } else { 0 };
+        let status_h: u16 = if self.status_bar_visible || self.rename_input.is_some() {
+            1
+        } else {
+            0
+        };
         let main_h = rows.saturating_sub(tab_h + status_h);
 
         let mut has_tree = self.ws().file_tree_visible;
@@ -590,13 +702,9 @@ impl App {
                             .get(&pane_id)
                             .map(|p| extract_selected_text(p, sr, sc, er, ec))
                             .unwrap_or_default(),
-                        SelectionTarget::Preview => extract_preview_selected_text(
-                            &self.ws().preview,
-                            sr,
-                            sc,
-                            er,
-                            ec,
-                        ),
+                        SelectionTarget::Preview => {
+                            extract_preview_selected_text(&self.ws().preview, sr, sc, er, ec)
+                        }
                     };
                     if !text.is_empty() {
                         self.copy_to_clipboard(&text);
@@ -735,13 +843,21 @@ impl App {
         match key.code {
             KeyCode::Esc => {
                 self.rename_input = None;
-                if needs_relayout { self.mark_layout_change(); }
+                if needs_relayout {
+                    self.mark_layout_change();
+                }
             }
             KeyCode::Enter => {
                 let trimmed = buf.trim().to_string();
-                self.ws_mut().custom_name = if trimmed.is_empty() { None } else { Some(trimmed) };
+                self.ws_mut().custom_name = if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                };
                 self.rename_input = None;
-                if needs_relayout { self.mark_layout_change(); }
+                if needs_relayout {
+                    self.mark_layout_change();
+                }
             }
             KeyCode::Backspace => {
                 buf.pop();
@@ -750,7 +866,10 @@ impl App {
                 // Ignore chars combined with Ctrl/Alt so shortcuts like
                 // Ctrl+C don't leak into the buffer as literal letters.
                 // Shift is fine — that's just uppercase.
-                if key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                {
                     return true;
                 }
                 // Cap at something sane so a stuck key can't grow the tab bar forever.
@@ -956,7 +1075,10 @@ impl App {
         self.next_pane_id = self.next_pane_id.wrapping_add(1);
 
         // Inherit CWD from the focused pane
-        let parent_cwd = self.ws().panes.get(&self.ws().focused_pane_id)
+        let parent_cwd = self
+            .ws()
+            .panes
+            .get(&self.ws().focused_pane_id)
             .map(|p| p.cwd.clone());
 
         let pane = Pane::new_with_cwd(new_id, 10, 40, self.event_tx.clone(), parent_cwd)?;
@@ -969,6 +1091,62 @@ impl App {
 
         self.mark_layout_change();
         Ok(())
+    }
+
+    /// Apply a multi-pane layout to the active workspace.
+    ///
+    /// The workspace is expected to contain a single initial pane created
+    /// by `App::new`. The root of the layout tree is mapped onto that
+    /// initial pane; splits are produced by recursively driving
+    /// `split_focused_pane`. Each `Pane` node's `command` (if any) is
+    /// queued via `Pane::queue_startup_command`, which the main event
+    /// loop will flush once the shell prompt is observed.
+    ///
+    /// Note: Phase 2 ignores the per-split `ratio`; splits use the
+    /// existing equal-split semantics. A follow-up may extend this.
+    pub fn apply_layout(&mut self, config: &LayoutConfig) -> Result<()> {
+        let initial_pane_id = self.ws().focused_pane_id;
+        self.apply_layout_node(&config.root, initial_pane_id)?;
+        Ok(())
+    }
+
+    fn apply_layout_node(&mut self, node: &LayoutNodeSpec, target_pane_id: usize) -> Result<()> {
+        match node {
+            LayoutNodeSpec::Pane { id, command } => {
+                // Register the leaf's id as a human-friendly name so IPC
+                // clients (and external tools like `ccmux-send`) can
+                // target this pane later without tracking numeric ids.
+                if !id.is_empty() {
+                    self.ws_mut().pane_names.insert(id.clone(), target_pane_id);
+                }
+                if let Some(cmd) = command {
+                    if let Some(pane) = self.ws_mut().panes.get_mut(&target_pane_id) {
+                        pane.queue_startup_command(cmd);
+                    }
+                }
+                Ok(())
+            }
+            LayoutNodeSpec::Split {
+                direction,
+                ratio: _,
+                first,
+                second,
+            } => {
+                // split_focused_pane operates on the focused pane and
+                // moves focus to the freshly-created child, so we focus
+                // the target first, then capture the new id afterwards.
+                self.ws_mut().focused_pane_id = target_pane_id;
+                let split_dir = match direction {
+                    DirectionSpec::Vertical => SplitDirection::Vertical,
+                    DirectionSpec::Horizontal => SplitDirection::Horizontal,
+                };
+                self.split_focused_pane(split_dir)?;
+                let new_pane_id = self.ws().focused_pane_id;
+                self.apply_layout_node(first, target_pane_id)?;
+                self.apply_layout_node(second, new_pane_id)?;
+                Ok(())
+            }
+        }
     }
 
     fn close_focused_pane(&mut self) {
@@ -1136,7 +1314,9 @@ impl App {
             let needs_relayout = !self.status_bar_visible;
             self.rename_input = None;
             self.dirty = true;
-            if needs_relayout { self.mark_layout_change(); }
+            if needs_relayout {
+                self.mark_layout_change();
+            }
         }
 
         match mouse.kind {
@@ -1149,8 +1329,10 @@ impl App {
 
                 // Check tab bar clicks
                 for &(tab_idx, rect) in &self.last_tab_rects {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         let now = Instant::now();
                         let is_double = matches!(
@@ -1175,8 +1357,10 @@ impl App {
 
                 // Check [+] new tab button
                 if let Some(rect) = self.last_new_tab_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         let _ = self.new_tab();
                         return;
@@ -1207,12 +1391,16 @@ impl App {
                     for (boundary, direction, path) in boundaries {
                         let on_border = match direction {
                             SplitDirection::Vertical => {
-                                col >= boundary.saturating_sub(1) && col <= boundary
-                                    && row >= pane_area.y && row < pane_area.y + pane_area.height
+                                col >= boundary.saturating_sub(1)
+                                    && col <= boundary
+                                    && row >= pane_area.y
+                                    && row < pane_area.y + pane_area.height
                             }
                             SplitDirection::Horizontal => {
-                                row >= boundary.saturating_sub(1) && row <= boundary
-                                    && col >= pane_area.x && col < pane_area.x + pane_area.width
+                                row >= boundary.saturating_sub(1)
+                                    && row <= boundary
+                                    && col >= pane_area.x
+                                    && col < pane_area.x + pane_area.width
                             }
                         };
                         if on_border {
@@ -1224,8 +1412,10 @@ impl App {
 
                 // Check file tree click
                 if let Some(rect) = self.ws().last_file_tree_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().focus_target = FocusTarget::FileTree;
                         let inner_y = row.saturating_sub(rect.y + 1);
@@ -1246,8 +1436,10 @@ impl App {
 
                 // Check preview click
                 if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().focus_target = FocusTarget::Preview;
                         return;
@@ -1257,8 +1449,10 @@ impl App {
                 // Check pane clicks
                 let pane_rects = self.ws().last_pane_rects.clone();
                 for (pane_id, rect) in pane_rects {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().focused_pane_id = pane_id;
                         self.ws_mut().focus_target = FocusTarget::Pane;
@@ -1266,7 +1460,12 @@ impl App {
                         // Check if clicking on scrollbar (rightmost column inside border)
                         let scrollbar_col = rect.x + rect.width - 2; // -1 border, -1 scrollbar
                         if col >= scrollbar_col {
-                            let inner = Rect::new(rect.x + 1, rect.y + 1, rect.width.saturating_sub(2), rect.height.saturating_sub(2));
+                            let inner = Rect::new(
+                                rect.x + 1,
+                                rect.y + 1,
+                                rect.width.saturating_sub(2),
+                                rect.height.saturating_sub(2),
+                            );
                             self.scroll_pane_to_click(pane_id, row, &inner);
                             self.dragging = Some(DragTarget::Scrollbar(pane_id, inner));
                         }
@@ -1322,10 +1521,12 @@ impl App {
                             // Pane: screen-relative coords inside inner.
                             sel.end_col = col
                                 .saturating_sub(inner.x)
-                                .min(inner.width.saturating_sub(1)) as u32;
+                                .min(inner.width.saturating_sub(1))
+                                as u32;
                             sel.end_row = row
                                 .saturating_sub(inner.y)
-                                .min(inner.height.saturating_sub(1)) as u32;
+                                .min(inner.height.saturating_sub(1))
+                                as u32;
                         }
                         SelectionTarget::Preview => {
                             // Preview: translate screen coords to
@@ -1362,8 +1563,8 @@ impl App {
                             let h_scroll = self.ws().preview.h_scroll_offset.max(h_scroll);
                             // Clamp end_row to a valid absolute line index.
                             let lines_len = self.ws().preview.lines.len();
-                            let abs_row = (scroll_v + screen_row as usize)
-                                .min(lines_len.saturating_sub(1));
+                            let abs_row =
+                                (scroll_v + screen_row as usize).min(lines_len.saturating_sub(1));
                             let abs_col = screen_col as usize + h_scroll;
                             // Update the selection endpoint (source coords).
                             if let Some(sel) = self.selection.as_mut() {
@@ -1377,11 +1578,14 @@ impl App {
                     let pane_rects = self.ws().last_pane_rects.clone();
                     let mut started = false;
                     for (pane_id, rect) in pane_rects {
-                        if col >= rect.x && col < rect.x + rect.width
-                            && row >= rect.y && row < rect.y + rect.height
+                        if col >= rect.x
+                            && col < rect.x + rect.width
+                            && row >= rect.y
+                            && row < rect.y + rect.height
                         {
                             let inner = Rect::new(
-                                rect.x + 1, rect.y + 1,
+                                rect.x + 1,
+                                rect.y + 1,
                                 rect.width.saturating_sub(2),
                                 rect.height.saturating_sub(2),
                             );
@@ -1406,12 +1610,15 @@ impl App {
                     // survive scrolling.
                     if !started {
                         if let Some(rect) = self.ws().last_preview_rect {
-                            if col >= rect.x && col < rect.x + rect.width
-                                && row >= rect.y && row < rect.y + rect.height
+                            if col >= rect.x
+                                && col < rect.x + rect.width
+                                && row >= rect.y
+                                && row < rect.y + rect.height
                             {
                                 const GUTTER: u16 = 5;
                                 let inner = Rect::new(
-                                    rect.x + 1 + GUTTER, rect.y + 1,
+                                    rect.x + 1 + GUTTER,
+                                    rect.y + 1,
                                     rect.width.saturating_sub(2 + GUTTER),
                                     rect.height.saturating_sub(2),
                                 );
@@ -1453,13 +1660,9 @@ impl App {
                                 .get(&pane_id)
                                 .map(|p| extract_selected_text(p, sr, sc, er, ec))
                                 .unwrap_or_default(),
-                            SelectionTarget::Preview => extract_preview_selected_text(
-                                &self.ws().preview,
-                                sr,
-                                sc,
-                                er,
-                                ec,
-                            ),
+                            SelectionTarget::Preview => {
+                                extract_preview_selected_text(&self.ws().preview, sr, sc, er, ec)
+                            }
                         };
                         if !text.is_empty() {
                             self.copy_to_clipboard(&text);
@@ -1473,16 +1676,20 @@ impl App {
                 let row = mouse.row;
 
                 if let Some(rect) = self.ws().last_file_tree_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().file_tree.scroll_up(3);
                         return;
                     }
                 }
                 if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().preview.scroll_up(3);
                         return;
@@ -1490,8 +1697,10 @@ impl App {
                 }
                 let pane_rects = self.ws().last_pane_rects.clone();
                 for (pane_id, rect) in pane_rects {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         if let Some(pane) = self.ws().panes.get(&pane_id) {
                             pane.scroll_up(3);
@@ -1505,16 +1714,20 @@ impl App {
                 let row = mouse.row;
 
                 if let Some(rect) = self.ws().last_file_tree_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().file_tree.scroll_down(3);
                         return;
                     }
                 }
                 if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().preview.scroll_down(3);
                         return;
@@ -1522,8 +1735,10 @@ impl App {
                 }
                 let pane_rects = self.ws().last_pane_rects.clone();
                 for (pane_id, rect) in pane_rects {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         if let Some(pane) = self.ws().panes.get(&pane_id) {
                             pane.scroll_down(3);
@@ -1536,8 +1751,10 @@ impl App {
                 let col = mouse.column;
                 let row = mouse.row;
                 if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().preview.scroll_left(4);
                     }
@@ -1547,8 +1764,10 @@ impl App {
                 let col = mouse.column;
                 let row = mouse.row;
                 if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x && col < rect.x + rect.width
-                        && row >= rect.y && row < rect.y + rect.height
+                    if col >= rect.x
+                        && col < rect.x + rect.width
+                        && row >= rect.y
+                        && row < rect.y + rect.height
                     {
                         self.ws_mut().preview.scroll_right(4);
                     }
@@ -1664,6 +1883,183 @@ impl App {
             ws.shutdown();
         }
     }
+
+    /// Drain any pending IPC commands and dispatch them. Safe to call
+    /// every frame — it's a no-op when the channel is empty. Commands
+    /// always target the active workspace.
+    pub fn drain_app_commands(&mut self) {
+        // Pop into a local Vec first so we can borrow `self` mutably
+        // inside `handle_app_command` without fighting the receiver
+        // borrow.
+        let mut cmds: Vec<AppCommand> = Vec::new();
+        while let Ok(cmd) = self.command_rx.try_recv() {
+            cmds.push(cmd);
+        }
+        for cmd in cmds {
+            self.handle_app_command(cmd);
+        }
+    }
+
+    fn handle_app_command(&mut self, cmd: AppCommand) {
+        match cmd {
+            AppCommand::List { reply } => {
+                let ws = self.ws();
+                let focused = ws.focused_pane_id;
+                // Invert pane_names so we can look up by id.
+                let mut name_by_id: HashMap<usize, String> = HashMap::new();
+                for (name, id) in &ws.pane_names {
+                    name_by_id.insert(*id, name.clone());
+                }
+                let mut infos: Vec<PaneInfo> = Vec::new();
+                for id in ws.layout.collect_pane_ids() {
+                    infos.push(PaneInfo {
+                        id,
+                        name: name_by_id.get(&id).cloned(),
+                        focused: id == focused,
+                    });
+                }
+                let _ = reply.send(infos);
+            }
+            AppCommand::Send {
+                target,
+                data,
+                append_enter,
+                reply,
+            } => {
+                let result = self.handle_send(&target, &data, append_enter);
+                let _ = reply.send(result);
+            }
+            AppCommand::Focus { target, reply } => {
+                let result = self.handle_focus(&target);
+                let _ = reply.send(result);
+            }
+            AppCommand::Split {
+                target,
+                direction,
+                command,
+                name,
+                reply,
+            } => {
+                let result = self.handle_split(&target, direction, command, name);
+                let _ = reply.send(result);
+            }
+            AppCommand::NewTab {
+                command,
+                name,
+                label,
+                reply,
+            } => {
+                let result = self.handle_new_tab(command, name, label);
+                let _ = reply.send(result);
+            }
+        }
+    }
+
+    fn handle_new_tab(
+        &mut self,
+        command: Option<String>,
+        name: Option<String>,
+        label: Option<String>,
+    ) -> std::result::Result<usize, String> {
+        // Delegate to the existing keybinding-driven new_tab so we
+        // don't drift from the interactive behavior (pane id bookkeeping,
+        // active_tab update, cwd inheritance). The freshly-created tab
+        // becomes the active one, so `ws_mut()` points at it.
+        self.new_tab().map_err(|e| e.to_string())?;
+        let new_pane_id = self.ws().focused_pane_id;
+        if let Some(cmd) = command {
+            if let Some(pane) = self.ws_mut().panes.get_mut(&new_pane_id) {
+                pane.queue_startup_command(&cmd);
+            }
+        }
+        if let Some(name) = name {
+            if !name.is_empty() {
+                self.ws_mut().pane_names.insert(name, new_pane_id);
+            }
+        }
+        if let Some(label) = label {
+            if !label.is_empty() {
+                self.ws_mut().custom_name = Some(label);
+            }
+        }
+        self.dirty = true;
+        Ok(new_pane_id)
+    }
+
+    fn handle_send(
+        &mut self,
+        target: &PaneRef,
+        data: &[u8],
+        append_enter: bool,
+    ) -> std::result::Result<(), String> {
+        let pane_id = self
+            .ws()
+            .resolve_pane_ref(target)
+            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+        let pane = self
+            .ws_mut()
+            .panes
+            .get_mut(&pane_id)
+            .ok_or_else(|| "pane vanished".to_string())?;
+        pane.write_input(data).map_err(|e| e.to_string())?;
+        if append_enter {
+            pane.write_input(b"\r").map_err(|e| e.to_string())?;
+        }
+        self.dirty = true;
+        Ok(())
+    }
+
+    fn handle_focus(&mut self, target: &PaneRef) -> std::result::Result<(), String> {
+        let pane_id = self
+            .ws()
+            .resolve_pane_ref(target)
+            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+        let ws = self.ws_mut();
+        ws.focused_pane_id = pane_id;
+        ws.focus_target = FocusTarget::Pane;
+        self.dirty = true;
+        Ok(())
+    }
+
+    fn handle_split(
+        &mut self,
+        target: &PaneRef,
+        direction: ipc::Direction,
+        command: Option<String>,
+        name: Option<String>,
+    ) -> std::result::Result<usize, String> {
+        let target_pane_id = self
+            .ws()
+            .resolve_pane_ref(target)
+            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+        let prev_focus = self.ws().focused_pane_id;
+        self.ws_mut().focused_pane_id = target_pane_id;
+        let split_dir = match direction {
+            ipc::Direction::Vertical => SplitDirection::Vertical,
+            ipc::Direction::Horizontal => SplitDirection::Horizontal,
+        };
+        self.split_focused_pane(split_dir)
+            .map_err(|e| e.to_string())?;
+        let new_pane_id = self.ws().focused_pane_id;
+        // split_focused_pane is a no-op (keeps focus) when the pane is
+        // too small or the workspace is already at MAX_PANES; detect
+        // that by checking whether focus actually advanced.
+        if new_pane_id == target_pane_id {
+            self.ws_mut().focused_pane_id = prev_focus;
+            return Err("split refused (max panes reached or pane too small)".to_string());
+        }
+        if let Some(cmd) = command {
+            if let Some(pane) = self.ws_mut().panes.get_mut(&new_pane_id) {
+                pane.queue_startup_command(&cmd);
+            }
+        }
+        if let Some(name) = name {
+            if !name.is_empty() {
+                self.ws_mut().pane_names.insert(name, new_pane_id);
+            }
+        }
+        Ok(new_pane_id)
+    }
 }
 
 /// Extract directory name from a path for tab title.
@@ -1709,7 +2105,13 @@ fn extract_selected_text(pane: &Pane, sr: u32, sc: u32, er: u32, ec: u32) -> Str
 /// `sr`/`er` are absolute line indices; `sc`/`ec` are char offsets
 /// within the line (selection is stored in source coordinates so it
 /// survives scrolling). Trailing empty lines are stripped.
-fn extract_preview_selected_text(preview: &crate::preview::Preview, sr: u32, sc: u32, er: u32, ec: u32) -> String {
+fn extract_preview_selected_text(
+    preview: &crate::preview::Preview,
+    sr: u32,
+    sc: u32,
+    er: u32,
+    ec: u32,
+) -> String {
     let lines = &preview.lines;
     let mut out: Vec<String> = Vec::new();
 
@@ -1722,7 +2124,9 @@ fn extract_preview_selected_text(preview: &crate::preview::Preview, sr: u32, sc:
         let chars: Vec<char> = line.chars().collect();
 
         let col_start = if abs_row == sr { sc as usize } else { 0 };
-        let col_end_inclusive = if abs_row == er { ec as usize } else {
+        let col_end_inclusive = if abs_row == er {
+            ec as usize
+        } else {
             chars.len().saturating_sub(1)
         };
 
@@ -1757,7 +2161,9 @@ fn key_event_to_bytes(key: &KeyEvent) -> Option<Vec<u8>> {
     match key.code {
         KeyCode::Char(c) => {
             if ctrl {
-                let ctrl_byte = (c.to_ascii_lowercase() as u8).wrapping_sub(b'a').wrapping_add(1);
+                let ctrl_byte = (c.to_ascii_lowercase() as u8)
+                    .wrapping_sub(b'a')
+                    .wrapping_add(1);
                 if ctrl_byte <= 26 {
                     if alt {
                         // Alt+Ctrl+Char → ESC + ctrl byte
@@ -1796,9 +2202,18 @@ fn key_event_to_bytes(key: &KeyEvent) -> Option<Vec<u8>> {
         KeyCode::Insert => Some(b"\x1b[2~".to_vec()),
         KeyCode::F(n) => {
             let seq = match n {
-                1 => "\x1bOP", 2 => "\x1bOQ", 3 => "\x1bOR", 4 => "\x1bOS",
-                5 => "\x1b[15~", 6 => "\x1b[17~", 7 => "\x1b[18~", 8 => "\x1b[19~",
-                9 => "\x1b[20~", 10 => "\x1b[21~", 11 => "\x1b[23~", 12 => "\x1b[24~",
+                1 => "\x1bOP",
+                2 => "\x1bOQ",
+                3 => "\x1bOR",
+                4 => "\x1bOS",
+                5 => "\x1b[15~",
+                6 => "\x1b[17~",
+                7 => "\x1b[18~",
+                8 => "\x1b[19~",
+                9 => "\x1b[20~",
+                10 => "\x1b[21~",
+                11 => "\x1b[23~",
+                12 => "\x1b[24~",
                 _ => return None,
             };
             Some(seq.as_bytes().to_vec())
@@ -1892,5 +2307,247 @@ mod tests {
         let ids = vec![1, 2, 3];
         assert_eq!((0 + 1) % ids.len(), 1);
         assert_eq!((2 + 1) % ids.len(), 0);
+    }
+
+    // ─── resolve_pane_ref_impl (Phase 3 Step 3.2) ────────────
+
+    fn mk_ids(ids: &[usize]) -> HashSet<usize> {
+        ids.iter().copied().collect()
+    }
+
+    #[test]
+    fn resolve_focused_returns_focused_id_when_known() {
+        let names = HashMap::new();
+        let ids = mk_ids(&[1, 2, 3]);
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Focused, &names, &ids, 2),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn resolve_focused_returns_none_when_focus_stale() {
+        let names = HashMap::new();
+        let ids = mk_ids(&[1, 3]);
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Focused, &names, &ids, 2),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_by_id_returns_id_when_known() {
+        let names = HashMap::new();
+        let ids = mk_ids(&[1, 2, 3]);
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Id(3), &names, &ids, 1),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn resolve_by_id_returns_none_when_unknown() {
+        let names = HashMap::new();
+        let ids = mk_ids(&[1, 2]);
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Id(99), &names, &ids, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_by_name_returns_id_when_registered() {
+        let mut names = HashMap::new();
+        names.insert("engineering".to_string(), 7);
+        let ids = mk_ids(&[1, 7]);
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Name("engineering".into()), &names, &ids, 1),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn resolve_by_name_returns_none_when_unregistered() {
+        let names = HashMap::new();
+        let ids = mk_ids(&[1, 7]);
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Name("missing".into()), &names, &ids, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_by_name_returns_none_when_pane_closed() {
+        // Name still registered but the pane has been removed — the
+        // dangling entry must not resolve to a ghost id.
+        let mut names = HashMap::new();
+        names.insert("engineering".to_string(), 7);
+        let ids = mk_ids(&[1]); // 7 has been closed
+        assert_eq!(
+            resolve_pane_ref_impl(&PaneRef::Name("engineering".into()), &names, &ids, 1),
+            None
+        );
+    }
+
+    // ─── apply_layout integration (Phase 2 review fix) ────────
+    //
+    // These tests spawn real PTYs through App::new / Pane::new_with_cwd
+    // because apply_layout drives split_focused_pane, which unavoidably
+    // creates child shell processes. On a dev machine this costs a few
+    // milliseconds per pane; in CI it's measurable but acceptable for a
+    // handful of tests. Each test calls `app.shutdown()` at the end so
+    // the spawned shells don't linger.
+
+    fn make_pane_spec(id: &str) -> crate::layout_config::LayoutNodeSpec {
+        crate::layout_config::LayoutNodeSpec::Pane {
+            id: id.to_string(),
+            command: None,
+        }
+    }
+
+    #[test]
+    fn apply_layout_maps_split_first_to_target_and_second_to_new() {
+        // Given a 2-pane Split spec, after apply_layout:
+        // - pane_names["left"]  must point at the workspace's original
+        //   pane (what we split off)
+        // - pane_names["right"] must point at the freshly-created pane
+        // - the LayoutNode tree must have Leaf(left) in `first` and
+        //   Leaf(right) in `second`
+        // Regression guard for the reviewer's concern that the
+        // first/second recursion arms in apply_layout_node might drift.
+        let cfg = crate::layout_config::LayoutConfig {
+            version: 1,
+            name: "test".into(),
+            root: crate::layout_config::LayoutNodeSpec::Split {
+                direction: crate::layout_config::DirectionSpec::Vertical,
+                ratio: 0.5,
+                first: Box::new(make_pane_spec("left")),
+                second: Box::new(make_pane_spec("right")),
+            },
+        };
+
+        let mut app = App::new(40, 80).expect("App::new");
+        let initial_pane_id = app.ws().focused_pane_id;
+
+        app.apply_layout(&cfg).expect("apply_layout");
+
+        let ws = app.ws();
+        let left_id = *ws
+            .pane_names
+            .get("left")
+            .expect("pane_names[left] should be registered");
+        let right_id = *ws
+            .pane_names
+            .get("right")
+            .expect("pane_names[right] should be registered");
+
+        assert_eq!(
+            left_id, initial_pane_id,
+            "`first` spec ('left') must map to the original/split-target pane"
+        );
+        assert_ne!(
+            right_id, initial_pane_id,
+            "`second` spec ('right') must map to a newly-spawned pane"
+        );
+
+        match &ws.layout {
+            LayoutNode::Split { first, second, .. } => {
+                match first.as_ref() {
+                    LayoutNode::Leaf { pane_id } => {
+                        assert_eq!(*pane_id, left_id, "layout.first must be the 'left' pane")
+                    }
+                    other => panic!("expected Leaf in first, got {other:?}"),
+                }
+                match second.as_ref() {
+                    LayoutNode::Leaf { pane_id } => {
+                        assert_eq!(*pane_id, right_id, "layout.second must be the 'right' pane")
+                    }
+                    other => panic!("expected Leaf in second, got {other:?}"),
+                }
+            }
+            other => panic!("expected Split at root, got {other:?}"),
+        }
+
+        app.shutdown();
+    }
+
+    #[test]
+    fn apply_layout_nested_split_preserves_positions() {
+        // A right-heavy tree: Split { first: "A", second: Split { "B", "C" } }.
+        // After apply, the LayoutNode must mirror that shape exactly.
+        let cfg = crate::layout_config::LayoutConfig {
+            version: 1,
+            name: "nested".into(),
+            root: crate::layout_config::LayoutNodeSpec::Split {
+                direction: crate::layout_config::DirectionSpec::Vertical,
+                ratio: 0.5,
+                first: Box::new(make_pane_spec("A")),
+                second: Box::new(crate::layout_config::LayoutNodeSpec::Split {
+                    direction: crate::layout_config::DirectionSpec::Horizontal,
+                    ratio: 0.5,
+                    first: Box::new(make_pane_spec("B")),
+                    second: Box::new(make_pane_spec("C")),
+                }),
+            },
+        };
+
+        let mut app = App::new(40, 80).expect("App::new");
+        app.apply_layout(&cfg).expect("apply_layout");
+
+        let ws = app.ws();
+        let a_id = *ws.pane_names.get("A").expect("A registered");
+        let b_id = *ws.pane_names.get("B").expect("B registered");
+        let c_id = *ws.pane_names.get("C").expect("C registered");
+
+        match &ws.layout {
+            LayoutNode::Split {
+                first: outer_first,
+                second: outer_second,
+                ..
+            } => {
+                match outer_first.as_ref() {
+                    LayoutNode::Leaf { pane_id } => assert_eq!(*pane_id, a_id),
+                    other => panic!("outer.first must be Leaf(A), got {other:?}"),
+                }
+                match outer_second.as_ref() {
+                    LayoutNode::Split {
+                        first: inner_first,
+                        second: inner_second,
+                        ..
+                    } => {
+                        match inner_first.as_ref() {
+                            LayoutNode::Leaf { pane_id } => assert_eq!(*pane_id, b_id),
+                            other => panic!("inner.first must be Leaf(B), got {other:?}"),
+                        }
+                        match inner_second.as_ref() {
+                            LayoutNode::Leaf { pane_id } => assert_eq!(*pane_id, c_id),
+                            other => panic!("inner.second must be Leaf(C), got {other:?}"),
+                        }
+                    }
+                    other => panic!("outer.second must be a Split, got {other:?}"),
+                }
+            }
+            other => panic!("expected Split at root, got {other:?}"),
+        }
+
+        app.shutdown();
+    }
+
+    #[test]
+    fn app_command_channel_sends_and_receives() {
+        // Smoke-test that the AppCommand channel round-trips without
+        // panicking. We can't exercise handle_* without spawning PTYs,
+        // but confirming the types fit together catches breakage.
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(AppCommand::List { reply: reply_tx }).unwrap();
+        match rx.try_recv() {
+            Ok(AppCommand::List { reply }) => {
+                reply.send(Vec::new()).unwrap();
+                let list = reply_rx.recv().unwrap();
+                assert!(list.is_empty());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,385 @@
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "ccmux", version, about = "Claude Code Multiplexer")]
+pub struct Cli {
+    /// Subcommands talk to an already-running ccmux instance over IPC.
+    /// When absent, ccmux launches as a TUI (using the flags below).
+    #[command(subcommand)]
+    pub command: Option<IpcCommand>,
+
+    /// Working directory to change into before launching
+    pub dir: Option<PathBuf>,
+
+    /// Command to execute automatically in the initial pane after the shell is ready
+    #[arg(long, value_name = "CMD", conflicts_with = "layout")]
+    pub exec: Option<String>,
+
+    /// Load a multi-pane layout by name from
+    /// `./ccmux-layouts/<NAME>.toml` or `~/.config/ccmux/layouts/<NAME>.toml`
+    #[arg(long, value_name = "NAME", conflicts_with = "exec")]
+    pub layout: Option<String>,
+}
+
+/// Subcommands dispatched to a running ccmux instance via its IPC
+/// endpoint. These always exit without starting the TUI.
+#[derive(Subcommand, Debug, Clone)]
+pub enum IpcCommand {
+    /// List panes in the active workspace.
+    List,
+    /// Write text to a pane. Exactly one of --name / --id / --focused.
+    Send {
+        /// Pane name (defined in the layout or via `split --id NAME`).
+        #[arg(long, conflicts_with_all = ["id", "focused"])]
+        name: Option<String>,
+        /// Numeric pane id as shown by `ccmux list`.
+        #[arg(long, conflicts_with_all = ["name", "focused"])]
+        id: Option<usize>,
+        /// Target the currently focused pane.
+        #[arg(long, conflicts_with_all = ["name", "id"])]
+        focused: bool,
+        /// Append Enter after the text so the shell executes it.
+        #[arg(long)]
+        enter: bool,
+        /// Text to send.
+        text: String,
+    },
+    /// Move keyboard focus to a pane.
+    Focus {
+        #[arg(long, conflicts_with = "id")]
+        name: Option<String>,
+        #[arg(long, conflicts_with = "name")]
+        id: Option<usize>,
+    },
+    /// Open a new tab with a fresh single pane. Focus switches to the
+    /// new tab. Optionally pre-assigns a stable pane name and tab
+    /// label.
+    NewTab {
+        /// Command to run in the new pane.
+        #[arg(long)]
+        command: Option<String>,
+        /// Stable name for the new pane (lookup via `--name`).
+        #[arg(long)]
+        id: Option<String>,
+        /// Tab label (overrides the cwd-derived default).
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// Split a pane and optionally run a command in the new side.
+    Split {
+        /// Target pane to split. Defaults to the focused pane.
+        #[arg(long, conflicts_with_all = ["target_id", "target_focused"])]
+        target_name: Option<String>,
+        #[arg(long, conflicts_with_all = ["target_name", "target_focused"])]
+        target_id: Option<usize>,
+        #[arg(long, conflicts_with_all = ["target_name", "target_id"])]
+        target_focused: bool,
+        /// Split direction.
+        #[arg(long, value_parser = ["vertical", "horizontal"])]
+        direction: String,
+        /// Command to run in the freshly-created pane.
+        #[arg(long)]
+        command: Option<String>,
+        /// Stable name to assign to the new pane so it can be addressed
+        /// later via `--name`.
+        #[arg(long)]
+        id: Option<String>,
+    },
+}
+
+impl Cli {
+    /// Validate fields that clap cannot express declaratively.
+    pub fn validate_exec(&self) -> anyhow::Result<()> {
+        if let Some(cmd) = &self.exec {
+            if cmd.is_empty() {
+                anyhow::bail!("--exec value must not be empty");
+            }
+        }
+        Ok(())
+    }
+}
+
+impl IpcCommand {
+    /// Translate a CLI subcommand into the over-the-wire IPC request.
+    pub fn to_request(&self) -> anyhow::Result<crate::ipc::Request> {
+        use crate::ipc::{Direction, PaneRef, Request};
+
+        fn pick_ref(
+            name: &Option<String>,
+            id: &Option<usize>,
+            focused: bool,
+        ) -> anyhow::Result<PaneRef> {
+            match (name, id, focused) {
+                (Some(n), None, false) => Ok(PaneRef::Name(n.clone())),
+                (None, Some(i), false) => Ok(PaneRef::Id(*i)),
+                (None, None, true) => Ok(PaneRef::Focused),
+                (None, None, false) => Ok(PaneRef::Focused),
+                _ => {
+                    anyhow::bail!("ambiguous target: use at most one of --name / --id / --focused")
+                }
+            }
+        }
+
+        match self {
+            IpcCommand::List => Ok(Request::List),
+            IpcCommand::NewTab { command, id, label } => Ok(Request::NewTab {
+                command: command.clone(),
+                id: id.clone(),
+                label: label.clone(),
+            }),
+            IpcCommand::Send {
+                name,
+                id,
+                focused,
+                enter,
+                text,
+            } => Ok(Request::Send {
+                target: pick_ref(name, id, *focused)?,
+                data: text.clone(),
+                append_enter: *enter,
+            }),
+            IpcCommand::Focus { name, id } => Ok(Request::Focus {
+                target: pick_ref(name, id, false)?,
+            }),
+            IpcCommand::Split {
+                target_name,
+                target_id,
+                target_focused,
+                direction,
+                command,
+                id,
+            } => {
+                let dir = match direction.as_str() {
+                    "vertical" => Direction::Vertical,
+                    "horizontal" => Direction::Horizontal,
+                    other => anyhow::bail!("invalid direction: {other}"),
+                };
+                Ok(Request::Split {
+                    target: pick_ref(target_name, target_id, *target_focused)?,
+                    direction: dir,
+                    command: command.clone(),
+                    id: id.clone(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_no_args() {
+        let cli = Cli::try_parse_from(["ccmux"]).unwrap();
+        assert_eq!(cli.dir, None);
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn parses_directory_only() {
+        let cli = Cli::try_parse_from(["ccmux", "/path"]).unwrap();
+        assert_eq!(cli.dir, Some(PathBuf::from("/path")));
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn parses_exec_flag() {
+        let cli = Cli::try_parse_from(["ccmux", "--exec", "claude /company"]).unwrap();
+        assert_eq!(cli.dir, None);
+        assert_eq!(cli.exec.as_deref(), Some("claude /company"));
+    }
+
+    #[test]
+    fn parses_dir_and_exec() {
+        let cli = Cli::try_parse_from(["ccmux", ".", "--exec", "cce"]).unwrap();
+        assert_eq!(cli.dir, Some(PathBuf::from(".")));
+        assert_eq!(cli.exec.as_deref(), Some("cce"));
+    }
+
+    #[test]
+    fn rejects_empty_exec() {
+        let result = Cli::try_parse_from(["ccmux", "--exec", ""]);
+        assert!(
+            result.is_ok(),
+            "clap is permissive; validation happens later"
+        );
+        let cli = result.unwrap();
+        assert_eq!(cli.exec.as_deref(), Some(""));
+        assert!(
+            cli.validate_exec().is_err(),
+            "empty exec should fail validation"
+        );
+    }
+
+    #[test]
+    fn parses_layout_flag() {
+        let cli = Cli::try_parse_from(["ccmux", "--layout", "cc-campany"]).unwrap();
+        assert_eq!(cli.layout.as_deref(), Some("cc-campany"));
+        assert_eq!(cli.exec, None);
+    }
+
+    #[test]
+    fn rejects_exec_and_layout_together() {
+        let result = Cli::try_parse_from(["ccmux", "--exec", "x", "--layout", "y"]);
+        assert!(
+            result.is_err(),
+            "exec and layout must be mutually exclusive"
+        );
+    }
+
+    // -- Phase 3: IPC subcommands ------------------------------------
+
+    #[test]
+    fn parses_list_subcommand() {
+        let cli = Cli::try_parse_from(["ccmux", "list"]).unwrap();
+        assert!(matches!(cli.command, Some(IpcCommand::List)));
+    }
+
+    #[test]
+    fn parses_send_subcommand_with_name() {
+        let cli = Cli::try_parse_from([
+            "ccmux",
+            "send",
+            "--name",
+            "engineering",
+            "--enter",
+            "echo hi",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(IpcCommand::Send {
+                name,
+                enter,
+                text,
+                focused,
+                ..
+            }) => {
+                assert_eq!(name.as_deref(), Some("engineering"));
+                assert!(enter);
+                assert!(!focused);
+                assert_eq!(text, "echo hi");
+            }
+            other => panic!("expected Send, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_focus_subcommand_with_id() {
+        let cli = Cli::try_parse_from(["ccmux", "focus", "--id", "2"]).unwrap();
+        match cli.command {
+            Some(IpcCommand::Focus { id, name }) => {
+                assert_eq!(id, Some(2));
+                assert!(name.is_none());
+            }
+            other => panic!("expected Focus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_split_subcommand() {
+        let cli = Cli::try_parse_from([
+            "ccmux",
+            "split",
+            "--direction",
+            "horizontal",
+            "--command",
+            "ccr",
+            "--id",
+            "research",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(IpcCommand::Split {
+                direction,
+                command,
+                id,
+                ..
+            }) => {
+                assert_eq!(direction, "horizontal");
+                assert_eq!(command.as_deref(), Some("ccr"));
+                assert_eq!(id.as_deref(), Some("research"));
+            }
+            other => panic!("expected Split, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_send_with_two_targets() {
+        let result = Cli::try_parse_from(["ccmux", "send", "--name", "a", "--id", "1", "text"]);
+        assert!(result.is_err(), "name and id are mutually exclusive");
+    }
+
+    #[test]
+    fn split_rejects_bad_direction() {
+        let result = Cli::try_parse_from(["ccmux", "split", "--direction", "diagonal"]);
+        assert!(result.is_err(), "direction must be vertical or horizontal");
+    }
+
+    #[test]
+    fn send_to_request_uses_focused_when_no_target() {
+        let cli = Cli::try_parse_from(["ccmux", "send", "hi"]).unwrap();
+        let cmd = cli.command.unwrap();
+        let req = cmd.to_request().unwrap();
+        match req {
+            crate::ipc::Request::Send { target, data, .. } => {
+                assert!(matches!(target, crate::ipc::PaneRef::Focused));
+                assert_eq!(data, "hi");
+            }
+            other => panic!("expected Send, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_new_tab_subcommand() {
+        let cli = Cli::try_parse_from([
+            "ccmux",
+            "new-tab",
+            "--command",
+            "cce",
+            "--id",
+            "engineering",
+            "--label",
+            "eng",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(IpcCommand::NewTab { command, id, label }) => {
+                assert_eq!(command.as_deref(), Some("cce"));
+                assert_eq!(id.as_deref(), Some("engineering"));
+                assert_eq!(label.as_deref(), Some("eng"));
+            }
+            other => panic!("expected NewTab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_tab_to_request_preserves_fields() {
+        let cli = Cli::try_parse_from(["ccmux", "new-tab", "--command", "ccr", "--id", "research"])
+            .unwrap();
+        let req = cli.command.unwrap().to_request().unwrap();
+        match req {
+            crate::ipc::Request::NewTab { command, id, label } => {
+                assert_eq!(command.as_deref(), Some("ccr"));
+                assert_eq!(id.as_deref(), Some("research"));
+                assert!(label.is_none());
+            }
+            other => panic!("expected NewTab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn split_to_request_translates_direction() {
+        let cli = Cli::try_parse_from(["ccmux", "split", "--direction", "vertical", "--id", "foo"])
+            .unwrap();
+        let req = cli.command.unwrap().to_request().unwrap();
+        match req {
+            crate::ipc::Request::Split { direction, id, .. } => {
+                assert!(matches!(direction, crate::ipc::Direction::Vertical));
+                assert_eq!(id.as_deref(), Some("foo"));
+            }
+            other => panic!("expected Split, got {other:?}"),
+        }
+    }
+}

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -1,0 +1,141 @@
+//! IPC client: opens a short-lived connection to the running ccmux
+//! instance, performs the [`Request::Hello`] handshake, then sends
+//! exactly one [`Request`] and reads exactly one [`Response`].
+//!
+//! Connection lifecycle matches the server in [`super::server`]: one
+//! request per connection, closed by the client dropping the stream.
+
+use std::io::{BufRead, BufReader, Write};
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use interprocess::local_socket::{prelude::*, Stream};
+
+use super::endpoint::EndpointName;
+use super::{Request, Response};
+
+/// How long we wait for a response before giving up. The server replies
+/// within milliseconds unless the App is genuinely wedged; this value
+/// is a belt-and-braces safety net so a misbehaving server can't hang
+/// a shell script that invokes `ccmux send`.
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Send a single request to the endpoint and return the response.
+pub fn send_request(endpoint: &EndpointName, request: &Request) -> Result<Response> {
+    let name = make_connection_name(endpoint)?;
+    let conn =
+        Stream::connect(name).with_context(|| format!("connect to {}", endpoint.as_str()))?;
+    // interprocess 2.4 exposes read/write timeouts through the
+    // platform-specific wrappers; at the portable surface we rely on
+    // the blocking default. Blocking is fine here because the server's
+    // per-connection timeout already bounds our wait.
+    let _ = RESPONSE_TIMEOUT; // reserved for a future timeout hookup
+    converse(conn, request)
+}
+
+fn make_connection_name(endpoint: &EndpointName) -> Result<interprocess::local_socket::Name<'_>> {
+    #[cfg(windows)]
+    {
+        use interprocess::os::windows::local_socket::NamedPipe;
+        Ok(endpoint.as_str().to_fs_name::<NamedPipe>()?)
+    }
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        Ok(endpoint.as_str().to_fs_name::<GenericFilePath>()?)
+    }
+}
+
+fn converse(conn: Stream, request: &Request) -> Result<Response> {
+    let mut reader = BufReader::new(conn);
+
+    // Handshake
+    let hello = Request::Hello {
+        client_pid: std::process::id(),
+    };
+    write_request_line(reader.get_mut(), &hello)?;
+    let hello_resp = read_response_line(&mut reader)?;
+    match hello_resp {
+        Response::Hello { .. } => {}
+        Response::Err { message } => {
+            return Err(anyhow!("server refused hello: {message}"));
+        }
+        Response::Ok { .. } => {
+            return Err(anyhow!("unexpected ok response to hello"));
+        }
+    }
+
+    // Actual command
+    write_request_line(reader.get_mut(), request)?;
+    let resp = read_response_line(&mut reader)?;
+    Ok(resp)
+}
+
+fn write_request_line<W: Write>(w: &mut W, req: &Request) -> Result<()> {
+    let mut json = serde_json::to_string(req)?;
+    json.push('\n');
+    w.write_all(json.as_bytes())?;
+    w.flush()?;
+    Ok(())
+}
+
+fn read_response_line<R: BufRead>(r: &mut R) -> Result<Response> {
+    let mut buf = String::new();
+    let n = r.read_line(&mut buf)?;
+    if n == 0 {
+        return Err(anyhow!("server closed connection before replying"));
+    }
+    let resp: Response = serde_json::from_str(buf.trim())
+        .with_context(|| format!("parse response json: {buf:?}"))?;
+    Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipc::{Direction, PaneRef};
+
+    #[test]
+    fn write_request_line_is_newline_terminated() {
+        let mut out: Vec<u8> = Vec::new();
+        let req = Request::List;
+        write_request_line(&mut out, &req).unwrap();
+        assert!(out.ends_with(b"\n"));
+        // The line without the trailing newline must parse back to the
+        // original request — protects against accidentally emitting
+        // multi-line JSON.
+        let line = std::str::from_utf8(&out).unwrap().trim_end();
+        let parsed: Request = serde_json::from_str(line).unwrap();
+        assert_eq!(parsed, Request::List);
+    }
+
+    #[test]
+    fn read_response_line_parses_ok() {
+        let input: &[u8] = b"{\"status\":\"ok\",\"data\":null}\n";
+        let mut reader = std::io::BufReader::new(input);
+        let resp = read_response_line(&mut reader).unwrap();
+        assert!(matches!(resp, Response::Ok { .. }));
+    }
+
+    #[test]
+    fn read_response_line_eof_is_error() {
+        let input: &[u8] = b"";
+        let mut reader = std::io::BufReader::new(input);
+        assert!(read_response_line(&mut reader).is_err());
+    }
+
+    #[test]
+    fn write_request_line_roundtrips_split() {
+        let req = Request::Split {
+            target: PaneRef::Focused,
+            direction: Direction::Horizontal,
+            command: Some("echo".into()),
+            id: Some("foo".into()),
+        };
+        let mut out: Vec<u8> = Vec::new();
+        write_request_line(&mut out, &req).unwrap();
+        let line = std::str::from_utf8(&out).unwrap().trim_end();
+        let parsed: Request = serde_json::from_str(line).unwrap();
+        assert_eq!(parsed, req);
+    }
+}

--- a/src/ipc/endpoint.rs
+++ b/src/ipc/endpoint.rs
@@ -1,0 +1,151 @@
+//! Cross-platform IPC endpoint naming.
+//!
+//! Endpoints are scoped per running ccmux instance using its PID, so
+//! multiple ccmux processes on one machine don't collide. The endpoint
+//! name is also published to child PTYs via the `CCMUX_SOCKET`
+//! environment variable so in-pane clients (the secretary, etc.) can
+//! find the right server.
+
+use anyhow::{anyhow, Context, Result};
+use std::path::PathBuf;
+
+pub const ENV_SOCKET: &str = "CCMUX_SOCKET";
+
+/// Compute the IPC endpoint name for a ccmux instance with the given PID.
+///
+/// On Windows this is a Named Pipe path (`\\.\pipe\ccmux-<pid>`).
+/// On Unix this is a filesystem path under `$XDG_RUNTIME_DIR/ccmux/`,
+/// falling back to `$TMPDIR` and then `/tmp/ccmux-$UID/`.
+pub fn endpoint_for_pid(pid: u32) -> Result<EndpointName> {
+    #[cfg(windows)]
+    {
+        Ok(EndpointName::pipe(format!(r"\\.\pipe\ccmux-{pid}")))
+    }
+    #[cfg(unix)]
+    {
+        let dir = unix_socket_dir()?;
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("failed to create {}", dir.display()))?;
+        // Restrict directory to owner-only; ignore failure on platforms
+        // where chmod isn't expressible (shouldn't happen on unix).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o700);
+            let _ = std::fs::set_permissions(&dir, perms);
+        }
+        let path = dir.join(format!("ccmux-{pid}.sock"));
+        Ok(EndpointName::socket(path))
+    }
+}
+
+#[cfg(unix)]
+fn unix_socket_dir() -> Result<PathBuf> {
+    if let Ok(d) = std::env::var("XDG_RUNTIME_DIR") {
+        if !d.is_empty() {
+            return Ok(PathBuf::from(d).join("ccmux"));
+        }
+    }
+    if let Ok(d) = std::env::var("TMPDIR") {
+        if !d.is_empty() {
+            return Ok(PathBuf::from(d).join(format!("ccmux-{}", uid())));
+        }
+    }
+    Ok(PathBuf::from("/tmp").join(format!("ccmux-{}", uid())))
+}
+
+#[cfg(unix)]
+fn uid() -> u32 {
+    // Avoid pulling in `nix` just for getuid; libc is already a transitive
+    // dependency of basically everything on Unix. Until we add it
+    // explicitly, fall back to env(USER) if libc isn't available — the
+    // value only needs to be stable per-user.
+    std::env::var("UID")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EndpointName {
+    repr: String,
+    kind: EndpointKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EndpointKind {
+    Pipe,
+    Socket,
+}
+
+impl EndpointName {
+    pub fn pipe(name: impl Into<String>) -> Self {
+        Self {
+            repr: name.into(),
+            kind: EndpointKind::Pipe,
+        }
+    }
+    pub fn socket(path: PathBuf) -> Self {
+        Self {
+            repr: path.display().to_string(),
+            kind: EndpointKind::Socket,
+        }
+    }
+    pub fn as_str(&self) -> &str {
+        &self.repr
+    }
+    pub fn kind(&self) -> EndpointKind {
+        self.kind
+    }
+}
+
+/// Look up the endpoint a child process should connect to. Returns an
+/// error if the parent ccmux did not publish `CCMUX_SOCKET`.
+pub fn endpoint_from_env() -> Result<EndpointName> {
+    let s = std::env::var(ENV_SOCKET)
+        .map_err(|_| anyhow!("{ENV_SOCKET} not set; are you running inside ccmux?"))?;
+    if s.is_empty() {
+        return Err(anyhow!("{ENV_SOCKET} is empty"));
+    }
+    #[cfg(windows)]
+    {
+        Ok(EndpointName::pipe(s))
+    }
+    #[cfg(unix)]
+    {
+        Ok(EndpointName::socket(PathBuf::from(s)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_for_pid_includes_pid() {
+        let ep = endpoint_for_pid(12345).unwrap();
+        assert!(ep.as_str().contains("12345"), "{}", ep.as_str());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_endpoint_uses_pipe_prefix() {
+        let ep = endpoint_for_pid(1).unwrap();
+        assert!(ep.as_str().starts_with(r"\\.\pipe\"), "{}", ep.as_str());
+        assert_eq!(ep.kind(), EndpointKind::Pipe);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_endpoint_is_socket_path() {
+        let ep = endpoint_for_pid(1).unwrap();
+        assert!(ep.as_str().ends_with(".sock"), "{}", ep.as_str());
+        assert_eq!(ep.kind(), EndpointKind::Socket);
+    }
+
+    #[test]
+    fn endpoint_from_env_fails_without_var() {
+        std::env::remove_var(ENV_SOCKET);
+        assert!(endpoint_from_env().is_err());
+    }
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -1,0 +1,234 @@
+//! IPC protocol for controlling a running ccmux instance from outside.
+//!
+//! Wire format: newline-delimited JSON. Each line is one [`Request`] from
+//! client to server, followed by exactly one [`Response`] from server to
+//! client. Connections are short-lived in the v1 protocol — clients open,
+//! send one request, read one response, close.
+
+use serde::{Deserialize, Serialize};
+
+pub mod client;
+pub mod endpoint;
+pub mod server;
+
+/// One IPC call from a client to the running ccmux instance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum Request {
+    /// First message after connecting — exchanges PIDs and a session
+    /// token so a stale socket file with a re-used PID cannot be
+    /// silently mistaken for a live instance.
+    Hello { client_pid: u32 },
+    /// List all panes in the active workspace.
+    List,
+    /// Write `data` to the target pane's PTY. If `append_enter` is true,
+    /// a newline is appended so the shell executes the command.
+    Send {
+        target: PaneRef,
+        data: String,
+        #[serde(default)]
+        append_enter: bool,
+    },
+    /// Split the target pane and (optionally) run a command in the new
+    /// pane. The new pane is named `id` if provided.
+    Split {
+        target: PaneRef,
+        direction: Direction,
+        #[serde(default)]
+        command: Option<String>,
+        #[serde(default)]
+        id: Option<String>,
+    },
+    /// Move keyboard focus to the target pane.
+    Focus { target: PaneRef },
+    /// Create a new tab with a fresh single pane. The server switches
+    /// focus to the new tab (matching the existing Alt+T keybinding).
+    NewTab {
+        /// Startup command for the new pane.
+        #[serde(default)]
+        command: Option<String>,
+        /// Stable name to register for the new pane so it can be
+        /// addressed via `PaneRef::Name` later.
+        #[serde(default)]
+        id: Option<String>,
+        /// Override the tab label (otherwise derived from the cwd).
+        #[serde(default)]
+        label: Option<String>,
+    },
+}
+
+/// Identifies a pane in a request. Names are user-friendly and stable
+/// across splits; numeric ids are stable across the session but assigned
+/// internally; `Focused` is "whichever pane is focused right now".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneRef {
+    Id(usize),
+    Name(String),
+    Focused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Direction {
+    Vertical,
+    Horizontal,
+}
+
+/// One entry in the `List` response payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaneInfo {
+    pub id: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub focused: bool,
+}
+
+/// Server reply to one [`Request`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum Response {
+    /// Successful call. `data` is request-specific (e.g. the pane list).
+    Ok {
+        #[serde(default)]
+        data: serde_json::Value,
+    },
+    /// Hello reply: server identifies itself with PID and a session
+    /// token derived from its start time, so the client can detect
+    /// PID re-use from a previous crashed instance.
+    Hello {
+        server_pid: u32,
+        session_token: String,
+    },
+    /// Server-side failure. `message` is human-readable and not
+    /// machine-parseable; clients should match on `code` if added later.
+    Err { message: String },
+}
+
+impl Response {
+    pub fn ok_unit() -> Self {
+        Response::Ok {
+            data: serde_json::Value::Null,
+        }
+    }
+    pub fn ok_value(value: serde_json::Value) -> Self {
+        Response::Ok { data: value }
+    }
+    pub fn err(message: impl Into<String>) -> Self {
+        Response::Err {
+            message: message.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(req: &Request) -> Request {
+        let s = serde_json::to_string(req).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    #[test]
+    fn list_request_roundtrips() {
+        assert_eq!(roundtrip(&Request::List), Request::List);
+    }
+
+    #[test]
+    fn send_request_roundtrips_with_enter() {
+        let r = Request::Send {
+            target: PaneRef::Name("engineering".into()),
+            data: "hello".into(),
+            append_enter: true,
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn split_request_roundtrips() {
+        let r = Request::Split {
+            target: PaneRef::Focused,
+            direction: Direction::Vertical,
+            command: Some("cce".into()),
+            id: Some("engineering".into()),
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn pane_ref_id_serializes_with_numeric() {
+        let s = serde_json::to_string(&PaneRef::Id(7)).unwrap();
+        assert!(s.contains("\"id\""), "{s}");
+        assert!(s.contains("7"), "{s}");
+    }
+
+    #[test]
+    fn pane_ref_focused_serializes_with_unit() {
+        let s = serde_json::to_string(&PaneRef::Focused).unwrap();
+        assert!(s.contains("focused"), "{s}");
+    }
+
+    #[test]
+    fn unknown_command_fails_to_parse() {
+        let bad = r#"{"cmd":"explode","target":{"focused":null}}"#;
+        let parsed: Result<Request, _> = serde_json::from_str(bad);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn response_err_serializes_message() {
+        let r = Response::err("nope");
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"err\""), "{s}");
+        assert!(s.contains("nope"), "{s}");
+    }
+
+    #[test]
+    fn response_ok_unit_has_null_data() {
+        let r = Response::ok_unit();
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"ok\""), "{s}");
+        assert!(s.contains("null"), "{s}");
+    }
+
+    #[test]
+    fn hello_request_carries_pid() {
+        let r = Request::Hello { client_pid: 42 };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn new_tab_request_roundtrips() {
+        let r = Request::NewTab {
+            command: Some("cce".into()),
+            id: Some("engineering".into()),
+            label: Some("eng".into()),
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn new_tab_request_defaults_all_fields() {
+        let minimal = r#"{"cmd":"new_tab"}"#;
+        let parsed: Request = serde_json::from_str(minimal).unwrap();
+        match parsed {
+            Request::NewTab {
+                command: None,
+                id: None,
+                label: None,
+            } => {}
+            other => panic!("expected empty NewTab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hello_response_carries_token() {
+        let r = Response::Hello {
+            server_pid: 100,
+            session_token: "abc".into(),
+        };
+        let parsed: Response = serde_json::from_str(&serde_json::to_string(&r).unwrap()).unwrap();
+        assert_eq!(parsed, r);
+    }
+}

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1,0 +1,461 @@
+//! IPC server: accepts connections on a named endpoint and forwards
+//! each request to the App's command channel.
+//!
+//! Wire protocol: newline-delimited JSON. A connection must start with
+//! a `Hello` request; the server replies with a [`Response::Hello`]
+//! carrying its PID and a per-instance session token. The client then
+//! sends exactly one command and reads exactly one response before the
+//! server closes its side.
+//!
+//! Threading model:
+//! - One accept thread lives for the process lifetime and blocks on
+//!   `listener.incoming()`.
+//! - Each connection is handed to a short-lived worker thread so a slow
+//!   client can't starve the accept loop.
+//! - Workers communicate with the App by pushing an [`AppCommand`] into
+//!   the shared `Sender<AppCommand>` and blocking on a [`oneshot`] reply
+//!   with a timeout, so an unresponsive App can never hang a worker
+//!   indefinitely.
+
+use std::io::{BufRead, BufReader, Write};
+use std::sync::mpsc::Sender;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
+
+use super::endpoint::EndpointName;
+use super::{Direction, PaneRef, Request, Response};
+use crate::app::AppCommand;
+
+/// How long a worker waits for the App's event loop to process one
+/// command before giving up. The App drains commands every frame
+/// (~30Hz), so 5s is orders of magnitude more than the expected latency
+/// — a timeout here means the App is genuinely wedged.
+const APP_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct IpcServer {
+    pub endpoint: EndpointName,
+    pub session_token: String,
+    // We intentionally don't hold a JoinHandle. The accept thread lives
+    // until the process exits, at which point the OS reclaims the pipe
+    // or socket. Orderly shutdown is not needed in v1.
+}
+
+impl IpcServer {
+    /// Bind the listener and start accepting in a background thread.
+    pub fn spawn(
+        endpoint: EndpointName,
+        command_tx: Sender<AppCommand>,
+        session_token: String,
+    ) -> Result<Self> {
+        let listener = bind_listener(&endpoint)
+            .with_context(|| format!("bind IPC endpoint {}", endpoint.as_str()))?;
+
+        let token_for_thread = session_token.clone();
+        let endpoint_for_log = endpoint.as_str().to_string();
+        thread::Builder::new()
+            .name("ccmux-ipc-accept".into())
+            .spawn(move || {
+                accept_loop(listener, command_tx, token_for_thread, endpoint_for_log);
+            })
+            .context("spawn IPC accept thread")?;
+
+        Ok(Self {
+            endpoint,
+            session_token,
+        })
+    }
+}
+
+fn bind_listener(endpoint: &EndpointName) -> Result<interprocess::local_socket::Listener> {
+    // `to_fs_name` lets us pass an OS-native path (both the Windows
+    // pipe name `\\.\pipe\…` and a Unix socket path are absolute file
+    // names). `try_overwrite(true)` replaces a stale Unix socket file
+    // left behind by a crashed previous instance — on Windows the
+    // equivalent is a no-op because Named Pipes don't leak files.
+    #[cfg(windows)]
+    let name = {
+        use interprocess::os::windows::local_socket::NamedPipe;
+        endpoint.as_str().to_fs_name::<NamedPipe>()?
+    };
+    #[cfg(unix)]
+    let name = {
+        use interprocess::local_socket::GenericFilePath;
+        endpoint.as_str().to_fs_name::<GenericFilePath>()?
+    };
+
+    let listener = ListenerOptions::new()
+        .name(name)
+        .try_overwrite(true)
+        .create_sync()?;
+    Ok(listener)
+}
+
+fn accept_loop(
+    listener: interprocess::local_socket::Listener,
+    command_tx: Sender<AppCommand>,
+    session_token: String,
+    endpoint_for_log: String,
+) {
+    for conn in listener.incoming() {
+        let conn = match conn {
+            Ok(c) => c,
+            Err(e) => {
+                // A single failed accept shouldn't kill the server —
+                // the OS can recover from transient conditions.
+                eprintln!("ccmux IPC: accept failed on {endpoint_for_log}: {e}");
+                continue;
+            }
+        };
+
+        let tx = command_tx.clone();
+        let token = session_token.clone();
+        if let Err(e) = thread::Builder::new()
+            .name("ccmux-ipc-worker".into())
+            .spawn(move || {
+                if let Err(e) = handle_connection(conn, tx, &token) {
+                    eprintln!("ccmux IPC: connection error: {e}");
+                }
+            })
+        {
+            // Thread spawn failures are extremely rare (EAGAIN under
+            // system pressure). Dropping the connection is safe — the
+            // client sees EOF and can retry. We deliberately don't fall
+            // back to inline handling because that would block the
+            // accept loop behind a slow request.
+            eprintln!("ccmux IPC: worker spawn failed, dropping connection: {e}");
+        }
+    }
+}
+
+fn handle_connection(
+    conn: Stream,
+    command_tx: Sender<AppCommand>,
+    session_token: &str,
+) -> Result<()> {
+    // The stream is split by wrapping in BufReader for line-buffered
+    // reads; writes go through BufReader::get_mut. We can't construct
+    // two BufReader clones without a split, so we borrow mutably.
+    let mut reader = BufReader::new(conn);
+    let mut line = String::new();
+
+    // ── 1. Handshake ───────────────────────────────────────
+    if read_line_or_eof(&mut reader, &mut line)?.is_none() {
+        return Ok(());
+    }
+    let req: Request = match serde_json::from_str(line.trim()) {
+        Ok(r) => r,
+        Err(e) => {
+            return write_response_line(
+                reader.get_mut(),
+                &Response::err(format!("parse error on hello: {e}")),
+            );
+        }
+    };
+    match req {
+        Request::Hello { client_pid: _ } => {
+            let hello = Response::Hello {
+                server_pid: std::process::id(),
+                session_token: session_token.to_string(),
+            };
+            write_response_line(reader.get_mut(), &hello)?;
+        }
+        _ => {
+            write_response_line(
+                reader.get_mut(),
+                &Response::err("first message must be hello"),
+            )?;
+            return Ok(());
+        }
+    }
+
+    // ── 2. One command ─────────────────────────────────────
+    line.clear();
+    if read_line_or_eof(&mut reader, &mut line)?.is_none() {
+        return Ok(());
+    }
+    let req: Request = match serde_json::from_str(line.trim()) {
+        Ok(r) => r,
+        Err(e) => {
+            return write_response_line(
+                reader.get_mut(),
+                &Response::err(format!("parse error: {e}")),
+            );
+        }
+    };
+    let resp = dispatch_request(req, &command_tx);
+    write_response_line(reader.get_mut(), &resp)?;
+    Ok(())
+}
+
+fn read_line_or_eof<R: BufRead>(reader: &mut R, buf: &mut String) -> Result<Option<()>> {
+    let n = reader.read_line(buf)?;
+    Ok(if n == 0 { None } else { Some(()) })
+}
+
+fn write_response_line<W: Write>(w: &mut W, resp: &Response) -> Result<()> {
+    let mut json = serde_json::to_string(resp)?;
+    json.push('\n');
+    w.write_all(json.as_bytes())?;
+    w.flush()?;
+    Ok(())
+}
+
+fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
+    match req {
+        Request::Hello { .. } => Response::err("unexpected duplicate hello"),
+        Request::List => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if command_tx
+                .send(AppCommand::List { reply: reply_tx })
+                .is_err()
+            {
+                return Response::err("app shutting down");
+            }
+            match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+                Ok(list) => match serde_json::to_value(&list) {
+                    Ok(v) => Response::ok_value(v),
+                    Err(e) => Response::err(format!("serialize pane list: {e}")),
+                },
+                Err(e) => Response::err(format!("app did not respond: {e}")),
+            }
+        }
+        Request::Send {
+            target,
+            data,
+            append_enter,
+        } => forward_unit(command_tx, |reply| AppCommand::Send {
+            target,
+            data: data.into_bytes(),
+            append_enter,
+            reply,
+        }),
+        Request::Focus { target } => {
+            forward_unit(command_tx, |reply| AppCommand::Focus { target, reply })
+        }
+        Request::Split {
+            target,
+            direction,
+            command,
+            id,
+        } => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if command_tx
+                .send(AppCommand::Split {
+                    target,
+                    direction,
+                    command,
+                    name: id,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return Response::err("app shutting down");
+            }
+            match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+                Ok(Ok(new_id)) => Response::ok_value(serde_json::json!({ "id": new_id })),
+                Ok(Err(msg)) => Response::err(msg),
+                Err(e) => Response::err(format!("app did not respond: {e}")),
+            }
+        }
+        Request::NewTab { command, id, label } => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if command_tx
+                .send(AppCommand::NewTab {
+                    command,
+                    name: id,
+                    label,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return Response::err("app shutting down");
+            }
+            match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+                Ok(Ok(new_id)) => Response::ok_value(serde_json::json!({ "id": new_id })),
+                Ok(Err(msg)) => Response::err(msg),
+                Err(e) => Response::err(format!("app did not respond: {e}")),
+            }
+        }
+    }
+}
+
+/// Forward a command whose success result is `()` and translate the
+/// reply into a [`Response`]. Factored out because three of the four
+/// variants share this exact shape.
+fn forward_unit(
+    command_tx: &Sender<AppCommand>,
+    build: impl FnOnce(oneshot::Sender<std::result::Result<(), String>>) -> AppCommand,
+) -> Response {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx.send(build(reply_tx)).is_err() {
+        return Response::err("app shutting down");
+    }
+    match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+        Ok(Ok(_)) => Response::ok_unit(),
+        Ok(Err(msg)) => Response::err(msg),
+        Err(e) => Response::err(format!("app did not respond: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipc::Request;
+    use std::sync::mpsc;
+
+    #[test]
+    fn dispatch_list_ok_when_app_replies() {
+        // Pretend to be the App: spawn a thread that pulls a List
+        // command off the channel and replies with an empty list.
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::List { reply }) = rx.recv() {
+                reply.send(Vec::new()).unwrap();
+            }
+        });
+
+        let resp = dispatch_request(Request::List, &tx);
+        handle.join().unwrap();
+
+        match resp {
+            Response::Ok { data } => {
+                // An empty Vec<PaneInfo> serializes to a JSON array.
+                assert!(data.is_array(), "expected array, got {data:?}");
+                assert_eq!(data.as_array().map(|a| a.len()), Some(0));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_focus_ok_when_app_replies_ok() {
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::Focus { reply, .. }) = rx.recv() {
+                reply.send(Ok(())).unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::Focus {
+                target: PaneRef::Focused,
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        assert!(matches!(resp, Response::Ok { .. }));
+    }
+
+    #[test]
+    fn dispatch_focus_err_when_app_replies_err() {
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::Focus { reply, .. }) = rx.recv() {
+                reply.send(Err("pane not found".into())).unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::Focus {
+                target: PaneRef::Id(999),
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        match resp {
+            Response::Err { message } => assert!(message.contains("pane not found")),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_split_returns_new_id() {
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::Split { reply, .. }) = rx.recv() {
+                reply.send(Ok(42)).unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::Split {
+                target: PaneRef::Focused,
+                direction: Direction::Vertical,
+                command: None,
+                id: None,
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        match resp {
+            Response::Ok { data } => {
+                assert_eq!(data.get("id").and_then(|v| v.as_u64()), Some(42));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_send_forwards_data_and_enter() {
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::Send {
+                data,
+                append_enter,
+                reply,
+                ..
+            }) = rx.recv()
+            {
+                assert_eq!(data, b"hello");
+                assert!(append_enter);
+                reply.send(Ok(())).unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::Send {
+                target: PaneRef::Name("engineering".into()),
+                data: "hello".into(),
+                append_enter: true,
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        assert!(matches!(resp, Response::Ok { .. }));
+    }
+
+    #[test]
+    fn dispatch_new_tab_returns_new_id() {
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::NewTab { reply, .. }) = rx.recv() {
+                reply.send(Ok(11)).unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::NewTab {
+                command: Some("cce".into()),
+                id: Some("engineering".into()),
+                label: None,
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        match resp {
+            Response::Ok { data } => {
+                assert_eq!(data.get("id").and_then(|v| v.as_u64()), Some(11));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_refuses_second_hello() {
+        // Duplicate hello after handshake should be an error path.
+        let (tx, _rx) = mpsc::channel::<AppCommand>();
+        let resp = dispatch_request(Request::Hello { client_pid: 1 }, &tx);
+        match resp {
+            Response::Err { message } => assert!(message.contains("hello")),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+}

--- a/src/layout_config.rs
+++ b/src/layout_config.rs
@@ -1,0 +1,402 @@
+//! Multi-pane layout configuration loaded from TOML.
+//!
+//! A layout is a binary tree of panes, where each leaf is a pane (with an
+//! optional command) and each interior node is a split with a direction
+//! (`vertical` or `horizontal`) and a ratio.
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct LayoutConfig {
+    pub version: u8,
+    pub name: String,
+    pub root: LayoutNodeSpec,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum LayoutNodeSpec {
+    Pane {
+        id: String,
+        #[serde(default)]
+        command: Option<String>,
+    },
+    Split {
+        direction: DirectionSpec,
+        ratio: f32,
+        first: Box<LayoutNodeSpec>,
+        second: Box<LayoutNodeSpec>,
+    },
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum DirectionSpec {
+    Vertical,
+    Horizontal,
+}
+
+const SUPPORTED_VERSION: u8 = 1;
+const MAX_PANES: usize = 16;
+const MIN_RATIO: f32 = 0.1;
+const MAX_RATIO: f32 = 0.9;
+const ID_PATTERN_HINT: &str = "id must contain only [A-Za-z0-9_-]";
+
+impl LayoutConfig {
+    /// Parse a layout from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<Self> {
+        let cfg: Self = toml::from_str(s).context("failed to parse layout TOML")?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// Resolve the path to a layout file by name. Search order:
+    ///   1. `$CCMUX_LAYOUTS_DIR/<name>.toml` (env override, for tests)
+    ///   2. `./ccmux-layouts/<name>.toml` (project local)
+    ///   3. `~/.config/ccmux/layouts/<name>.toml` (user global)
+    pub fn resolve_path(name: &str) -> Result<PathBuf> {
+        let candidates = Self::candidate_paths(name);
+        for p in &candidates {
+            if p.is_file() {
+                return Ok(p.clone());
+            }
+        }
+        let listed = candidates
+            .iter()
+            .map(|p| format!("  - {}", p.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Err(anyhow!("layout '{name}' not found. Searched:\n{listed}"))
+    }
+
+    fn candidate_paths(name: &str) -> Vec<PathBuf> {
+        let env_dir = std::env::var("CCMUX_LAYOUTS_DIR").ok();
+        candidate_paths_from(name, env_dir.as_deref(), dirs::config_dir())
+    }
+
+    /// Load and parse a layout by name.
+    pub fn load(name: &str) -> Result<Self> {
+        let path = Self::resolve_path(name)?;
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read layout file {}", path.display()))?;
+        Self::from_toml_str(&content)
+    }
+
+    /// Validate the parsed layout: schema version, ratios, id uniqueness,
+    /// id character set, and pane count.
+    pub fn validate(&self) -> Result<()> {
+        if self.version != SUPPORTED_VERSION {
+            return Err(anyhow!(
+                "unsupported layout version {} (this build expects {})",
+                self.version,
+                SUPPORTED_VERSION
+            ));
+        }
+        if self.name.trim().is_empty() {
+            return Err(anyhow!("layout name must not be empty"));
+        }
+        let mut ids = HashSet::new();
+        let mut count = 0usize;
+        validate_node(&self.root, &mut ids, &mut count)?;
+        if count == 0 {
+            return Err(anyhow!("layout must contain at least one pane"));
+        }
+        if count > MAX_PANES {
+            return Err(anyhow!("layout has {count} panes (max {MAX_PANES})",));
+        }
+        Ok(())
+    }
+}
+
+/// Pure version of `candidate_paths` that takes the env override and
+/// user-config dir as arguments. Split out so tests can verify the
+/// search order without mutating the process-wide `CCMUX_LAYOUTS_DIR`
+/// env var (which races under `cargo test`'s parallel runner).
+fn candidate_paths_from(
+    name: &str,
+    env_dir: Option<&str>,
+    user_cfg_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let file = format!("{name}.toml");
+    let mut out = Vec::new();
+    if let Some(env_dir) = env_dir {
+        if !env_dir.is_empty() {
+            out.push(PathBuf::from(env_dir).join(&file));
+        }
+    }
+    out.push(PathBuf::from("ccmux-layouts").join(&file));
+    if let Some(cfg_dir) = user_cfg_dir {
+        out.push(cfg_dir.join("ccmux").join("layouts").join(&file));
+    }
+    out
+}
+
+fn validate_node(
+    node: &LayoutNodeSpec,
+    ids: &mut HashSet<String>,
+    count: &mut usize,
+) -> Result<()> {
+    match node {
+        LayoutNodeSpec::Pane { id, .. } => {
+            if id.trim().is_empty() {
+                return Err(anyhow!("pane id must not be empty"));
+            }
+            if !id
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                return Err(anyhow!("invalid pane id '{id}': {ID_PATTERN_HINT}"));
+            }
+            if !ids.insert(id.clone()) {
+                return Err(anyhow!("duplicate pane id '{id}'"));
+            }
+            *count += 1;
+            Ok(())
+        }
+        LayoutNodeSpec::Split {
+            ratio,
+            first,
+            second,
+            ..
+        } => {
+            if !ratio.is_finite() {
+                return Err(anyhow!("split ratio must be a finite number"));
+            }
+            if *ratio < MIN_RATIO || *ratio > MAX_RATIO {
+                return Err(anyhow!(
+                    "split ratio {ratio} out of range ({MIN_RATIO}..={MAX_RATIO})",
+                ));
+            }
+            validate_node(first, ids, count)?;
+            validate_node(second, ids, count)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn single_pane_toml() -> &'static str {
+        r#"
+            version = 1
+            name = "single"
+            [root]
+            type = "pane"
+            id = "secretary"
+            command = "claude /company"
+        "#
+    }
+
+    fn nested_layout_toml() -> &'static str {
+        r#"
+            version = 1
+            name = "cc-campany"
+            [root]
+            type = "split"
+            direction = "vertical"
+            ratio = 0.5
+
+              [root.first]
+              type = "pane"
+              id = "secretary"
+              command = "claude /company"
+
+              [root.second]
+              type = "split"
+              direction = "horizontal"
+              ratio = 0.5
+
+                [root.second.first]
+                type = "pane"
+                id = "engineering"
+                command = "cce"
+
+                [root.second.second]
+                type = "pane"
+                id = "research"
+                command = "ccr"
+        "#
+    }
+
+    #[test]
+    fn parses_single_pane_layout() {
+        let cfg = LayoutConfig::from_toml_str(single_pane_toml()).unwrap();
+        assert_eq!(cfg.version, 1);
+        assert_eq!(cfg.name, "single");
+        match &cfg.root {
+            LayoutNodeSpec::Pane { id, command } => {
+                assert_eq!(id, "secretary");
+                assert_eq!(command.as_deref(), Some("claude /company"));
+            }
+            _ => panic!("expected Pane at root"),
+        }
+    }
+
+    #[test]
+    fn parses_nested_split_layout() {
+        let cfg = LayoutConfig::from_toml_str(nested_layout_toml()).unwrap();
+        assert_eq!(cfg.name, "cc-campany");
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let toml = r#"
+            version = 99
+            name = "x"
+            [root]
+            type = "pane"
+            id = "a"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let toml = r#"
+            version = 1
+            name = ""
+            [root]
+            type = "pane"
+            id = "a"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_pane_ids() {
+        let toml = r#"
+            version = 1
+            name = "dup"
+            [root]
+            type = "split"
+            direction = "vertical"
+            ratio = 0.5
+              [root.first]
+              type = "pane"
+              id = "a"
+              [root.second]
+              type = "pane"
+              id = "a"
+        "#;
+        let err = LayoutConfig::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("duplicate pane id"), "{err}");
+    }
+
+    #[test]
+    fn rejects_invalid_id_characters() {
+        let toml = r#"
+            version = 1
+            name = "bad-id"
+            [root]
+            type = "pane"
+            id = "has space"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_ratio_below_min() {
+        let toml = r#"
+            version = 1
+            name = "x"
+            [root]
+            type = "split"
+            direction = "vertical"
+            ratio = 0.05
+              [root.first]
+              type = "pane"
+              id = "a"
+              [root.second]
+              type = "pane"
+              id = "b"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_ratio_above_max() {
+        let toml = r#"
+            version = 1
+            name = "x"
+            [root]
+            type = "split"
+            direction = "vertical"
+            ratio = 0.95
+              [root.first]
+              type = "pane"
+              id = "a"
+              [root.second]
+              type = "pane"
+              id = "b"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_ratio_nan() {
+        let toml = r#"
+            version = 1
+            name = "x"
+            [root]
+            type = "split"
+            direction = "vertical"
+            ratio = nan
+              [root.first]
+              type = "pane"
+              id = "a"
+              [root.second]
+              type = "pane"
+              id = "b"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_pane_without_id() {
+        let toml = r#"
+            version = 1
+            name = "x"
+            [root]
+            type = "pane"
+        "#;
+        assert!(LayoutConfig::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn env_override_comes_first() {
+        // Test the pure helper directly so we don't race with other
+        // tests on the shared `CCMUX_LAYOUTS_DIR` env var.
+        let paths = candidate_paths_from(
+            "foo",
+            Some("/tmp/ccmux-test-layouts"),
+            Some(PathBuf::from("/fake-user-cfg")),
+        );
+        assert_eq!(paths[0], PathBuf::from("/tmp/ccmux-test-layouts/foo.toml"));
+    }
+
+    #[test]
+    fn empty_env_override_is_ignored() {
+        // `CCMUX_LAYOUTS_DIR=""` must not become a bogus `./foo.toml`
+        // candidate — we only honor a non-empty override.
+        let paths = candidate_paths_from("foo", Some(""), Some(PathBuf::from("/fake-user-cfg")));
+        assert_eq!(paths[0], PathBuf::from("ccmux-layouts/foo.toml"));
+    }
+
+    #[test]
+    fn candidate_paths_fall_through_to_user_cfg() {
+        // With no env override, first candidate is the project-local
+        // directory and the user config dir is the fallback.
+        let paths = candidate_paths_from("foo", None, Some(PathBuf::from("/home/user/.config")));
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], PathBuf::from("ccmux-layouts/foo.toml"));
+        assert_eq!(
+            paths[1],
+            PathBuf::from("/home/user/.config/ccmux/layouts/foo.toml")
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 mod app;
 mod claude_monitor;
+mod cli;
 mod filetree;
+mod ipc;
+mod layout_config;
 mod pane;
 mod preview;
 mod ui;
@@ -11,29 +14,47 @@ use std::panic;
 use std::time::Duration;
 
 use anyhow::Result;
+use clap::Parser;
 use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use crossterm::execute;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
 fn main() -> Result<()> {
-    // Detect if running inside another ccmux instance
+    // Parse CLI args. clap handles --help / --version and exits cleanly
+    // before we enter raw mode below.
+    let cli = cli::Cli::parse();
+    cli.validate_exec()?;
+
+    // Phase 3: subcommands (`ccmux list`, `ccmux send`, …) are IPC
+    // clients and MUST be runnable from inside a ccmux pane — that's
+    // the whole point. Dispatch them before the nested-TUI guard kicks
+    // in, so the `CCMUX=1` env var set by the parent doesn't block
+    // legitimate client invocations.
+    if let Some(cmd) = cli.command.as_ref() {
+        return run_ipc_client(cmd);
+    }
+
+    // No subcommand: we're about to launch another TUI. Refuse if we're
+    // already inside a ccmux pane, since nesting vt100 parsers in
+    // vt100 parsers produces unreadable output and confuses the mouse.
     if std::env::var("CCMUX").is_ok() {
         eprintln!("ccmux: already running inside a ccmux pane (nested instance not allowed).");
-        eprintln!("       Open a new tab with Alt+T (or Ctrl+T) or split with Ctrl+D / Ctrl+E instead.");
+        eprintln!(
+            "       Open a new tab with Alt+T (or Ctrl+T) or split with Ctrl+D / Ctrl+E instead."
+        );
         std::process::exit(1);
     }
 
     // If a directory is passed as argument, cd into it first
-    if let Some(dir) = std::env::args().nth(1) {
-        let path = std::path::Path::new(&dir);
-        if path.is_dir() {
-            std::env::set_current_dir(path)?;
+    if let Some(dir) = &cli.dir {
+        if dir.is_dir() {
+            std::env::set_current_dir(dir)?;
         } else {
-            eprintln!("ccmux: not a directory: {}", dir);
+            eprintln!("ccmux: not a directory: {}", dir.display());
             std::process::exit(1);
         }
     }
@@ -61,8 +82,58 @@ fn main() -> Result<()> {
     // Get initial terminal size
     let size = terminal.size()?;
 
-    // Create app
+    // Phase 3: start the IPC server BEFORE spawning child PTYs so the
+    // first `CCMUX_SOCKET` value children see is the real one. Children
+    // inherit env from this process (via portable-pty's CommandBuilder),
+    // and we publish `CCMUX` as a "you're inside ccmux" flag here too.
+    let our_pid = std::process::id();
+    let ipc_endpoint = ipc::endpoint::endpoint_for_pid(our_pid)?;
+    std::env::set_var(ipc::endpoint::ENV_SOCKET, ipc_endpoint.as_str());
+    std::env::set_var("CCMUX", "1");
+
+    // Create app (spawns the initial pane, which captures the env above).
     let mut app = app::App::new(size.height, size.width)?;
+
+    // Session token derived from the process's start nanoseconds so a
+    // client connecting through a stale socket file whose PID got
+    // re-used cannot be silently fooled — the server echoes this token
+    // back on hello, and the client verifies it against its own expect.
+    let session_token = format!(
+        "{}-{}",
+        our_pid,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    if let Err(e) = ipc::server::IpcServer::spawn(
+        ipc_endpoint.clone(),
+        app.command_tx.clone(),
+        session_token.clone(),
+    ) {
+        // IPC is non-essential for the TUI itself — fail soft so users
+        // without the required socket permissions can still use ccmux
+        // as a plain multiplexer.
+        eprintln!("ccmux: IPC server failed to start ({e}); external commands disabled.");
+    }
+
+    // Phase 1 (--exec): queue the requested command on the initial focused
+    // pane. The command will be flushed into the PTY by the main event
+    // loop once the shell prompt is ready (see `try_flush_startup`).
+    if let Some(cmd) = cli.exec.as_deref() {
+        let focused_id = app.ws().focused_pane_id;
+        if let Some(pane) = app.ws_mut().panes.get_mut(&focused_id) {
+            pane.queue_startup_command(cmd);
+        }
+    }
+
+    // Phase 2 (--layout): expand a multi-pane layout from a TOML file.
+    // Each leaf pane's command (if any) is queued via the same Phase 1
+    // mechanism so all panes flush once their shells are ready.
+    if let Some(layout_name) = cli.layout.as_deref() {
+        let cfg = layout_config::LayoutConfig::load(layout_name)?;
+        app.apply_layout(&cfg)?;
+    }
 
     // Main event loop
     let result = run_event_loop(&mut terminal, &mut app);
@@ -84,6 +155,38 @@ fn main() -> Result<()> {
     result
 }
 
+/// Handle an IPC subcommand (`ccmux send …`, `ccmux list`, etc.).
+/// Resolves the endpoint from the `CCMUX_SOCKET` env var the parent
+/// ccmux published to its child PTYs; prints the server's response to
+/// stdout and exits with a non-zero code on error so shell scripts can
+/// branch on it.
+fn run_ipc_client(cmd: &cli::IpcCommand) -> Result<()> {
+    let endpoint = ipc::endpoint::endpoint_from_env()
+        .map_err(|e| anyhow::anyhow!("{e}; run this from inside a ccmux pane"))?;
+    let request = cmd.to_request()?;
+    let response = ipc::client::send_request(&endpoint, &request)?;
+    match response {
+        ipc::Response::Ok { data } => {
+            // `null` → nothing to print; anything else goes out as
+            // pretty JSON so shell scripts can `jq` it. We don't print
+            // spurious newlines for empty responses so pipelines stay
+            // tight.
+            if !data.is_null() {
+                let pretty =
+                    serde_json::to_string_pretty(&data).unwrap_or_else(|_| data.to_string());
+                println!("{pretty}");
+            }
+            Ok(())
+        }
+        ipc::Response::Hello { .. } => {
+            // Hello should only appear as the handshake reply, never
+            // as a top-level command response.
+            Err(anyhow::anyhow!("server returned hello to a command"))
+        }
+        ipc::Response::Err { message } => Err(anyhow::anyhow!("{message}")),
+    }
+}
+
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut app::App,
@@ -93,6 +196,20 @@ fn run_event_loop(
     loop {
         // Drain any PTY output events
         app.drain_pty_events();
+
+        // Phase 3: dispatch any commands delivered from the IPC server
+        // thread. No-op when the channel is empty, so it's cheap to call
+        // every frame.
+        app.drain_app_commands();
+
+        // Phase 1 (--exec): flush queued startup commands once the shell
+        // prompt is observed. This is a no-op for panes without a queued
+        // command, so it's safe to run every frame.
+        for ws in &mut app.workspaces {
+            for pane in ws.panes.values_mut() {
+                let _ = pane.try_flush_startup();
+            }
+        }
 
         // After paste, wait a few frames for PTY echo to settle
         if app.paste_cooldown > 0 {
@@ -145,7 +262,8 @@ fn run_event_loop(
                                                 }
                                                 break;
                                             }
-                                            if let Some(b) = crate::app::key_event_to_bytes_pub(&k) {
+                                            if let Some(b) = crate::app::key_event_to_bytes_pub(&k)
+                                            {
                                                 paste_buffer.extend_from_slice(&b);
                                             }
                                         }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -23,6 +24,13 @@ pub struct Pane {
     pub title: Arc<Mutex<String>>,
     pub cwd: PathBuf,
     pub total_scrollback: Arc<std::sync::atomic::AtomicUsize>,
+    /// Bytes to write into the PTY once the shell prompt is ready.
+    /// `None` means no command queued (or already flushed).
+    pub pending_startup: Option<Vec<u8>>,
+    /// Set to `true` by the reader thread once a shell prompt has been
+    /// observed. Used to gate `pending_startup` flushing so the command
+    /// is not eaten by an initializing shell.
+    pub prompt_seen: Arc<AtomicBool>,
 }
 
 impl Pane {
@@ -31,7 +39,13 @@ impl Pane {
         Self::new_with_cwd(id, rows, cols, event_tx, None)
     }
 
-    pub fn new_with_cwd(id: usize, rows: u16, cols: u16, event_tx: Sender<AppEvent>, cwd: Option<PathBuf>) -> Result<Self> {
+    pub fn new_with_cwd(
+        id: usize,
+        rows: u16,
+        cols: u16,
+        event_tx: Sender<AppEvent>,
+        cwd: Option<PathBuf>,
+    ) -> Result<Self> {
         let pty_system = native_pty_system();
 
         let pty_size = PtySize {
@@ -41,9 +55,7 @@ impl Pane {
             pixel_height: 0,
         };
 
-        let pair = pty_system
-            .openpty(pty_size)
-            .context("Failed to open PTY")?;
+        let pair = pty_system.openpty(pty_size).context("Failed to open PTY")?;
 
         let shell = detect_shell();
         let mut cmd = CommandBuilder::new(&shell);
@@ -57,7 +69,8 @@ impl Pane {
             cmd.arg("--login");
         }
 
-        let work_dir = cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let work_dir =
+            cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
         cmd.cwd(&work_dir);
         cmd.env("TERM", "xterm-256color");
         cmd.env("CCMUX", "1"); // marker to detect nested ccmux
@@ -88,8 +101,18 @@ impl Pane {
         let title_clone = Arc::clone(&pane_title);
         let scrollback_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let scrollback_clone = Arc::clone(&scrollback_counter);
+        let prompt_seen = Arc::new(AtomicBool::new(false));
+        let prompt_seen_clone = Arc::clone(&prompt_seen);
         let reader_handle = thread::spawn(move || {
-            pty_reader_thread(reader, parser_clone, title_clone, scrollback_clone, id, event_tx);
+            pty_reader_thread(
+                reader,
+                parser_clone,
+                title_clone,
+                scrollback_clone,
+                prompt_seen_clone,
+                id,
+                event_tx,
+            );
         });
 
         let mut pane = Self {
@@ -105,6 +128,8 @@ impl Pane {
             title: pane_title,
             cwd: work_dir,
             total_scrollback: scrollback_counter,
+            pending_startup: None,
+            prompt_seen,
         };
 
         // Inject OSC 7 hook after shell starts
@@ -190,7 +215,9 @@ impl Pane {
         let current = screen.scrollback();
         // Estimate max by checking: set_scrollback clamps to actual scrollback length
         // We can't query it directly, so use the stored total_scrollback as estimate
-        let total = self.total_scrollback.load(std::sync::atomic::Ordering::Relaxed);
+        let total = self
+            .total_scrollback
+            .load(std::sync::atomic::Ordering::Relaxed);
         (current, total)
     }
 
@@ -198,7 +225,9 @@ impl Pane {
     pub fn scroll_down(&self, lines: usize) {
         let mut parser = self.parser.lock().unwrap_or_else(|e| e.into_inner());
         let current = parser.screen().scrollback();
-        parser.screen_mut().set_scrollback(current.saturating_sub(lines));
+        parser
+            .screen_mut()
+            .set_scrollback(current.saturating_sub(lines));
     }
 
     /// Reset scroll to the bottom (live view).
@@ -234,6 +263,41 @@ impl Pane {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
+
+    /// Queue a command to be written into the PTY once the shell prompt
+    /// is ready. A trailing newline is appended automatically so the
+    /// command is executed as soon as the shell sees it.
+    pub fn queue_startup_command(&mut self, cmd: &str) {
+        let mut data = cmd.as_bytes().to_vec();
+        if !data.ends_with(b"\n") {
+            data.push(b'\n');
+        }
+        self.pending_startup = Some(data);
+    }
+
+    /// If a startup command is queued and the shell prompt has been
+    /// observed, write the command into the PTY and clear the queue.
+    /// Returns `Ok(true)` if a flush happened, `Ok(false)` otherwise.
+    /// Acquire ordering pairs with the reader thread's `Release` store.
+    pub fn try_flush_startup(&mut self) -> std::io::Result<bool> {
+        if self.pending_startup.is_none() {
+            return Ok(false);
+        }
+        if !self.prompt_seen.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        if let Some(data) = self.pending_startup.take() {
+            // Mirror `write_input`: any write OR flush failure marks the
+            // pane as exited and is reported as a no-op flush so callers
+            // do not see partial-write panics.
+            if self.writer.write_all(&data).is_err() || self.writer.flush().is_err() {
+                self.exited = true;
+                return Ok(false);
+            }
+            return Ok(true);
+        }
+        Ok(false)
+    }
 }
 
 impl Drop for Pane {
@@ -248,9 +312,16 @@ fn pty_reader_thread(
     parser: Arc<Mutex<vt100::Parser>>,
     title: Arc<Mutex<String>>,
     scrollback_count: Arc<std::sync::atomic::AtomicUsize>,
+    prompt_seen: Arc<AtomicBool>,
     pane_id: usize,
     event_tx: Sender<AppEvent>,
 ) {
+    // Rolling tail of the most recent bytes read from the PTY. Used to
+    // detect a shell prompt that may straddle two reader chunks. Capped
+    // so the buffer cannot grow without bound.
+    const TAIL_CAP: usize = 256;
+    let mut tail: Vec<u8> = Vec::with_capacity(TAIL_CAP * 2);
+
     let mut buf = [0u8; 4096];
     loop {
         match reader.read(&mut buf) {
@@ -267,8 +338,17 @@ fn pty_reader_thread(
                     scrollback_count.fetch_add(newlines, std::sync::atomic::Ordering::Relaxed);
                 }
 
-                // Detect OSC 7 (cwd notification)
+                // Detect OSC 7 (cwd notification). Bash/zsh emit this on
+                // every prompt thanks to the hook injected in `Pane::new`,
+                // so its presence is also a strong "prompt is up" signal.
+                // Release ordering pairs with the Acquire load in
+                // `Pane::try_flush_startup` so the queued startup command
+                // is published to the main thread atomically.
                 if let Some(path) = extract_osc7(data) {
+                    prompt_seen.store(true, Ordering::Release);
+                    // Drop the rolling tail once the latch is set so we
+                    // do not retain memory for the rest of the session.
+                    tail = Vec::new();
                     let _ = event_tx.send(AppEvent::CwdChanged(pane_id, path));
                 }
 
@@ -276,6 +356,21 @@ fn pty_reader_thread(
                 if let Some(new_title) = extract_osc_title(data) {
                     if let Ok(mut t) = title.lock() {
                         *t = new_title;
+                    }
+                }
+
+                // Heuristic prompt detection over a rolling tail so prompts
+                // that straddle two reads are still picked up.
+                if !prompt_seen.load(Ordering::Acquire) {
+                    tail.extend_from_slice(data);
+                    if tail.len() > TAIL_CAP * 2 {
+                        let drop = tail.len() - TAIL_CAP;
+                        tail.drain(..drop);
+                    }
+                    if is_prompt_ready(&tail) {
+                        prompt_seen.store(true, Ordering::Release);
+                        // Tail no longer needed once the flag latches on.
+                        tail = Vec::new();
                     }
                 }
 
@@ -301,8 +396,7 @@ fn extract_osc7(data: &[u8]) -> Option<PathBuf> {
     let rest = &s[start + marker.len()..];
 
     // Find the terminator: BEL (\x07) or ST (\x1b\\)
-    let end = rest.find('\x07')
-        .or_else(|| rest.find("\x1b\\"));
+    let end = rest.find('\x07').or_else(|| rest.find("\x1b\\"));
 
     let uri = &rest[..end?];
 
@@ -350,14 +444,78 @@ fn extract_osc_title(data: &[u8]) -> Option<String> {
     for marker in &["\x1b]0;", "\x1b]2;"] {
         if let Some(start) = s.find(marker) {
             let rest = &s[start + marker.len()..];
-            let end = rest.find('\x07')
-                .or_else(|| rest.find("\x1b\\"));
+            let end = rest.find('\x07').or_else(|| rest.find("\x1b\\"));
             if let Some(end) = end {
                 return Some(rest[..end].to_string());
             }
         }
     }
     None
+}
+
+/// Returns `true` if `buf` looks like the recently-emitted bytes end with
+/// a shell prompt (`$`, `>`, `%`, or `#`), optionally followed by trailing
+/// whitespace and CSI/ANSI escape sequences such as color resets.
+///
+/// This is intentionally conservative: it strips only ANSI CSI sequences
+/// (`ESC [ ... <final-byte>`) and trailing ASCII whitespace. False
+/// negatives (e.g. exotic prompt styles) only delay startup-command flush
+/// by one PTY read cycle. False positives risk firing the startup command
+/// against a still-initializing shell.
+pub fn is_prompt_ready(buf: &[u8]) -> bool {
+    let stripped = strip_csi_escapes(buf);
+    let trimmed = trim_ascii_whitespace_end(&stripped);
+    let Some(&last) = trimmed.last() else {
+        return false;
+    };
+    if !matches!(last, b'$' | b'>' | b'%' | b'#') {
+        return false;
+    }
+    // Guard against common non-prompt endings that happen to finish
+    // with a prompt-like character:
+    // - PowerShell / npm-style progress bars: `[====>]` redrawing can
+    //   leave `====>` visible mid-frame before the closing bracket.
+    // - Percentage readouts: `50%` ends in `%` (zsh's prompt marker).
+    // Each guard rejects a specific combination of (last, prev) that is
+    // overwhelmingly output, not a prompt.
+    if let Some(&prev) = trimmed.get(trimmed.len().saturating_sub(2)) {
+        if last == b'>' && matches!(prev, b'=' | b'-' | b'~' | b'.' | b'*') {
+            return false;
+        }
+        if last == b'%' && prev.is_ascii_digit() {
+            return false;
+        }
+    }
+    true
+}
+
+fn strip_csi_escapes(buf: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(buf.len());
+    let mut i = 0;
+    while i < buf.len() {
+        if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b'[' {
+            i += 2;
+            while i < buf.len() {
+                let c = buf[i];
+                i += 1;
+                if (0x40..=0x7E).contains(&c) {
+                    break;
+                }
+            }
+        } else {
+            out.push(buf[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+fn trim_ascii_whitespace_end(buf: &[u8]) -> &[u8] {
+    let mut end = buf.len();
+    while end > 0 && matches!(buf[end - 1], b' ' | b'\t' | b'\r' | b'\n') {
+        end -= 1;
+    }
+    &buf[..end]
 }
 
 /// Detect the appropriate shell to launch.
@@ -388,10 +546,7 @@ fn detect_shell_windows() -> PathBuf {
     }
 
     // Try bash in PATH
-    if let Ok(output) = std::process::Command::new("where")
-        .arg("bash")
-        .output()
-    {
+    if let Ok(output) = std::process::Command::new("where").arg("bash").output() {
         if output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);
             if let Some(line) = stdout.lines().next() {
@@ -452,5 +607,95 @@ mod tests {
                 "Should use $SHELL env var"
             );
         }
+    }
+
+    // -- is_prompt_ready -------------------------------------------------
+
+    #[test]
+    fn prompt_ready_dollar_with_space() {
+        assert!(is_prompt_ready(b"user@host:~$ "));
+    }
+
+    #[test]
+    fn prompt_ready_powershell_chevron() {
+        assert!(is_prompt_ready(b"PS C:\\> "));
+    }
+
+    #[test]
+    fn prompt_ready_zsh_percent() {
+        assert!(is_prompt_ready(b"% "));
+    }
+
+    #[test]
+    fn prompt_ready_root_hash() {
+        assert!(is_prompt_ready(b"root@host:/# "));
+    }
+
+    #[test]
+    fn prompt_not_ready_when_loading() {
+        assert!(!is_prompt_ready(b"loading dependencies..."));
+    }
+
+    #[test]
+    fn prompt_ready_strips_trailing_ansi_color() {
+        // Common: prompt char then color reset
+        assert!(is_prompt_ready(b"user@host:~$ \x1b[0m"));
+    }
+
+    #[test]
+    fn prompt_not_ready_for_empty_input() {
+        assert!(!is_prompt_ready(b""));
+    }
+
+    #[test]
+    fn prompt_not_ready_when_only_motd_text() {
+        assert!(!is_prompt_ready(b"Welcome to Ubuntu 22.04 LTS"));
+    }
+
+    // ─── progress-bar / output misfire guards ────────────────
+
+    #[test]
+    fn prompt_not_ready_for_progress_bar_equals_chevron() {
+        // Mid-redraw progress bar: `[====>   ]` truncated to `====>`
+        // before the closing bracket comes through. Must not trigger.
+        assert!(!is_prompt_ready(b"loading [====>"));
+    }
+
+    #[test]
+    fn prompt_not_ready_for_dashed_progress_chevron() {
+        // `--->` style progress marker (common in make-style output).
+        assert!(!is_prompt_ready(b"step 3 --->"));
+    }
+
+    #[test]
+    fn prompt_not_ready_for_asterisk_chevron() {
+        assert!(!is_prompt_ready(b"***>"));
+    }
+
+    #[test]
+    fn prompt_not_ready_for_percentage_readout() {
+        // `50%` at end of a progress line should NOT look like a zsh
+        // prompt.
+        assert!(!is_prompt_ready(b"Downloading... 50%"));
+    }
+
+    #[test]
+    fn prompt_not_ready_for_hundred_percent() {
+        assert!(!is_prompt_ready(b"Done: 100%"));
+    }
+
+    #[test]
+    fn prompt_ready_powershell_with_real_path_before_chevron() {
+        // Regression guard: the previous char in a PowerShell prompt is
+        // a letter or path separator (`>` after `e` or `\`), not an
+        // ASCII-art character — must still trigger.
+        assert!(is_prompt_ready(b"PS C:\\Users\\me>"));
+        assert!(is_prompt_ready(b"PS C:\\Users\\me> "));
+    }
+
+    #[test]
+    fn prompt_ready_zsh_percent_after_space() {
+        // Bare `%` preceded by whitespace stays a valid zsh prompt.
+        assert!(is_prompt_ready(b"user ~/dir % "));
     }
 }


### PR DESCRIPTION
## Summary
上流 [Shin-sibainu/ccmux#4](https://github.com/Shin-sibainu/ccmux/pull/4) (sora2005-dev による \`--exec\` / \`--layout\` / IPC 実装) をフォーク先取りで取り込む。アンブレラ Issue #8 の Phase 0。

## 取り込んだ機能
- **\`--exec \"CMD\"\`** — 起動直後に初期ペインでコマンド自動実行 (shell prompt 検出同期)
- **\`--layout NAME\`** — TOML でマルチペイン構成を定義 → 自動展開 (\`ccmux-layouts/<NAME>.toml\` または \`~/.config/ccmux/layouts/\`)
- **\`ccmux <subcommand>\`** — 動作中インスタンスへの IPC 経由制御
  - \`ccmux list\` — ペイン一覧
  - \`ccmux send --name X \"text\" --enter\` — ペインへ入力送信
  - \`ccmux focus --name X\`
  - \`ccmux split --direction vertical --command ... --id ...\`
  - \`ccmux new-tab --command ... --id ...\`
  - 通信: Windows Named Pipe / Unix Socket、改行区切り JSON

## 変更内容
- 単一コミット (sora2005-dev 原著者をそのまま保持) で cherry-pick
- 13 files / +3145 -102
- 新規: \`src/cli.rs\`, \`src/ipc/{mod,client,endpoint,server}.rs\`, \`src/layout_config.rs\`, \`ccmux-layouts/{test,cc-campany}.toml\`

## Test plan
- [x] \`cargo build --release\` 成功 (warnings のみ)
- [x] \`cargo test\` — 112 passed (新規 layout_config / app::apply_layout* テストも含む)
- [x] \`ccmux --help\` で subcommand 5つが表示される
- [x] \`ccmux-layouts/test.toml\` を \`--layout test\` で読み込み
- [ ] 実際の IPC 動作確認 (マージ後に動作テスト用に v0.6.0-fork.1 のリリースを打つ)

## 上流との関係
上流 PR #4 は未マージ。将来マージ/改変された場合の reconcile は Issue #8 で追跡。

## Known warnings (解消は別 PR)
- \`EndpointName::socket\` / \`EndpointName::kind\` dead code (future 用)
- \`IpcServer.endpoint\` / \`session_token\` unused fields

Refs #8, #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)