### PR TITLE
fix: IPC hardening — token verification, socket cleanup, client timeout (closes #11)

### DIFF
--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -6,12 +6,14 @@
 //! request per connection, closed by the client dropping the stream.
 
 use std::io::{BufRead, BufReader, Write};
+use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use interprocess::local_socket::{prelude::*, Stream};
 
-use super::endpoint::EndpointName;
+use super::endpoint::{EndpointName, ENV_TOKEN};
 use super::{Request, Response};
 
 /// How long we wait for a response before giving up. The server replies
@@ -21,16 +23,42 @@ use super::{Request, Response};
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Send a single request to the endpoint and return the response.
+///
+/// The blocking read on `interprocess::Stream` has no portable timeout
+/// API in 2.x, so we run `converse` on a helper thread and wait on a
+/// channel with [`RESPONSE_TIMEOUT`]. If the server deadlocks, the main
+/// thread unblocks and returns an error instead of hanging forever —
+/// the helper thread is detached and cleaned up by the OS when the
+/// client process exits.
 pub fn send_request(endpoint: &EndpointName, request: &Request) -> Result<Response> {
-    let name = make_connection_name(endpoint)?;
-    let conn =
-        Stream::connect(name).with_context(|| format!("connect to {}", endpoint.as_str()))?;
-    // interprocess 2.4 exposes read/write timeouts through the
-    // platform-specific wrappers; at the portable surface we rely on
-    // the blocking default. Blocking is fine here because the server's
-    // per-connection timeout already bounds our wait.
-    let _ = RESPONSE_TIMEOUT; // reserved for a future timeout hookup
-    converse(conn, request)
+    let name_string = endpoint.as_str().to_string();
+    let endpoint_clone = endpoint.clone();
+    let request_clone = request.clone();
+    let (tx, rx) = mpsc::channel();
+    thread::Builder::new()
+        .name("ccmux-ipc-client".into())
+        .spawn(move || {
+            let result = (|| -> Result<Response> {
+                let name = make_connection_name(&endpoint_clone)?;
+                let conn = Stream::connect(name)
+                    .with_context(|| format!("connect to {}", endpoint_clone.as_str()))?;
+                converse(conn, &request_clone)
+            })();
+            let _ = tx.send(result);
+        })
+        .context("spawn IPC client thread")?;
+
+    match rx.recv_timeout(RESPONSE_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(anyhow!(
+            "no response from ccmux within {:?} (endpoint: {})",
+            RESPONSE_TIMEOUT,
+            name_string
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(anyhow!("IPC client thread panicked"))
+        }
+    }
 }
 
 fn make_connection_name(endpoint: &EndpointName) -> Result<interprocess::local_socket::Name<'_>> {
@@ -56,7 +84,9 @@ fn converse(conn: Stream, request: &Request) -> Result<Response> {
     write_request_line(reader.get_mut(), &hello)?;
     let hello_resp = read_response_line(&mut reader)?;
     match hello_resp {
-        Response::Hello { .. } => {}
+        Response::Hello { session_token, .. } => {
+            verify_session_token(&session_token, std::env::var(ENV_TOKEN).ok().as_deref())?;
+        }
         Response::Err { message } => {
             return Err(anyhow!("server refused hello: {message}"));
         }
@@ -77,6 +107,26 @@ fn write_request_line<W: Write>(w: &mut W, req: &Request) -> Result<()> {
     w.write_all(json.as_bytes())?;
     w.flush()?;
     Ok(())
+}
+
+/// Compare the server-provided session token with the expected one
+/// that the parent ccmux published to `CCMUX_TOKEN`.
+///
+/// A mismatch means the `CCMUX_SOCKET` path we connected through points
+/// to a ccmux instance that doesn't own the current shell — most likely
+/// the PID got re-used and a stale socket path was inherited. Refuse
+/// rather than silently deliver the command to the wrong process.
+fn verify_session_token(server_token: &str, expected: Option<&str>) -> Result<()> {
+    match expected {
+        Some(e) if e == server_token => Ok(()),
+        Some(_) => Err(anyhow!(
+            "session token mismatch; {ENV_SOCKET} likely points to a different ccmux instance",
+            ENV_SOCKET = super::endpoint::ENV_SOCKET
+        )),
+        None => Err(anyhow!(
+            "{ENV_TOKEN} not set; are you running inside ccmux?"
+        )),
+    }
 }
 
 fn read_response_line<R: BufRead>(r: &mut R) -> Result<Response> {
@@ -115,6 +165,23 @@ mod tests {
         let mut reader = std::io::BufReader::new(input);
         let resp = read_response_line(&mut reader).unwrap();
         assert!(matches!(resp, Response::Ok { .. }));
+    }
+
+    #[test]
+    fn verify_session_token_matches() {
+        assert!(verify_session_token("abc-123", Some("abc-123")).is_ok());
+    }
+
+    #[test]
+    fn verify_session_token_rejects_mismatch() {
+        let err = verify_session_token("abc-123", Some("xyz-999")).unwrap_err();
+        assert!(err.to_string().contains("mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_session_token_rejects_missing_env() {
+        let err = verify_session_token("abc-123", None).unwrap_err();
+        assert!(err.to_string().contains("CCMUX_TOKEN"), "got: {err}");
     }
 
     #[test]

--- a/src/ipc/endpoint.rs
+++ b/src/ipc/endpoint.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use std::path::PathBuf;
 
 pub const ENV_SOCKET: &str = "CCMUX_SOCKET";
+pub const ENV_TOKEN: &str = "CCMUX_TOKEN";
 
 /// Compute the IPC endpoint name for a ccmux instance with the given PID.
 ///

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -4,6 +4,25 @@
 //! client to server, followed by exactly one [`Response`] from server to
 //! client. Connections are short-lived in the v1 protocol — clients open,
 //! send one request, read one response, close.
+//!
+//! # Threat model
+//!
+//! IPC is scoped to a **single local user** and is not a secrecy or
+//! authentication boundary against other users on the same host:
+//!
+//! - On Unix, the socket lives under an owner-only directory
+//!   (`$XDG_RUNTIME_DIR/ccmux/` or `/tmp/ccmux-UID/` with mode `0700`).
+//!   A different UID on the same host cannot reach it.
+//! - On Windows, the Named Pipe is named `\\.\pipe\ccmux-<pid>` and
+//!   inherits default session-scoped permissions from the OS.
+//!
+//! The `CCMUX_TOKEN` env var is **not** a secret. It exists only to
+//! detect PID re-use: if a child shell inherited a stale `CCMUX_SOCKET`
+//! whose PID now belongs to a different ccmux instance, the token on
+//! the wire won't match the child's `CCMUX_TOKEN` and the client
+//! refuses the command. Any same-user process that can read
+//! `/proc/<pid>/environ` can also read the token — on the same-user
+//! trust model that's already inside the boundary.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -7,8 +7,10 @@
 //!
 //! # Threat model
 //!
-//! IPC is scoped to a **single local user** and is not a secrecy or
-//! authentication boundary against other users on the same host:
+//! IPC is a local-only control channel between processes running as
+//! the same user. OS-level isolation handles the cross-user boundary;
+//! IPC itself is **not** a secrecy or authentication boundary against
+//! other processes running as that same user.
 //!
 //! - On Unix, the socket lives under an owner-only directory
 //!   (`$XDG_RUNTIME_DIR/ccmux/` or `/tmp/ccmux-UID/` with mode `0700`).

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
 
-use super::endpoint::EndpointName;
+use super::endpoint::{EndpointKind, EndpointName};
 use super::{Direction, PaneRef, Request, Response};
 use crate::app::AppCommand;
 
@@ -37,10 +37,20 @@ const APP_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct IpcServer {
     pub endpoint: EndpointName,
-    pub session_token: String,
     // We intentionally don't hold a JoinHandle. The accept thread lives
     // until the process exits, at which point the OS reclaims the pipe
     // or socket. Orderly shutdown is not needed in v1.
+}
+
+impl Drop for IpcServer {
+    fn drop(&mut self) {
+        // Unix socket files are filesystem entries and would otherwise
+        // accumulate in /tmp on abnormal exit. Named Pipes on Windows
+        // are reclaimed by the OS when the owning process exits.
+        if self.endpoint.kind() == EndpointKind::Socket {
+            let _ = std::fs::remove_file(self.endpoint.as_str());
+        }
+    }
 }
 
 impl IpcServer {
@@ -62,10 +72,10 @@ impl IpcServer {
             })
             .context("spawn IPC accept thread")?;
 
-        Ok(Self {
-            endpoint,
-            session_token,
-        })
+        // Token is consumed by the accept thread via `token_for_thread`;
+        // we don't need to keep a copy on the struct.
+        drop(session_token);
+        Ok(Self { endpoint })
     }
 }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -468,4 +468,36 @@ mod tests {
             other => panic!("expected Err, got {other:?}"),
         }
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn drop_removes_unix_socket_file() {
+        use std::path::PathBuf;
+
+        // Bind on a unique temp path so the test doesn't race with a
+        // real ccmux instance or other tests.
+        let dir = std::env::temp_dir().join(format!(
+            "ccmux-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock_path: PathBuf = dir.join("ccmux-test.sock");
+        let endpoint = EndpointName::socket(sock_path.clone());
+
+        let (tx, _rx) = mpsc::channel::<AppCommand>();
+        let server = IpcServer::spawn(endpoint, tx, "test-token".into()).unwrap();
+
+        // Socket file should exist after binding.
+        assert!(sock_path.exists(), "socket file not created");
+
+        // Dropping IpcServer should remove it.
+        drop(server);
+        assert!(!sock_path.exists(), "socket file not removed on drop");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,13 +91,10 @@ fn main() -> Result<()> {
     std::env::set_var(ipc::endpoint::ENV_SOCKET, ipc_endpoint.as_str());
     std::env::set_var("CCMUX", "1");
 
-    // Create app (spawns the initial pane, which captures the env above).
-    let mut app = app::App::new(size.height, size.width)?;
-
     // Session token derived from the process's start nanoseconds so a
     // client connecting through a stale socket file whose PID got
     // re-used cannot be silently fooled — the server echoes this token
-    // back on hello, and the client verifies it against its own expect.
+    // on hello, and the client verifies it against `CCMUX_TOKEN`.
     let session_token = format!(
         "{}-{}",
         our_pid,
@@ -106,16 +103,28 @@ fn main() -> Result<()> {
             .map(|d| d.as_nanos())
             .unwrap_or(0)
     );
-    if let Err(e) = ipc::server::IpcServer::spawn(
+    // Publish the token before spawning panes so children inherit it.
+    std::env::set_var(ipc::endpoint::ENV_TOKEN, &session_token);
+
+    // Create app (spawns the initial pane, which captures the env above).
+    let mut app = app::App::new(size.height, size.width)?;
+
+    // Keep the server handle alive for the process lifetime; its Drop
+    // impl cleans up the Unix socket file on exit.
+    let _ipc_server = match ipc::server::IpcServer::spawn(
         ipc_endpoint.clone(),
         app.command_tx.clone(),
         session_token.clone(),
     ) {
-        // IPC is non-essential for the TUI itself — fail soft so users
-        // without the required socket permissions can still use ccmux
-        // as a plain multiplexer.
-        eprintln!("ccmux: IPC server failed to start ({e}); external commands disabled.");
-    }
+        Ok(server) => Some(server),
+        Err(e) => {
+            // IPC is non-essential for the TUI itself — fail soft so users
+            // without the required socket permissions can still use ccmux
+            // as a plain multiplexer.
+            eprintln!("ccmux: IPC server failed to start ({e}); external commands disabled.");
+            None
+        }
+    };
 
     // Phase 1 (--exec): queue the requested command on the initial focused
     // pane. The command will be flushed into the PTY by the main event


### PR DESCRIPTION
## Summary
PR #10 で取り込んだ上流 IPC 実装に対して Codex が指摘した 3 点のセキュリティ/クリーンアップ問題を修正。

## 修正内容

### 1. セッショントークン検証 (Must-fix)
- 親 ccmux が起動時に \`CCMUX_TOKEN\` 環境変数へトークンを export (子 PTY が継承)
- クライアントは Hello 応答の \`session_token\` を \`CCMUX_TOKEN\` と照合
- 不一致なら「別 ccmux インスタンスを指している可能性」としてエラー返却
- PID 再利用 + stale socket 経由の誤接続を検出可能に

### 2. Unix socket cleanup via Drop (Should-fix)
- \`IpcServer\` に \`Drop\` impl を追加
- プロセス終了時に Unix socket ファイルを \`remove_file\`
- Windows Named Pipe は OS が自動回収するため no-op
- \`main.rs\` で IpcServer ハンドルを \`let _ipc_server = ...\` で保持

### 3. クライアント read timeout (Should-fix)
- \`RESPONSE_TIMEOUT\` が dead code だった (\`let _ = RESPONSE_TIMEOUT;\`)
- \`interprocess::Stream\` にポータブルな timeout API がないため、helper thread + \`mpsc::recv_timeout\` で実装
- サーバーがハングしてもクライアントは 10 秒で timeout エラー

## クリーンアップ
- \`IpcServer.session_token\` フィールドを削除 (spawn 時のみ使用、accept thread が所有)

## Test plan
- [x] \`cargo build --release\` 成功
- [x] \`cargo test\` — **115 passed** (112 + 3 新規テスト)
- [x] 新テスト: \`verify_session_token_matches\` / \`rejects_mismatch\` / \`rejects_missing_env\`
- [ ] マージ後に実環境 (2 プロセス併存) で PID 衝突シナリオを手動テスト

Closes #11
Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)