### PR TITLE
fix: add --locked to release build (closes #17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --locked
 
       - name: Rename binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
CI (#15) では \`cargo build --locked\` / \`cargo test --locked\` で Cargo.lock 固定を強制しているが、release.yml のリリースビルドには \`--locked\` がなかった。CI で検証したバージョンと異なる依存解決でリリースバイナリが作られる可能性があったため修正。

## 変更
\`.github/workflows/release.yml\` の build step:
\`\`\`diff
-        run: cargo build --release --target \${{ matrix.target }}
+        run: cargo build --release --target \${{ matrix.target }} --locked
\`\`\`

## Test plan
- [x] diff 1 行のみの変更
- [ ] マージ後、次のリリースタグで CI 通過後と同じ依存解決でビルドされることを確認

Closes #17
Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)