### PR TITLE
chore: add CI workflow (rustfmt + cross-platform build/test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --locked --verbose
+      - run: cargo test --locked --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,15 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Jobs only read the repo; no write permissions needed.
+permissions:
+  contents: read
+
 jobs:
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -32,6 +37,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/src/claude_monitor.rs
+++ b/src/claude_monitor.rs
@@ -64,7 +64,11 @@ impl ClaudeState {
 
     /// Todo completion stats: (completed, total).
     pub fn todo_progress(&self) -> (usize, usize) {
-        let completed = self.todos.iter().filter(|t| t.status == "completed").count();
+        let completed = self
+            .todos
+            .iter()
+            .filter(|t| t.status == "completed")
+            .count();
         (completed, self.todos.len())
     }
 
@@ -195,10 +199,7 @@ impl ClaudeMonitor {
             // Locate or re-locate the JSONL file.
             // Full directory scan every 5s or when our path disappears,
             // to detect new sessions (new JSONL files).
-            let path_missing = monitor
-                .jsonl_path
-                .as_ref()
-                .map_or(true, |p| !p.exists());
+            let path_missing = monitor.jsonl_path.as_ref().map_or(true, |p| !p.exists());
             let stale_scan = monitor.last_rescan.elapsed() > Duration::from_secs(5);
             if path_missing || stale_scan {
                 monitor.last_rescan = Instant::now();
@@ -317,7 +318,10 @@ fn process_event(monitor: &mut PaneMonitor, line: &str) {
             }
 
             // Model name
-            if let Some(model) = message.and_then(|m| m.get("model")).and_then(|v| v.as_str()) {
+            if let Some(model) = message
+                .and_then(|m| m.get("model"))
+                .and_then(|v| v.as_str())
+            {
                 monitor.state.model = Some(model.to_string());
             }
 
@@ -342,8 +346,14 @@ fn process_event(monitor: &mut PaneMonitor, line: &str) {
 
             if should_count {
                 if let Some(usage) = message.and_then(|m| m.get("usage")) {
-                    let input = usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let output = usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let input = usage
+                        .get("input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let output = usage
+                        .get("output_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
                     let cache_read = usage
                         .get("cache_read_input_tokens")
                         .and_then(|v| v.as_u64())
@@ -385,9 +395,7 @@ fn process_event(monitor: &mut PaneMonitor, line: &str) {
 
                             // Sub-agent tools (real name in JSONL is "Agent", "Task" was old name)
                             if name == "Agent" || name == "Task" {
-                                if let Some(task_id) =
-                                    block.get("id").and_then(|v| v.as_str())
-                                {
+                                if let Some(task_id) = block.get("id").and_then(|v| v.as_str()) {
                                     let subagent_type = block
                                         .get("input")
                                         .and_then(|i| i.get("subagent_type"))
@@ -397,8 +405,7 @@ fn process_event(monitor: &mut PaneMonitor, line: &str) {
                                     monitor
                                         .active_task_ids
                                         .insert(task_id.to_string(), subagent_type);
-                                    monitor.state.subagent_count =
-                                        monitor.active_task_ids.len();
+                                    monitor.state.subagent_count = monitor.active_task_ids.len();
                                     monitor.state.subagent_types =
                                         monitor.active_task_ids.values().cloned().collect();
                                 }
@@ -415,14 +422,8 @@ fn process_event(monitor: &mut PaneMonitor, line: &str) {
                                         .iter()
                                         .filter_map(|t| {
                                             Some(TodoItem {
-                                                content: t
-                                                    .get("content")?
-                                                    .as_str()?
-                                                    .to_string(),
-                                                status: t
-                                                    .get("status")?
-                                                    .as_str()?
-                                                    .to_string(),
+                                                content: t.get("content")?.as_str()?.to_string(),
+                                                status: t.get("status")?.as_str()?.to_string(),
                                             })
                                         })
                                         .collect();
@@ -446,8 +447,7 @@ fn process_event(monitor: &mut PaneMonitor, line: &str) {
                     if block.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
                         has_tool_result = true;
                         // If this tool_result is for a Task, decrement the active set
-                        if let Some(tool_use_id) =
-                            block.get("tool_use_id").and_then(|v| v.as_str())
+                        if let Some(tool_use_id) = block.get("tool_use_id").and_then(|v| v.as_str())
                         {
                             if monitor.active_task_ids.remove(tool_use_id).is_some() {
                                 monitor.state.subagent_count = monitor.active_task_ids.len();

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -47,7 +47,12 @@ impl FileEntry {
 /// Maximum entries per directory to prevent DoS from huge directories.
 const MAX_ENTRIES_PER_DIR: usize = 500;
 
-fn scan_directory_filtered(path: &Path, depth: usize, max_depth: usize, show_hidden: bool) -> Vec<FileEntry> {
+fn scan_directory_filtered(
+    path: &Path,
+    depth: usize,
+    max_depth: usize,
+    show_hidden: bool,
+) -> Vec<FileEntry> {
     let entries = match fs::read_dir(path) {
         Ok(entries) => entries,
         Err(_) => return Vec::new(),
@@ -63,10 +68,7 @@ fn scan_directory_filtered(path: &Path, depth: usize, max_depth: usize, show_hid
         }
 
         let entry_path = entry.path();
-        let name = entry
-            .file_name()
-            .to_string_lossy()
-            .to_string();
+        let name = entry.file_name().to_string_lossy().to_string();
 
         // Always skip .git (too large and noisy)
         if name == ".git" {
@@ -234,7 +236,12 @@ impl FileTree {
         if entry.path == path && entry.is_dir {
             entry.is_expanded = !entry.is_expanded;
             if entry.is_expanded && entry.children.is_empty() {
-                entry.children = scan_directory_filtered(&entry.path, entry.depth + 1, entry.depth + 2, show_hidden);
+                entry.children = scan_directory_filtered(
+                    &entry.path,
+                    entry.depth + 1,
+                    entry.depth + 2,
+                    show_hidden,
+                );
             }
             return true;
         }
@@ -291,10 +298,7 @@ mod tests {
     fn test_scan_directory_skips_git() {
         let entries = scan_directory_filtered(Path::new("."), 0, 1, true);
         for entry in &entries {
-            assert!(
-                entry.name != ".git",
-                ".git should always be skipped"
-            );
+            assert!(entry.name != ".git", ".git should always be skipped");
         }
     }
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -55,9 +55,7 @@ pub fn send_request(endpoint: &EndpointName, request: &Request) -> Result<Respon
             RESPONSE_TIMEOUT,
             name_string
         )),
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            Err(anyhow!("IPC client thread panicked"))
-        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow!("IPC client thread panicked")),
     }
 }
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -2,9 +2,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
+use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
-use syntect::easy::HighlightLines;
 
 const MAX_PREVIEW_LINES: usize = 500;
 const BINARY_CHECK_BYTES: usize = 8192;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, BorderType, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, DragTarget, FocusTarget};
@@ -30,21 +30,21 @@ const MIN_PANE_AREA_WIDTH: u16 = 20;
 fn file_icon(name: &str) -> (&'static str, Color) {
     let ext = name.rsplit('.').next().unwrap_or("");
     match ext {
-        "rs" => ("\u{1f980} ", Color::Rgb(0xde, 0x93, 0x5f)),  // 🦀 orange
-        "toml" => ("\u{2699}\u{fe0f} ", Color::Rgb(0x9e, 0x9e, 0x9e)),  // ⚙️ gray
-        "lock" => ("\u{1f512} ", Color::Rgb(0x9e, 0x9e, 0x9e)),  // 🔒
-        "md" => ("\u{1f4c4} ", Color::Rgb(0x58, 0xa6, 0xff)),   // 📄 blue
-        "json" => ("{ ", Color::Rgb(0xf1, 0xe0, 0x5a)),         // { yellow
+        "rs" => ("\u{1f980} ", Color::Rgb(0xde, 0x93, 0x5f)), // 🦀 orange
+        "toml" => ("\u{2699}\u{fe0f} ", Color::Rgb(0x9e, 0x9e, 0x9e)), // ⚙️ gray
+        "lock" => ("\u{1f512} ", Color::Rgb(0x9e, 0x9e, 0x9e)), // 🔒
+        "md" => ("\u{1f4c4} ", Color::Rgb(0x58, 0xa6, 0xff)), // 📄 blue
+        "json" => ("{ ", Color::Rgb(0xf1, 0xe0, 0x5a)),       // { yellow
         "yaml" | "yml" => ("~ ", Color::Rgb(0xf1, 0xe0, 0x5a)), // ~ yellow
-        "js" => ("\u{26a1} ", Color::Rgb(0xf1, 0xe0, 0x5a)),    // ⚡ yellow
+        "js" => ("\u{26a1} ", Color::Rgb(0xf1, 0xe0, 0x5a)),  // ⚡ yellow
         "ts" | "tsx" => ("\u{26a1} ", Color::Rgb(0x31, 0x78, 0xc6)), // ⚡ blue
-        "jsx" => ("\u{26a1} ", Color::Rgb(0x61, 0xda, 0xfb)),   // ⚡ cyan
-        "py" => ("\u{1f40d} ", Color::Rgb(0x35, 0x72, 0xa5)),   // 🐍 blue
+        "jsx" => ("\u{26a1} ", Color::Rgb(0x61, 0xda, 0xfb)), // ⚡ cyan
+        "py" => ("\u{1f40d} ", Color::Rgb(0x35, 0x72, 0xa5)), // 🐍 blue
         "sh" | "bash" | "zsh" => ("$ ", Color::Rgb(0x3f, 0xb9, 0x50)), // $ green
         "css" | "scss" => ("# ", Color::Rgb(0x56, 0x3d, 0x7c)), // # purple
-        "html" => ("< ", Color::Rgb(0xe3, 0x4c, 0x26)),         // < orange
+        "html" => ("< ", Color::Rgb(0xe3, 0x4c, 0x26)),       // < orange
         "gitignore" => ("\u{2022} ", Color::Rgb(0xf0, 0x50, 0x33)), // • git red
-        _ => ("\u{2022} ", TEXT_DIM),                             // • default
+        _ => ("\u{2022} ", TEXT_DIM),                         // • default
     }
 }
 
@@ -93,7 +93,10 @@ fn render_tab_bar(app: &mut App, frame: &mut Frame, area: Rect) {
     // Logo
     spans.push(Span::styled(
         " \u{25c8} ",
-        Style::default().fg(ACCENT_CLAUDE).bg(HEADER_BG).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(ACCENT_CLAUDE)
+            .bg(HEADER_BG)
+            .add_modifier(Modifier::BOLD),
     ));
     x += 3;
 
@@ -250,7 +253,9 @@ fn render_file_tree(app: &mut App, frame: &mut Frame, area: Rect) {
     };
 
     let title_style = if is_focused {
-        Style::default().fg(ACCENT_BLUE).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(ACCENT_BLUE)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(TEXT_DIM)
     };
@@ -300,7 +305,11 @@ fn render_file_tree(app: &mut App, frame: &mut Frame, area: Rect) {
 
         // Icon + name
         let (icon, name_display, name_color) = if entry.is_dir {
-            let icon = if entry.is_expanded { "\u{1f4c2} " } else { "\u{1f4c1} " }; // 📂 / 📁
+            let icon = if entry.is_expanded {
+                "\u{1f4c2} "
+            } else {
+                "\u{1f4c1} "
+            }; // 📂 / 📁
             (icon, &entry.name, ACCENT_BLUE)
         } else {
             let (icon, color) = file_icon(&entry.name);
@@ -314,7 +323,10 @@ fn render_file_tree(app: &mut App, frame: &mut Frame, area: Rect) {
         let mut spans = vec![Span::styled(indicator, indicator_style)];
 
         let content_style = if is_selected {
-            Style::default().fg(TEXT).bg(ACTIVE_BG).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(TEXT)
+                .bg(ACTIVE_BG)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(name_color).bg(PANEL_BG)
         };
@@ -362,9 +374,9 @@ fn render_panes(app: &mut App, frame: &mut Frame, area: Rect) {
     for (pane_id, rect) in rects {
         if let Some(pane) = app.ws().panes.get(&pane_id) {
             let is_focused = pane_id == focused_id && focus_target == FocusTarget::Pane;
-            let pane_sel = selection.as_ref().filter(|s| {
-                matches!(s.target, crate::app::SelectionTarget::Pane(id) if id == pane_id)
-            });
+            let pane_sel = selection.as_ref().filter(
+                |s| matches!(s.target, crate::app::SelectionTarget::Pane(id) if id == pane_id),
+            );
             let claude_state = app.claude_monitor.state(pane_id);
             render_single_pane(pane, is_focused, pane_sel, &claude_state, frame, rect);
         }
@@ -424,9 +436,13 @@ fn render_single_pane(
     };
 
     let title_style = if is_focused && is_claude {
-        Style::default().fg(ACCENT_CLAUDE).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(ACCENT_CLAUDE)
+            .add_modifier(Modifier::BOLD)
     } else if is_focused {
-        Style::default().fg(FOCUS_BORDER).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(FOCUS_BORDER)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(TEXT_DIM)
     };
@@ -435,7 +451,10 @@ fn render_single_pane(
     let bottom_title = if is_scrolled {
         Line::from(Span::styled(
             " \u{2191} SCROLL ",
-            Style::default().fg(ACCENT_CLAUDE).bg(SCROLL_BG).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(ACCENT_CLAUDE)
+                .bg(SCROLL_BG)
+                .add_modifier(Modifier::BOLD),
         ))
     } else if is_claude {
         let mut spans = Vec::new();
@@ -525,9 +544,15 @@ fn render_terminal_content(
                 let bg = vt100_color_to_ratatui(cell.bgcolor());
 
                 let mut modifiers = Modifier::empty();
-                if cell.bold() { modifiers |= Modifier::BOLD; }
-                if cell.italic() { modifiers |= Modifier::ITALIC; }
-                if cell.underline() { modifiers |= Modifier::UNDERLINED; }
+                if cell.bold() {
+                    modifiers |= Modifier::BOLD;
+                }
+                if cell.italic() {
+                    modifiers |= Modifier::ITALIC;
+                }
+                if cell.underline() {
+                    modifiers |= Modifier::UNDERLINED;
+                }
 
                 let style = if cell.inverse() {
                     Style::default().fg(bg).bg(fg).add_modifier(modifiers)
@@ -599,9 +624,15 @@ fn render_terminal_content(
             let y = area.y + row;
             let is_thumb = row >= thumb_top && row < thumb_top + thumb_height;
             let (sym, style) = if is_thumb {
-                ("\u{2588}", Style::default().fg(Color::Rgb(0x58, 0x5e, 0x68))) // █ thumb
+                (
+                    "\u{2588}",
+                    Style::default().fg(Color::Rgb(0x58, 0x5e, 0x68)),
+                ) // █ thumb
             } else {
-                ("\u{2502}", Style::default().fg(Color::Rgb(0x2d, 0x33, 0x3b))) // │ track
+                (
+                    "\u{2502}",
+                    Style::default().fg(Color::Rgb(0x2d, 0x33, 0x3b)),
+                ) // │ track
             };
             if let Some(cell) = buf.cell_mut((scrollbar_x, y)) {
                 cell.set_symbol(sym);
@@ -649,7 +680,9 @@ fn render_preview(app: &App, frame: &mut Frame, area: Rect) {
         .border_style(Style::default().fg(border_color))
         .title(Span::styled(
             title,
-            Style::default().fg(ACCENT_CLAUDE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(ACCENT_CLAUDE)
+                .add_modifier(Modifier::BOLD),
         ))
         .title_bottom(line_info)
         .style(Style::default().bg(PANEL_BG));
@@ -693,24 +726,21 @@ fn render_preview(app: &App, frame: &mut Frame, area: Rect) {
                 }
 
                 let span_chars = styled_span.text.chars().count();
-                let visible_text: std::borrow::Cow<'_, str> =
-                    if chars_skipped + span_chars <= h_scroll {
-                        // Entire span is off-screen to the left.
-                        chars_skipped += span_chars;
-                        continue;
-                    } else if chars_skipped >= h_scroll {
-                        std::borrow::Cow::Borrowed(styled_span.text.as_str())
-                    } else {
-                        // Partially skip into this span.
-                        let skip_in_span = h_scroll - chars_skipped;
-                        chars_skipped = h_scroll;
-                        let remainder: String = styled_span
-                            .text
-                            .chars()
-                            .skip(skip_in_span)
-                            .collect();
-                        std::borrow::Cow::Owned(remainder)
-                    };
+                let visible_text: std::borrow::Cow<'_, str> = if chars_skipped + span_chars
+                    <= h_scroll
+                {
+                    // Entire span is off-screen to the left.
+                    chars_skipped += span_chars;
+                    continue;
+                } else if chars_skipped >= h_scroll {
+                    std::borrow::Cow::Borrowed(styled_span.text.as_str())
+                } else {
+                    // Partially skip into this span.
+                    let skip_in_span = h_scroll - chars_skipped;
+                    chars_skipped = h_scroll;
+                    let remainder: String = styled_span.text.chars().skip(skip_in_span).collect();
+                    std::borrow::Cow::Owned(remainder)
+                };
 
                 if visible_text.is_empty() {
                     continue;
@@ -775,7 +805,8 @@ fn render_preview(app: &App, frame: &mut Frame, area: Rect) {
                     } else {
                         line_chars.saturating_sub(1)
                     };
-                    let src_col_end_clamped = src_col_end_inclusive.min(line_chars.saturating_sub(1));
+                    let src_col_end_clamped =
+                        src_col_end_inclusive.min(line_chars.saturating_sub(1));
                     if src_col_start > src_col_end_clamped {
                         continue;
                     }
@@ -819,50 +850,52 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
             Span::styled("空Enter", Style::default().fg(ACCENT_BLUE)),
             Span::styled(" 元に戻す", Style::default().fg(TEXT_DIM)),
         ])
-    } else { match focus {
-        FocusTarget::Preview => Line::from(vec![
-            Span::styled(" Scroll", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" スクロール  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^W", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 閉じる  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^P", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 配置替  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^Q", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 終了", Style::default().fg(TEXT_DIM)),
-        ]),
-        FocusTarget::FileTree => Line::from(vec![
-            Span::styled(" j/k", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 移動  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("Enter", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 開く  ", Style::default().fg(TEXT_DIM)),
-            Span::styled(".", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 隠しファイル  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("Esc", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 戻る  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^F", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 閉じる  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^Q", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 終了", Style::default().fg(TEXT_DIM)),
-        ]),
-        FocusTarget::Pane => Line::from(vec![
-            Span::styled(" ^D", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 縦分割  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^E", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 横分割  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^W", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 閉じる  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("A-T", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 新タブ  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("A-R", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" タブ名  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^F", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" ツリー  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^P", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 配置替  ", Style::default().fg(TEXT_DIM)),
-            Span::styled("^Q", Style::default().fg(ACCENT_BLUE)),
-            Span::styled(" 終了", Style::default().fg(TEXT_DIM)),
-        ]),
-    }};
+    } else {
+        match focus {
+            FocusTarget::Preview => Line::from(vec![
+                Span::styled(" Scroll", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" スクロール  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^W", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 閉じる  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^P", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 配置替  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^Q", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 終了", Style::default().fg(TEXT_DIM)),
+            ]),
+            FocusTarget::FileTree => Line::from(vec![
+                Span::styled(" j/k", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 移動  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("Enter", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 開く  ", Style::default().fg(TEXT_DIM)),
+                Span::styled(".", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 隠しファイル  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("Esc", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 戻る  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^F", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 閉じる  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^Q", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 終了", Style::default().fg(TEXT_DIM)),
+            ]),
+            FocusTarget::Pane => Line::from(vec![
+                Span::styled(" ^D", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 縦分割  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^E", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 横分割  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^W", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 閉じる  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("A-T", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 新タブ  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("A-R", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" タブ名  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^F", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" ツリー  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^P", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 配置替  ", Style::default().fg(TEXT_DIM)),
+                Span::styled("^Q", Style::default().fg(ACCENT_BLUE)),
+                Span::styled(" 終了", Style::default().fg(TEXT_DIM)),
+            ]),
+        }
+    };
 
     let status = Paragraph::new(hints).style(Style::default().bg(HEADER_BG));
     frame.render_widget(status, area);
@@ -890,11 +923,7 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
         // Context usage
         if claude_state.context_tokens > 0 {
             let ratio = claude_state.context_usage();
-            let bar = make_progress_bar(
-                (ratio * 10.0) as usize,
-                10,
-                6,
-            );
+            let bar = make_progress_bar((ratio * 10.0) as usize, 10, 6);
             let color = if ratio > 0.9 {
                 Color::Rgb(0xf8, 0x51, 0x49) // red
             } else if ratio > 0.7 {
@@ -939,8 +968,7 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
             .map(|s| unicode_width::UnicodeWidthStr::width(s.content.as_ref()) as u16)
             .sum();
         if area.width > total_width {
-            let right_rect =
-                Rect::new(area.x + area.width - total_width, area.y, total_width, 1);
+            let right_rect = Rect::new(area.x + area.width - total_width, area.y, total_width, 1);
             let widget =
                 Paragraph::new(Line::from(right_spans)).style(Style::default().bg(HEADER_BG));
             frame.render_widget(widget, right_rect);


### PR DESCRIPTION
## Summary
これまで CI がなく PR も main push も検証なしでマージされていた状態を解消する。

## 追加した workflow (\`.github/workflows/ci.yml\`)
- **fmt** (ubuntu): \`cargo fmt --all -- --check\`
- **test** (ubuntu / windows / macos マトリクス):
  - \`cargo build --locked\`
  - \`cargo test --locked\`
  - \`fail-fast: false\` で1プラットフォーム失敗が他をマスクしないように
- Swatinem/rust-cache で差分キャッシュ
- concurrency で同一ブランチの古い run はキャンセル

## 併せて \`cargo fmt --all\` を適用
ui.rs の長行折り返しを中心に、claude_monitor / filetree / preview / ipc/client に純粋な空白変更。**動作変更なし**。これをやらないと初回 CI が即 fail する。

## Clippy について
今回は入れていません。上流由来のコードに clippy lint が 13 件ほど残っていて、gate にすると無関係な PR まで blocked になるため。**Issue #14 で事前 cleanup 後に有効化**予定。

## Test plan
- [x] \`cargo fmt --all -- --check\` ローカル pass
- [x] \`cargo build --locked\` pass
- [x] \`cargo test --locked\` — 115 passed
- [ ] PR 上で CI workflow が回ることを確認
- [ ] マージ後に main の branch protection で \`test (ubuntu)\` / \`fmt\` を required に設定

## 関連
- Follow-up: #14 (clippy gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)