### PR TITLE
chore: clean up clippy lints and enable clippy CI gate (closes #14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo clippy --all-targets --all-features --locked -- -D warnings
+
   test:
     name: test (${{ matrix.os }})
     strategy:

--- a/src/app.rs
+++ b/src/app.rs
@@ -2094,7 +2094,7 @@ fn extract_selected_text(pane: &Pane, sr: u32, sc: u32, er: u32, ec: u32) -> Str
     }
 
     // Remove trailing empty lines
-    while lines.last().map_or(false, |l| l.is_empty()) {
+    while lines.last().is_some_and(|l| l.is_empty()) {
         lines.pop();
     }
 
@@ -2141,7 +2141,7 @@ fn extract_preview_selected_text(
     }
 
     // Strip trailing empty lines only.
-    while out.last().map_or(false, |l| l.is_empty()) {
+    while out.last().is_some_and(|l| l.is_empty()) {
         out.pop();
     }
 
@@ -2304,8 +2304,8 @@ mod tests {
 
     #[test]
     fn test_focus_cycling() {
-        let ids = vec![1, 2, 3];
-        assert_eq!((0 + 1) % ids.len(), 1);
+        let ids = [1, 2, 3];
+        assert_eq!(1 % ids.len(), 1);
         assert_eq!((2 + 1) % ids.len(), 0);
     }
 

--- a/src/claude_monitor.rs
+++ b/src/claude_monitor.rs
@@ -199,7 +199,7 @@ impl ClaudeMonitor {
             // Locate or re-locate the JSONL file.
             // Full directory scan every 5s or when our path disappears,
             // to detect new sessions (new JSONL files).
-            let path_missing = monitor.jsonl_path.as_ref().map_or(true, |p| !p.exists());
+            let path_missing = monitor.jsonl_path.as_ref().is_none_or(|p| !p.exists());
             let stale_scan = monitor.last_rescan.elapsed() > Duration::from_secs(5);
             if path_missing || stale_scan {
                 monitor.last_rescan = Instant::now();
@@ -489,7 +489,7 @@ fn find_jsonl_path(cwd: &Path) -> Option<PathBuf> {
     let entries = std::fs::read_dir(&project_dir).ok()?;
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "jsonl") {
+        if path.extension().is_some_and(|e| e == "jsonl") {
             if let Ok(meta) = entry.metadata() {
                 if let Ok(mtime) = meta.modified() {
                     match &latest {
@@ -604,8 +604,10 @@ mod tests {
     fn test_context_limit_opus_4_6_is_1m() {
         // Claude Code logs the plain model id without the [1m] suffix
         // even though Opus 4.6 ships with 1M context by default.
-        let mut state = ClaudeState::default();
-        state.model = Some("claude-opus-4-6".to_string());
+        let mut state = ClaudeState {
+            model: Some("claude-opus-4-6".to_string()),
+            ..Default::default()
+        };
         assert_eq!(state.context_limit(), 1_000_000);
 
         // Explicit 1m variant suffix still works.

--- a/src/ipc/endpoint.rs
+++ b/src/ipc/endpoint.rs
@@ -6,7 +6,10 @@
 //! environment variable so in-pane clients (the secretary, etc.) can
 //! find the right server.
 
-use anyhow::{anyhow, Context, Result};
+#[cfg(unix)]
+use anyhow::Context;
+use anyhow::{anyhow, Result};
+#[cfg(unix)]
 use std::path::PathBuf;
 
 pub const ENV_SOCKET: &str = "CCMUX_SOCKET";
@@ -80,12 +83,14 @@ pub enum EndpointKind {
 }
 
 impl EndpointName {
+    #[cfg(windows)]
     pub fn pipe(name: impl Into<String>) -> Self {
         Self {
             repr: name.into(),
             kind: EndpointKind::Pipe,
         }
     }
+    #[cfg(unix)]
     pub fn socket(path: PathBuf) -> Self {
         Self {
             repr: path.display().to_string(),

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -26,7 +26,7 @@ use anyhow::{Context, Result};
 use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
 
 use super::endpoint::{EndpointKind, EndpointName};
-use super::{Direction, PaneRef, Request, Response};
+use super::{Request, Response};
 use crate::app::AppCommand;
 
 /// How long a worker waits for the App's event loop to process one
@@ -313,7 +313,7 @@ fn forward_unit(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ipc::Request;
+    use crate::ipc::{Direction, PaneRef, Request};
     use std::sync::mpsc;
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -561,7 +561,7 @@ fn render_terminal_content(
                 };
 
                 // Apply selection highlight (only if dragged, not single click)
-                let has_selection = selection.map_or(false, |s| {
+                let has_selection = selection.is_some_and(|s| {
                     let (sr, sc, er, ec) = s.normalized();
                     (sr != er || sc != ec) && s.contains(row as u32, col as u32)
                 });
@@ -907,7 +907,7 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
         .ws()
         .panes
         .get(&focused_id)
-        .map_or(false, |p| p.is_claude_running());
+        .is_some_and(|p| p.is_claude_running());
 
     let mut right_spans = Vec::new();
 

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -37,10 +37,9 @@ impl VersionInfo {
 /// Spawn a background thread to check npm for a newer version.
 pub fn spawn_check(info: VersionInfo) {
     thread::spawn(move || {
-        let _ = thread::sleep(Duration::from_secs(1)); // delay so it doesn't compete with startup
-        match fetch_latest() {
-            Ok(version) => info.set(version),
-            Err(_) => {}
+        thread::sleep(Duration::from_secs(1)); // delay so it doesn't compete with startup
+        if let Ok(version) = fetch_latest() {
+            info.set(version);
         }
     });
 }


### PR DESCRIPTION
## Summary
上流由来の 13 件の clippy lint を解消し、CI に clippy job を追加。Issue #14 の対応。

## Lint 修正
| カテゴリ | 対応 |
|---|---|
| \`map_or\` → \`is_some_and\` / \`is_none_or\` | 5件 (app.rs, claude_monitor.rs, ui.rs) |
| \`let_unit_value\` | 1件 (version_check.rs: \`let _ = thread::sleep(...)\`) |
| \`single_match\` | 1件 (version_check.rs: match Ok/ignore-Err → if let Ok) |
| \`field_reassign_with_default\` | 1件 (claude_monitor.rs test) |
| \`useless_vec\` + \`identity_op\` | 2件 (app.rs test) |
| \`unused_imports\` | 2件 (src/ipc/server.rs の Direction / PaneRef → tests モジュール内へ) |
| \`dead_code\` | cfg-gate EndpointName::socket / pipe + PathBuf / Context imports |

すべて semantic 変更なし、または semantic 同等 (is_some_and は map_or(false, f) と等価)。

## CI gate 追加
\`.github/workflows/ci.yml\` に clippy job:
- ubuntu-latest
- \`cargo clippy --all-targets --all-features --locked -- -D warnings\`
- 15min timeout、rust-cache 再利用

## Test plan
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` local clean
- [x] \`cargo fmt --all -- --check\` pass
- [x] \`cargo build --locked\` pass
- [x] \`cargo test --locked\` — 115 passed
- [ ] CI で \`clippy\` job が緑
- [ ] マージ後に branch protection で \`clippy\` を required status check 追加

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)