### PR TITLE
fix: resolve Linux-only clippy lints missed in #20

### DIFF
--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -99,8 +99,8 @@ fn scan_directory_filtered(
     }
 
     // Sort alphabetically (case-insensitive)
-    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-    files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    dirs.sort_by_key(|e| e.name.to_lowercase());
+    files.sort_by_key(|e| e.name.to_lowercase());
 
     // Directories first, then files
     dirs.extend(files);

--- a/src/ipc/endpoint.rs
+++ b/src/ipc/endpoint.rs
@@ -76,7 +76,12 @@ pub struct EndpointName {
     kind: EndpointKind,
 }
 
+/// Both variants exist on every platform so `kind()` / pattern matches
+/// compile everywhere, but only one is actually constructed per target
+/// (Pipe on Windows, Socket on Unix). Allow dead_code so the idle side
+/// doesn't fail clippy.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(dead_code)]
 pub enum EndpointKind {
     Pipe,
     Socket,

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,39 +253,37 @@ fn run_event_loop(
         // Poll for crossterm events with a short timeout (~30fps)
         if event::poll(Duration::from_millis(33))? {
             match event::read()? {
-                Event::Key(key) => {
-                    if key.kind == KeyEventKind::Press {
-                        let consumed = app.handle_key_event(key)?;
-                        if !consumed {
-                            // Collect rapid key events as potential paste
-                            if let Some(bytes) = crate::app::key_event_to_bytes_pub(&key) {
-                                paste_buffer.extend_from_slice(&bytes);
-                                // Drain all immediately available key events (paste burst)
-                                while event::poll(Duration::from_millis(1))? {
-                                    if let Event::Key(k) = event::read()? {
-                                        if k.kind == KeyEventKind::Press {
-                                            if app.handle_key_event(k)? {
-                                                // Shortcut consumed — flush buffer first
-                                                if !paste_buffer.is_empty() {
-                                                    flush_paste_buffer(app, &mut paste_buffer)?;
-                                                }
-                                                break;
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    let consumed = app.handle_key_event(key)?;
+                    if !consumed {
+                        // Collect rapid key events as potential paste
+                        if let Some(bytes) = crate::app::key_event_to_bytes_pub(&key) {
+                            paste_buffer.extend_from_slice(&bytes);
+                            // Drain all immediately available key events (paste burst)
+                            while event::poll(Duration::from_millis(1))? {
+                                if let Event::Key(k) = event::read()? {
+                                    if k.kind == KeyEventKind::Press {
+                                        if app.handle_key_event(k)? {
+                                            // Shortcut consumed — flush buffer first
+                                            if !paste_buffer.is_empty() {
+                                                flush_paste_buffer(app, &mut paste_buffer)?;
                                             }
-                                            if let Some(b) = crate::app::key_event_to_bytes_pub(&k)
-                                            {
-                                                paste_buffer.extend_from_slice(&b);
-                                            }
+                                            break;
                                         }
-                                    } else {
-                                        break;
+                                        if let Some(b) = crate::app::key_event_to_bytes_pub(&k) {
+                                            paste_buffer.extend_from_slice(&b);
+                                        }
                                     }
+                                } else {
+                                    break;
                                 }
-                                flush_paste_buffer(app, &mut paste_buffer)?;
                             }
+                            flush_paste_buffer(app, &mut paste_buffer)?;
                         }
-                        app.dirty = true;
                     }
+                    app.dirty = true;
                 }
+                Event::Key(_) => {}
                 Event::Paste(text) => {
                     app.forward_paste_to_pty(&text)?;
                     app.paste_cooldown = 5;


### PR DESCRIPTION
## Summary
PR #20 (clippy cleanup) は Windows ローカルで clean だったが、Ubuntu CI で4件の lint が新たに表面化した (Rust 1.95 on Linux vs 1.94 on Windows local)。#20 はこの差分を認識せず CI 失敗のままマージされた (\`clippy\` が required status checks に未登録だったため)。

本 PR で Linux 側 lint を解消し、以降のマージで \`clippy\` が required checks に入った状態を安定維持できるようにする。

## 修正
1. \`EndpointKind::Pipe\` が Linux で never constructed: 両 variant が Drop 側 match 互換性のため必要なので、enum に \`#[allow(dead_code)]\`
2. \`filetree.rs::build_tree\` の \`sort_by\` → \`sort_by_key\` (clippy::unnecessary_sort_by)
3. \`main.rs\` の \`match Event::Key(key) => { if key.kind == Press { ... } }\` → guard 付き arm + explicit fall-through (clippy::collapsible_match)

## Test plan
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\` local clean (Windows)
- [x] \`cargo build --locked\` / \`cargo test --locked\` pass (115 tests)
- [x] \`cargo fmt\` clean
- [ ] **CI で clippy が緑** — 本 PR の主目的

## フォローアップ
マージ後に branch protection の required status checks に \`clippy\` を追加。これにより今後は Linux clippy 失敗でマージがブロックされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)