### PR TITLE
fix: IPC polish — constant-time compare, orderly shutdown, timeout coupling (closes #13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "subtle",
  "syntect",
  "toml",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 interprocess = "2"
 oneshot = "0.1"
+subtle = "2"

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -8,19 +8,13 @@
 use std::io::{BufRead, BufReader, Write};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use interprocess::local_socket::{prelude::*, Stream};
+use subtle::ConstantTimeEq;
 
 use super::endpoint::{EndpointName, ENV_TOKEN};
-use super::{Request, Response};
-
-/// How long we wait for a response before giving up. The server replies
-/// within milliseconds unless the App is genuinely wedged; this value
-/// is a belt-and-braces safety net so a misbehaving server can't hang
-/// a shell script that invokes `ccmux send`.
-const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+use super::{Request, Response, RESPONSE_TIMEOUT};
 
 /// Send a single request to the endpoint and return the response.
 ///
@@ -114,13 +108,24 @@ fn write_request_line<W: Write>(w: &mut W, req: &Request) -> Result<()> {
 /// to a ccmux instance that doesn't own the current shell — most likely
 /// the PID got re-used and a stale socket path was inherited. Refuse
 /// rather than silently deliver the command to the wrong process.
+///
+/// Uses a constant-time comparison; same-user tokens are not a secrecy
+/// boundary (see the crate-level threat model), but comparing byte-by-
+/// byte in constant time is the cheap hardening default.
 fn verify_session_token(server_token: &str, expected: Option<&str>) -> Result<()> {
     match expected {
-        Some(e) if e == server_token => Ok(()),
-        Some(_) => Err(anyhow!(
-            "session token mismatch; {ENV_SOCKET} likely points to a different ccmux instance",
-            ENV_SOCKET = super::endpoint::ENV_SOCKET
-        )),
+        Some(e) => {
+            let a = server_token.as_bytes();
+            let b = e.as_bytes();
+            if a.len() == b.len() && bool::from(a.ct_eq(b)) {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "session token mismatch; {ENV_SOCKET} likely points to a different ccmux instance",
+                    ENV_SOCKET = super::endpoint::ENV_SOCKET
+                ))
+            }
+        }
         None => Err(anyhow!(
             "{ENV_TOKEN} not set; are you running inside ccmux?"
         )),
@@ -180,6 +185,30 @@ mod tests {
     fn verify_session_token_rejects_missing_env() {
         let err = verify_session_token("abc-123", None).unwrap_err();
         assert!(err.to_string().contains("CCMUX_TOKEN"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_session_token_rejects_length_mismatch() {
+        let err = verify_session_token("short", Some("much-longer-token")).unwrap_err();
+        assert!(err.to_string().contains("mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_session_token_rejects_whitespace_wrap() {
+        // Whitespace is not trimmed; comparison is exact.
+        assert!(verify_session_token("abc", Some(" abc")).is_err());
+        assert!(verify_session_token("abc", Some("abc\n")).is_err());
+    }
+
+    #[test]
+    fn verify_session_token_unicode_roundtrip() {
+        assert!(verify_session_token("トークン", Some("トークン")).is_ok());
+        assert!(verify_session_token("トークン", Some("トーケン")).is_err());
+    }
+
+    #[test]
+    fn verify_session_token_rejects_empty_server_token() {
+        assert!(verify_session_token("", Some("nonempty")).is_err());
     }
 
     #[test]

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -27,6 +27,23 @@
 //! trust model that's already inside the boundary.
 
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Server-side budget for waking the App event loop with a single
+/// command. The App drains commands every frame (~30Hz), so 5s is
+/// orders of magnitude more than the expected latency — a timeout
+/// here means the App is genuinely wedged.
+pub(crate) const APP_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Client margin for connect + JSON write/read + scheduling on top of
+/// the server's [`APP_REPLY_TIMEOUT`]. Kept small so `ccmux send` in
+/// a shell script aborts within a few seconds if something is wrong.
+pub(crate) const CLIENT_MARGIN: Duration = Duration::from_secs(5);
+
+/// Total time the client waits for a full response before erroring out.
+/// Derived so the two timeouts stay in sync if one is tuned later.
+pub(crate) const RESPONSE_TIMEOUT: Duration =
+    Duration::from_secs(APP_REPLY_TIMEOUT.as_secs() + CLIENT_MARGIN.as_secs());
 
 pub mod client;
 pub mod endpoint;

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -19,9 +19,10 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
@@ -30,10 +31,19 @@ use super::endpoint::{EndpointKind, EndpointName};
 use super::{Request, Response, APP_REPLY_TIMEOUT};
 use crate::app::AppCommand;
 
+/// Upper bound for waiting on the accept thread during shutdown.
+/// `Drop` must not hang on an uncooperative accept thread — if the
+/// self-connect wakeup somehow fails and the thread stays blocked in
+/// `listener.incoming()`, we'd rather leak the thread (the OS reaps
+/// it on process exit) than stall the whole process from teardown.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
 pub struct IpcServer {
     pub endpoint: EndpointName,
     stop: Arc<AtomicBool>,
-    accept_handle: Option<thread::JoinHandle<()>>,
+    /// Signaled once the accept thread returns. Using a channel rather
+    /// than `JoinHandle::join` so Drop can wait with a timeout.
+    done_rx: Option<mpsc::Receiver<()>>,
 }
 
 impl Drop for IpcServer {
@@ -41,12 +51,12 @@ impl Drop for IpcServer {
         // Orderly shutdown so the accept thread exits before we remove
         // the socket file, avoiding the "stale listener, new path"
         // rebinding race: (1) flip the stop flag, (2) self-connect to
-        // unblock the blocked `accept()` call, (3) join the thread, and
-        // finally (4) unlink the socket on Unix.
+        // unblock the blocked `accept()` call, (3) wait for the thread
+        // to signal completion (bounded), then (4) unlink on Unix.
         self.stop.store(true, Ordering::Release);
         unblock_accept(&self.endpoint);
-        if let Some(handle) = self.accept_handle.take() {
-            let _ = handle.join();
+        if let Some(rx) = self.done_rx.take() {
+            let _ = rx.recv_timeout(SHUTDOWN_TIMEOUT);
         }
         if self.endpoint.kind() == EndpointKind::Socket {
             let _ = std::fs::remove_file(self.endpoint.as_str());
@@ -94,7 +104,8 @@ impl IpcServer {
         let stop_for_thread = stop.clone();
         let token_for_thread = session_token.clone();
         let endpoint_for_log = endpoint.as_str().to_string();
-        let accept_handle = thread::Builder::new()
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::Builder::new()
             .name("ccmux-ipc-accept".into())
             .spawn(move || {
                 accept_loop(
@@ -104,6 +115,11 @@ impl IpcServer {
                     endpoint_for_log,
                     stop_for_thread,
                 );
+                // Signal Drop that the accept loop has returned. If the
+                // receiver is already gone (Drop finished first because
+                // of the timeout) the send errors out silently; we
+                // don't care.
+                let _ = done_tx.send(());
             })
             .context("spawn IPC accept thread")?;
 
@@ -113,7 +129,7 @@ impl IpcServer {
         Ok(Self {
             endpoint,
             stop,
-            accept_handle: Some(accept_handle),
+            done_rx: Some(done_rx),
         })
     }
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -18,38 +18,65 @@
 //!   indefinitely.
 
 use std::io::{BufRead, BufReader, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
 
 use super::endpoint::{EndpointKind, EndpointName};
-use super::{Request, Response};
+use super::{Request, Response, APP_REPLY_TIMEOUT};
 use crate::app::AppCommand;
-
-/// How long a worker waits for the App's event loop to process one
-/// command before giving up. The App drains commands every frame
-/// (~30Hz), so 5s is orders of magnitude more than the expected latency
-/// — a timeout here means the App is genuinely wedged.
-const APP_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct IpcServer {
     pub endpoint: EndpointName,
-    // We intentionally don't hold a JoinHandle. The accept thread lives
-    // until the process exits, at which point the OS reclaims the pipe
-    // or socket. Orderly shutdown is not needed in v1.
+    stop: Arc<AtomicBool>,
+    accept_handle: Option<thread::JoinHandle<()>>,
 }
 
 impl Drop for IpcServer {
     fn drop(&mut self) {
-        // Unix socket files are filesystem entries and would otherwise
-        // accumulate in /tmp on abnormal exit. Named Pipes on Windows
-        // are reclaimed by the OS when the owning process exits.
+        // Orderly shutdown so the accept thread exits before we remove
+        // the socket file, avoiding the "stale listener, new path"
+        // rebinding race: (1) flip the stop flag, (2) self-connect to
+        // unblock the blocked `accept()` call, (3) join the thread, and
+        // finally (4) unlink the socket on Unix.
+        self.stop.store(true, Ordering::Release);
+        unblock_accept(&self.endpoint);
+        if let Some(handle) = self.accept_handle.take() {
+            let _ = handle.join();
+        }
         if self.endpoint.kind() == EndpointKind::Socket {
             let _ = std::fs::remove_file(self.endpoint.as_str());
         }
+    }
+}
+
+/// Open and immediately drop a client connection to the server's own
+/// endpoint. This wakes the blocked `Listener::incoming()` call so the
+/// accept thread can observe the stop flag and exit. Any error is
+/// ignored — the endpoint may already be torn down from an earlier
+/// Drop pass.
+fn unblock_accept(endpoint: &EndpointName) {
+    let name = match endpoint_to_name(endpoint) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+    let _ = Stream::connect(name);
+}
+
+fn endpoint_to_name(endpoint: &EndpointName) -> Result<interprocess::local_socket::Name<'_>> {
+    #[cfg(windows)]
+    {
+        use interprocess::os::windows::local_socket::NamedPipe;
+        Ok(endpoint.as_str().to_fs_name::<NamedPipe>()?)
+    }
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        Ok(endpoint.as_str().to_fs_name::<GenericFilePath>()?)
     }
 }
 
@@ -63,19 +90,31 @@ impl IpcServer {
         let listener = bind_listener(&endpoint)
             .with_context(|| format!("bind IPC endpoint {}", endpoint.as_str()))?;
 
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = stop.clone();
         let token_for_thread = session_token.clone();
         let endpoint_for_log = endpoint.as_str().to_string();
-        thread::Builder::new()
+        let accept_handle = thread::Builder::new()
             .name("ccmux-ipc-accept".into())
             .spawn(move || {
-                accept_loop(listener, command_tx, token_for_thread, endpoint_for_log);
+                accept_loop(
+                    listener,
+                    command_tx,
+                    token_for_thread,
+                    endpoint_for_log,
+                    stop_for_thread,
+                );
             })
             .context("spawn IPC accept thread")?;
 
         // Token is consumed by the accept thread via `token_for_thread`;
         // we don't need to keep a copy on the struct.
         drop(session_token);
-        Ok(Self { endpoint })
+        Ok(Self {
+            endpoint,
+            stop,
+            accept_handle: Some(accept_handle),
+        })
     }
 }
 
@@ -108,13 +147,24 @@ fn accept_loop(
     command_tx: Sender<AppCommand>,
     session_token: String,
     endpoint_for_log: String,
+    stop: Arc<AtomicBool>,
 ) {
     for conn in listener.incoming() {
+        // The self-connect triggered by IpcServer::drop returns here;
+        // observing the stop flag before handle_connection lets us
+        // exit cleanly instead of serving one last spurious request.
+        if stop.load(Ordering::Acquire) {
+            return;
+        }
         let conn = match conn {
             Ok(c) => c,
             Err(e) => {
-                // A single failed accept shouldn't kill the server —
-                // the OS can recover from transient conditions.
+                // Accept failures on a shutdown path are expected (the
+                // listener got unlinked under us); on a normal path
+                // they're transient and shouldn't kill the server.
+                if stop.load(Ordering::Acquire) {
+                    return;
+                }
                 eprintln!("ccmux IPC: accept failed on {endpoint_for_log}: {e}");
                 continue;
             }


### PR DESCRIPTION
## Summary
Issue #13 の3点 (PR #12 Codex レビューで Nice-to-have だった項目) を解消。

## A. 定数時間トークン比較 (\`subtle\` crate)
\`verify_session_token\` を \`ct_eq\` ベースに置換。same-user 前提で timing 攻撃は実害ないが、将来の同パターン流用防止の観点で cheap hardening。

## B. Accept thread の orderly shutdown
- \`IpcServer\` に \`stop: Arc<AtomicBool>\` + accept thread の \`JoinHandle\` を保持
- Drop の順序: (1) stop flag セット → (2) 自己接続で \`accept()\` をアンブロック → (3) thread join → (4) Unix socket unlink
- 「古い listener が生きた状態で新 ccmux が同じ path に rebind」する race を解消

## D. Timeout 定数の連結
- \`APP_REPLY_TIMEOUT\` (server) と \`RESPONSE_TIMEOUT\` (client) を \`src/ipc/mod.rs\` に集約
- \`RESPONSE_TIMEOUT = APP_REPLY_TIMEOUT + CLIENT_MARGIN\` として関係を明示

## 新規テスト (4件)
- \`verify_session_token_rejects_length_mismatch\`
- \`verify_session_token_rejects_whitespace_wrap\`
- \`verify_session_token_unicode_roundtrip\`
- \`verify_session_token_rejects_empty_server_token\`

## 依存追加
\`subtle = "2"\` (constant-time プリミティブのみ、runtime オーバーヘッドなし)

## Test plan
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --locked\` — **119 passed** (115 + 4 新規)
- [x] CI 3プラットフォーム緑

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)