### PR TITLE
chore: pin GitHub Actions to commit SHAs + add Dependabot (closes #16)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to SHAs up-to-date. Dependabot opens a PR
+  # when a new release of a pinned action is published, updating both
+  # the SHA and the trailing comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -39,8 +39,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --locked --verbose
       - run: cargo test --locked --verbose

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -48,7 +48,7 @@ jobs:
           cp -R docs/out/. _site/docs/
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: _site
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -48,7 +48,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/ccmux.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -75,7 +75,7 @@ jobs:
             | sed 's|[^ ]*/||' > ../checksums.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
@@ -93,10 +93,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js 24 (includes npm 11)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 


### PR DESCRIPTION
## Summary
タグ/ブランチ pinning (\`@v4\`, \`@stable\` 等) は action publisher がタグを悪意ある commit に移動させた場合に無防備。サプライチェーン強化のため commit SHA pinning に切り替え。Dependabot で週次自動更新も設定。

## 変更ファイル
- \`.github/workflows/ci.yml\`
- \`.github/workflows/release.yml\`
- \`.github/workflows/docs.yml\`
- \`.github/dependabot.yml\` (新規)

## Pin 済み action
| Action | Pin | 元タグ |
|---|---|---|
| actions/checkout | 34e11487 | v4 |
| actions/setup-node | 49933ea5 | v4 |
| actions/upload-artifact | ea165f8d | v4 |
| actions/download-artifact | d3f86a10 | v4 |
| actions/upload-pages-artifact | 56afc609 | v3 |
| actions/deploy-pages | d6db9016 | v4 |
| Swatinem/rust-cache | e18b4977 | v2 |
| softprops/action-gh-release | 3bb12739 | v2 |
| dtolnay/rust-toolchain | 29eef336 | stable |

## Dependabot 設定
- \`github-actions\` ecosystem で週次チェック
- 全 action を \`actions\` グループに束ねて1 PR にまとめる (レビュー負荷軽減)

## Test plan
- [x] 各 SHA は \`gh api repos/\$repo/commits/\$tag --jq .sha\` で解決
- [x] PR で CI が通る (同じ SHA で fmt/test pass)
- [ ] マージ後の最初の Dependabot PR が期待通りの形で来る

Closes #16
Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)