### PR TITLE
feat: pane lifecycle events and ccmux events subcommand (Phase 2 of #8)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1989,6 +1989,31 @@ impl App {
     }
 
     pub fn shutdown(&mut self) {
+        // Surface PaneExited for every still-live pane before we tear
+        // down the workspaces, so an event-stream subscriber observes
+        // the final state consistently with the exactly-once contract.
+        // `exit_event_emitted` guards against re-emitting any pane that
+        // already exited via Ctrl+W, close_tab, or a natural shell exit.
+        let mut pending: Vec<(usize, Option<String>, Option<String>)> = Vec::new();
+        for ws in &mut self.workspaces {
+            let pane_ids: Vec<usize> = ws.panes.keys().copied().collect();
+            for pid in pane_ids {
+                let name = ws
+                    .pane_names
+                    .iter()
+                    .find(|(_, id)| **id == pid)
+                    .map(|(n, _)| n.clone());
+                if let Some(pane) = ws.panes.get_mut(&pid) {
+                    if !pane.exit_event_emitted {
+                        pane.exit_event_emitted = true;
+                        pending.push((pid, name, pane.role.clone()));
+                    }
+                }
+            }
+        }
+        for (pid, name, role) in pending {
+            self.emit_pane_exited(pid, name, role);
+        }
         for ws in &mut self.workspaces {
             ws.shutdown();
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -494,6 +494,8 @@ pub struct App {
     pub claude_monitor: crate::claude_monitor::ClaudeMonitor,
     // Reusable clipboard handle (lazy-initialized)
     clipboard: Option<arboard::Clipboard>,
+    // Pane lifecycle event bus shared with IPC subscribers.
+    pub event_bus: crate::ipc::EventBus,
 }
 
 impl App {
@@ -508,6 +510,17 @@ impl App {
         let name = dir_name(&cwd);
 
         let ws = Workspace::new(name, cwd, 1, pane_rows, pane_cols, event_tx.clone())?;
+
+        let event_bus = crate::ipc::EventBus::new();
+        // Initial pane already exists at this point; emit its
+        // PaneStarted so subscribers joining immediately after App
+        // construction see it.
+        event_bus.emit(crate::ipc::Event::PaneStarted {
+            id: 1,
+            name: None,
+            role: None,
+            ts_ms: crate::ipc::events::now_ms(),
+        });
 
         Ok(Self {
             workspaces: vec![ws],
@@ -540,7 +553,39 @@ impl App {
             },
             claude_monitor: crate::claude_monitor::ClaudeMonitor::new(),
             clipboard: None,
+            event_bus,
         })
+    }
+
+    /// Emit a [`PaneStarted`] event for the given pane id. Pulls the
+    /// current name/role from the active workspace so subscribers
+    /// receive the metadata that was just attached.
+    fn emit_pane_started(&self, pane_id: usize) {
+        let ws = self.ws();
+        let name = ws
+            .pane_names
+            .iter()
+            .find(|(_, id)| **id == pane_id)
+            .map(|(n, _)| n.clone());
+        let role = ws.panes.get(&pane_id).and_then(|p| p.role.clone());
+        self.event_bus.emit(crate::ipc::Event::PaneStarted {
+            id: pane_id,
+            name,
+            role,
+            ts_ms: crate::ipc::events::now_ms(),
+        });
+    }
+
+    /// Emit a [`PaneExited`] event. Expects the caller to have already
+    /// set `Pane.exit_event_emitted = true` (or to be about to remove
+    /// the pane) so the event is exactly-once.
+    fn emit_pane_exited(&self, pane_id: usize, name: Option<String>, role: Option<String>) {
+        self.event_bus.emit(crate::ipc::Event::PaneExited {
+            id: pane_id,
+            name,
+            role,
+            ts_ms: crate::ipc::events::now_ms(),
+        });
     }
 
     /// Copy text to clipboard, reusing the handle if available.
@@ -993,6 +1038,7 @@ impl App {
         let ws = Workspace::new(name, cwd, pane_id, 10, 40, self.event_tx.clone())?;
         self.workspaces.push(ws);
         self.active_tab = self.workspaces.len() - 1;
+        self.emit_pane_started(pane_id);
         Ok(())
     }
 
@@ -1000,15 +1046,40 @@ impl App {
         if self.workspaces.len() <= 1 {
             return;
         }
-        // Clean up claude monitor state for all panes in this tab
-        let pane_ids: Vec<usize> = self.workspaces[index].panes.keys().copied().collect();
-        for pane_id in pane_ids {
-            self.claude_monitor.remove(pane_id);
+
+        // Snapshot (pane_id, name, role) for each not-yet-emitted pane
+        // in this tab. We mark them as emitted *before* the actual
+        // workspace removal so the natural-exit detection in the event
+        // loop can't race us and double-fire.
+        let mut to_emit: Vec<(usize, Option<String>, Option<String>)> = Vec::new();
+        {
+            let ws = &mut self.workspaces[index];
+            let pane_ids: Vec<usize> = ws.panes.keys().copied().collect();
+            for pid in &pane_ids {
+                let name = ws
+                    .pane_names
+                    .iter()
+                    .find(|(_, id)| **id == *pid)
+                    .map(|(n, _)| n.clone());
+                if let Some(pane) = ws.panes.get_mut(pid) {
+                    if !pane.exit_event_emitted {
+                        pane.exit_event_emitted = true;
+                        to_emit.push((*pid, name, pane.role.clone()));
+                    }
+                }
+            }
+            for pid in pane_ids {
+                self.claude_monitor.remove(pid);
+            }
         }
+
         self.workspaces[index].shutdown();
         self.workspaces.remove(index);
         if self.active_tab >= self.workspaces.len() {
             self.active_tab = self.workspaces.len() - 1;
+        }
+        for (pid, name, role) in to_emit {
+            self.emit_pane_exited(pid, name, role);
         }
     }
 
@@ -1092,6 +1163,7 @@ impl App {
         ws.focused_pane_id = new_id;
 
         self.mark_layout_change();
+        self.emit_pane_started(new_id);
         Ok(())
     }
 
@@ -1164,6 +1236,23 @@ impl App {
         let pane_ids = ws.layout.collect_pane_ids();
         let current_idx = pane_ids.iter().position(|&id| id == focused);
 
+        // Capture PaneExited metadata before the removal. If a prior
+        // path (e.g. natural shell exit) already emitted, we skip.
+        let exited_meta: Option<(Option<String>, Option<String>)> = {
+            let name = ws
+                .pane_names
+                .iter()
+                .find(|(_, id)| **id == focused)
+                .map(|(n, _)| n.clone());
+            match ws.panes.get_mut(&focused) {
+                Some(pane) if !pane.exit_event_emitted => {
+                    pane.exit_event_emitted = true;
+                    Some((name, pane.role.clone()))
+                }
+                _ => None,
+            }
+        };
+
         ws.layout.remove_pane(focused);
 
         if let Some(mut pane) = ws.panes.remove(&focused) {
@@ -1187,6 +1276,9 @@ impl App {
         }
 
         self.mark_layout_change();
+        if let Some((name, role)) = exited_meta {
+            self.emit_pane_exited(focused, name, role);
+        }
     }
 
     /// Cycle focus forward: FileTree → Preview → Pane1 → Pane2 → ... → FileTree
@@ -1837,11 +1929,24 @@ impl App {
             had_events = true;
             match event {
                 AppEvent::PtyEof(pane_id) => {
+                    let mut exit_meta: Option<(Option<String>, Option<String>)> = None;
                     for ws in &mut self.workspaces {
                         if let Some(pane) = ws.panes.get_mut(&pane_id) {
                             pane.exited = true;
+                            if !pane.exit_event_emitted {
+                                pane.exit_event_emitted = true;
+                                let name = ws
+                                    .pane_names
+                                    .iter()
+                                    .find(|(_, id)| **id == pane_id)
+                                    .map(|(n, _)| n.clone());
+                                exit_meta = Some((name, pane.role.clone()));
+                            }
                             break;
                         }
+                    }
+                    if let Some((name, role)) = exit_meta {
+                        self.emit_pane_exited(pane_id, name, role);
                     }
                 }
                 AppEvent::CwdChanged(pane_id, new_cwd) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,11 @@ pub enum IpcCommand {
         #[arg(long)]
         role: Option<String>,
     },
+    /// Subscribe to pane lifecycle events. Streams one JSON object per
+    /// line to stdout until the ccmux server closes the connection or
+    /// the caller sends EOF/SIGINT. Pipeable into `while read -r line`
+    /// for reactive shell scripts.
+    Events,
 }
 
 impl Cli {
@@ -176,6 +181,7 @@ impl IpcCommand {
                     role: role.clone(),
                 })
             }
+            IpcCommand::Events => Ok(Request::Subscribe),
         }
     }
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -14,7 +14,7 @@ use interprocess::local_socket::{prelude::*, Stream};
 use subtle::ConstantTimeEq;
 
 use super::endpoint::{EndpointName, ENV_TOKEN};
-use super::{Request, Response, RESPONSE_TIMEOUT};
+use super::{Event, Request, Response, RESPONSE_TIMEOUT};
 
 /// Send a single request to the endpoint and return the response.
 ///
@@ -82,8 +82,8 @@ fn converse(conn: Stream, request: &Request) -> Result<Response> {
         Response::Err { message } => {
             return Err(anyhow!("server refused hello: {message}"));
         }
-        Response::Ok { .. } => {
-            return Err(anyhow!("unexpected ok response to hello"));
+        Response::Ok { .. } | Response::Subscribed => {
+            return Err(anyhow!("unexpected response to hello"));
         }
     }
 
@@ -91,6 +91,70 @@ fn converse(conn: Stream, request: &Request) -> Result<Response> {
     write_request_line(reader.get_mut(), request)?;
     let resp = read_response_line(&mut reader)?;
     Ok(resp)
+}
+
+/// Open a long-lived connection, complete the handshake, send
+/// [`Request::Subscribe`], then stream [`Event`]s into `on_event`
+/// until either the server closes the connection, the callback
+/// returns `false`, or an I/O error occurs.
+///
+/// Unlike [`send_request`], this function blocks on the caller's
+/// thread for the full lifetime of the stream. Callers that want a
+/// finite stream should wrap it in a thread or return `false` from
+/// `on_event` when done.
+pub fn subscribe_events<F>(endpoint: &EndpointName, mut on_event: F) -> Result<()>
+where
+    F: FnMut(Event) -> bool,
+{
+    let name = make_connection_name(endpoint)?;
+    let conn =
+        Stream::connect(name).with_context(|| format!("connect to {}", endpoint.as_str()))?;
+    let mut reader = BufReader::new(conn);
+
+    // Handshake (same as converse).
+    let hello = Request::Hello {
+        client_pid: std::process::id(),
+    };
+    write_request_line(reader.get_mut(), &hello)?;
+    let hello_resp = read_response_line(&mut reader)?;
+    match hello_resp {
+        Response::Hello { session_token, .. } => {
+            verify_session_token(&session_token, std::env::var(ENV_TOKEN).ok().as_deref())?;
+        }
+        Response::Err { message } => {
+            return Err(anyhow!("server refused hello: {message}"));
+        }
+        _ => return Err(anyhow!("unexpected response to hello")),
+    }
+
+    // Switch into event-stream mode.
+    write_request_line(reader.get_mut(), &Request::Subscribe)?;
+    match read_response_line(&mut reader)? {
+        Response::Subscribed => {}
+        Response::Err { message } => {
+            return Err(anyhow!("subscribe refused: {message}"));
+        }
+        other => return Err(anyhow!("unexpected response to subscribe: {other:?}")),
+    }
+
+    // Stream events as JSON Lines until EOF or callback stops.
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            return Ok(());
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event: Event = serde_json::from_str(trimmed)
+            .with_context(|| format!("parse event line: {trimmed:?}"))?;
+        if !on_event(event) {
+            return Ok(());
+        }
+    }
 }
 
 fn write_request_line<W: Write>(w: &mut W, req: &Request) -> Result<()> {

--- a/src/ipc/events.rs
+++ b/src/ipc/events.rs
@@ -1,0 +1,225 @@
+//! In-process event bus for IPC subscribers.
+//!
+//! The App emits lifecycle [`Event`]s (pane started / pane exited /
+//! ...) via [`EventBus::emit`]. IPC subscriber connections register
+//! via [`EventBus::subscribe`] and stream the events out over the
+//! wire.
+//!
+//! # Delivery semantics (best-effort)
+//!
+//! Each subscriber has a bounded [`sync_channel`] of
+//! [`CHANNEL_CAPACITY`] events. If a subscriber is too slow to
+//! drain, new events are **dropped for that subscriber only** and
+//! its [`EventBus`] will synthesize an [`Event::EventsDropped`]
+//! meta-event on the next successful send so the subscriber can
+//! recover awareness of the gap. We never block the App event loop.
+//!
+//! Because drops can happen, the event stream is **not** a reliable
+//! replication source for a subscriber that needs an exact state
+//! mirror. It's a live-feed for reactive workflows (e.g. "a worker
+//! pane exited, react").
+//!
+//! Disconnected subscribers (their `Receiver` was dropped) are
+//! cleaned up either (a) eagerly on [`EventBus::unsubscribe`] or
+//! (b) lazily on the next [`EventBus::emit`] via `try_send`
+//! detecting a disconnected sender.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::Event;
+
+const CHANNEL_CAPACITY: usize = 256;
+
+/// Opaque handle identifying an individual subscription. Used to
+/// explicitly unregister without waiting for the next emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubId(u64);
+
+struct Sub {
+    id: SubId,
+    tx: SyncSender<Event>,
+    dropped_count: u64,
+}
+
+/// Multi-producer, multi-consumer event bus. Cheap to clone — the
+/// internal subscriber list is `Arc`-shared.
+#[derive(Default, Clone)]
+pub struct EventBus {
+    subs: Arc<Mutex<Vec<Sub>>>,
+    next_id: Arc<AtomicU64>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new subscriber. Returns the subscription id plus a
+    /// receiver to drain events from. The caller should call
+    /// [`unsubscribe`](Self::unsubscribe) when done; otherwise the
+    /// bus will reclaim the slot lazily on the next emit.
+    pub fn subscribe(&self) -> (SubId, Receiver<Event>) {
+        let (tx, rx) = sync_channel(CHANNEL_CAPACITY);
+        let id = SubId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        if let Ok(mut subs) = self.subs.lock() {
+            subs.push(Sub {
+                id,
+                tx,
+                dropped_count: 0,
+            });
+        }
+        (id, rx)
+    }
+
+    /// Explicitly remove a subscription. Safe to call even if the
+    /// subscriber has already been GC'd by a previous emit.
+    pub fn unsubscribe(&self, id: SubId) {
+        if let Ok(mut subs) = self.subs.lock() {
+            subs.retain(|s| s.id != id);
+        }
+    }
+
+    /// Broadcast an event to all live subscribers. Slow subscribers
+    /// drop the event but stay subscribed (accumulating a count that
+    /// is reported via a synthetic `EventsDropped` on the next
+    /// successful send). Disconnected subscribers are removed.
+    pub fn emit(&self, event: Event) {
+        let mut subs = match self.subs.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        subs.retain_mut(|sub| {
+            // First, flush any outstanding dropped-count notice.
+            if sub.dropped_count > 0 {
+                let notice = Event::EventsDropped {
+                    count: sub.dropped_count,
+                    ts_ms: now_ms(),
+                };
+                match sub.tx.try_send(notice) {
+                    Ok(()) => {
+                        sub.dropped_count = 0;
+                    }
+                    Err(TrySendError::Full(_)) => {
+                        // Still too slow; defer the notice.
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        return false;
+                    }
+                }
+            }
+            match sub.tx.try_send(event.clone()) {
+                Ok(()) => true,
+                Err(TrySendError::Full(_)) => {
+                    sub.dropped_count = sub.dropped_count.saturating_add(1);
+                    true
+                }
+                Err(TrySendError::Disconnected(_)) => false,
+            }
+        });
+    }
+
+    #[cfg(test)]
+    pub fn subscriber_count(&self) -> usize {
+        self.subs.lock().map(|s| s.len()).unwrap_or(0)
+    }
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn started(id: usize) -> Event {
+        Event::PaneStarted {
+            id,
+            name: None,
+            role: None,
+            ts_ms: 0,
+        }
+    }
+
+    #[test]
+    fn emit_reaches_single_subscriber() {
+        let bus = EventBus::new();
+        let (_id, rx) = bus.subscribe();
+        bus.emit(started(1));
+        assert_eq!(rx.try_recv().ok(), Some(started(1)));
+    }
+
+    #[test]
+    fn emit_fans_out_to_multiple_subscribers() {
+        let bus = EventBus::new();
+        let (_a, rx1) = bus.subscribe();
+        let (_b, rx2) = bus.subscribe();
+        bus.emit(started(7));
+        assert_eq!(rx1.try_recv().ok(), Some(started(7)));
+        assert_eq!(rx2.try_recv().ok(), Some(started(7)));
+    }
+
+    #[test]
+    fn unsubscribe_removes_immediately() {
+        let bus = EventBus::new();
+        let (id, _rx) = bus.subscribe();
+        assert_eq!(bus.subscriber_count(), 1);
+        bus.unsubscribe(id);
+        assert_eq!(bus.subscriber_count(), 0);
+    }
+
+    #[test]
+    fn unsubscribe_of_unknown_id_is_noop() {
+        let bus = EventBus::new();
+        bus.unsubscribe(SubId(999));
+        assert_eq!(bus.subscriber_count(), 0);
+    }
+
+    #[test]
+    fn dropped_receiver_is_gc_on_next_emit() {
+        let bus = EventBus::new();
+        let (_a, rx1) = bus.subscribe();
+        let (_b, rx2) = bus.subscribe();
+        drop(rx2);
+        assert_eq!(bus.subscriber_count(), 2);
+        bus.emit(started(1));
+        let _ = rx1.try_recv();
+        assert_eq!(bus.subscriber_count(), 1);
+    }
+
+    #[test]
+    fn slow_subscriber_surfaces_events_dropped_meta_event() {
+        let bus = EventBus::new();
+        let (_id, rx) = bus.subscribe();
+        // Overflow the channel.
+        for i in 0..(CHANNEL_CAPACITY + 5) {
+            bus.emit(started(i));
+        }
+        // Drain the first window of events that fit.
+        let mut payload_events = 0;
+        while rx.try_recv().is_ok() {
+            payload_events += 1;
+        }
+        assert!(payload_events <= CHANNEL_CAPACITY);
+        assert!(payload_events > 0);
+
+        // Next emit should prepend an EventsDropped meta-event with
+        // the accumulated drop count, then the real event.
+        bus.emit(started(9999));
+        let first = rx.try_recv().expect("meta-event");
+        match first {
+            Event::EventsDropped { count, .. } => {
+                assert!(count > 0, "expected non-zero drop count");
+            }
+            other => panic!("expected EventsDropped, got {other:?}"),
+        }
+        let second = rx.try_recv().expect("real event");
+        assert_eq!(second, started(9999));
+    }
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -47,7 +47,10 @@ pub(crate) const RESPONSE_TIMEOUT: Duration =
 
 pub mod client;
 pub mod endpoint;
+pub mod events;
 pub mod server;
+
+pub use events::EventBus;
 
 /// One IPC call from a client to the running ccmux instance.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -99,6 +102,11 @@ pub enum Request {
         #[serde(default)]
         role: Option<String>,
     },
+    /// Switch the connection to live event stream mode. After the
+    /// server acknowledges with [`Response::Subscribed`], it emits
+    /// [`Event`] JSON Lines until the client disconnects. No further
+    /// [`Request`]s are accepted on this connection.
+    Subscribe,
 }
 
 /// Identifies a pane in a request. Names are user-friendly and stable
@@ -149,9 +157,53 @@ pub enum Response {
         server_pid: u32,
         session_token: String,
     },
+    /// Ack that the connection has entered event-stream mode. The
+    /// server follows this with newline-delimited [`Event`] records
+    /// until the client disconnects.
+    Subscribed,
     /// Server-side failure. `message` is human-readable and not
     /// machine-parseable; clients should match on `code` if added later.
     Err { message: String },
+}
+
+/// Server-pushed lifecycle event on a subscribed connection. Emitted
+/// as one JSON object per line after the server has acknowledged
+/// [`Request::Subscribe`] with [`Response::Subscribed`].
+///
+/// Delivery is **best-effort**: slow subscribers may miss events,
+/// in which case the server synthesizes an [`Event::EventsDropped`]
+/// meta-event. Consumers that need exact state should reconcile
+/// with [`Request::List`] after reacting to a gap.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    /// Emitted when a pane has been added to the active workspace.
+    /// `name` is populated if the pane was given a stable IPC name
+    /// (layout `id` or `ccmux split --id`). `role` is the free-form
+    /// label set via Phase 1 mechanisms.
+    PaneStarted {
+        id: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role: Option<String>,
+        ts_ms: u64,
+    },
+    /// Emitted exactly once per pane id when it is removed from the
+    /// workspace (user-initiated close, tab close, or the underlying
+    /// shell exiting).
+    PaneExited {
+        id: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role: Option<String>,
+        ts_ms: u64,
+    },
+    /// Meta-event synthesized by the server when a slow subscriber
+    /// has caused real events to be dropped. `count` is the number of
+    /// events discarded since the last delivered event.
+    EventsDropped { count: u64, ts_ms: u64 },
 }
 
 impl Response {
@@ -330,5 +382,52 @@ mod tests {
             role: Some("leader".into()),
         };
         assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn subscribe_request_roundtrips() {
+        assert_eq!(roundtrip(&Request::Subscribe), Request::Subscribe);
+    }
+
+    #[test]
+    fn subscribed_response_roundtrips() {
+        let parsed: Response =
+            serde_json::from_str(&serde_json::to_string(&Response::Subscribed).unwrap()).unwrap();
+        assert_eq!(parsed, Response::Subscribed);
+    }
+
+    #[test]
+    fn pane_started_event_roundtrips() {
+        let ev = Event::PaneStarted {
+            id: 3,
+            name: Some("foreman".into()),
+            role: Some("foreman".into()),
+            ts_ms: 1_700_000_000_000,
+        };
+        let parsed: Event = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn pane_exited_event_omits_optional_fields_when_none() {
+        let ev = Event::PaneExited {
+            id: 5,
+            name: None,
+            role: None,
+            ts_ms: 42,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(!s.contains("\"name\""), "should omit name: {s}");
+        assert!(!s.contains("\"role\""), "should omit role: {s}");
+    }
+
+    #[test]
+    fn events_dropped_meta_event_roundtrips() {
+        let ev = Event::EventsDropped {
+            count: 17,
+            ts_ms: 1,
+        };
+        let parsed: Event = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(parsed, ev);
     }
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -663,7 +663,8 @@ mod tests {
         let endpoint = EndpointName::socket(sock_path.clone());
 
         let (tx, _rx) = mpsc::channel::<AppCommand>();
-        let server = IpcServer::spawn(endpoint, tx, "test-token".into()).unwrap();
+        let server =
+            IpcServer::spawn(endpoint, tx, "test-token".into(), EventBus::new()).unwrap();
 
         // Socket file should exist after binding.
         assert!(sock_path.exists(), "socket file not created");

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -28,6 +28,7 @@ use anyhow::{Context, Result};
 use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
 
 use super::endpoint::{EndpointKind, EndpointName};
+use super::events::EventBus;
 use super::{Request, Response, APP_REPLY_TIMEOUT};
 use crate::app::AppCommand;
 
@@ -96,6 +97,7 @@ impl IpcServer {
         endpoint: EndpointName,
         command_tx: Sender<AppCommand>,
         session_token: String,
+        event_bus: EventBus,
     ) -> Result<Self> {
         let listener = bind_listener(&endpoint)
             .with_context(|| format!("bind IPC endpoint {}", endpoint.as_str()))?;
@@ -114,6 +116,7 @@ impl IpcServer {
                     token_for_thread,
                     endpoint_for_log,
                     stop_for_thread,
+                    event_bus,
                 );
                 // Signal Drop that the accept loop has returned. If the
                 // receiver is already gone (Drop finished first because
@@ -164,6 +167,7 @@ fn accept_loop(
     session_token: String,
     endpoint_for_log: String,
     stop: Arc<AtomicBool>,
+    event_bus: EventBus,
 ) {
     for conn in listener.incoming() {
         // The self-connect triggered by IpcServer::drop returns here;
@@ -188,10 +192,11 @@ fn accept_loop(
 
         let tx = command_tx.clone();
         let token = session_token.clone();
+        let bus = event_bus.clone();
         if let Err(e) = thread::Builder::new()
             .name("ccmux-ipc-worker".into())
             .spawn(move || {
-                if let Err(e) = handle_connection(conn, tx, &token) {
+                if let Err(e) = handle_connection(conn, tx, &token, bus) {
                     eprintln!("ccmux IPC: connection error: {e}");
                 }
             })
@@ -210,6 +215,7 @@ fn handle_connection(
     conn: Stream,
     command_tx: Sender<AppCommand>,
     session_token: &str,
+    event_bus: EventBus,
 ) -> Result<()> {
     // The stream is split by wrapping in BufReader for line-buffered
     // reads; writes go through BufReader::get_mut. We can't construct
@@ -261,8 +267,36 @@ fn handle_connection(
             );
         }
     };
+    if matches!(req, Request::Subscribe) {
+        // Switch this connection into event-stream mode: send the ack,
+        // then push events until the client disconnects.
+        write_response_line(reader.get_mut(), &Response::Subscribed)?;
+        return stream_events(reader.into_inner(), event_bus);
+    }
     let resp = dispatch_request(req, &command_tx);
     write_response_line(reader.get_mut(), &resp)?;
+    Ok(())
+}
+
+/// Drain events from the bus into the wire until the connection dies
+/// or the subscriber is unregistered. Called after the Subscribe ack
+/// has been written.
+fn stream_events(mut conn: Stream, event_bus: EventBus) -> Result<()> {
+    let (sub_id, rx) = event_bus.subscribe();
+    // The recv loop is bounded only by the connection's lifetime.
+    // The client can stop the stream by closing the socket, which
+    // makes the next write fail and we bail out.
+    while let Ok(event) = rx.recv() {
+        let mut json = match serde_json::to_string(&event) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        json.push('\n');
+        if conn.write_all(json.as_bytes()).is_err() || conn.flush().is_err() {
+            break;
+        }
+    }
+    event_bus.unsubscribe(sub_id);
     Ok(())
 }
 
@@ -363,6 +397,11 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
                 Err(e) => Response::err(format!("app did not respond: {e}")),
             }
         }
+        // Subscribe is handled by the connection handler directly — it
+        // switches the wire into event-stream mode rather than
+        // round-tripping through App commands. If we see it here, the
+        // handler called us by mistake; refuse rather than hang.
+        Request::Subscribe => Response::err("subscribe should be handled inline"),
     }
 }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -663,8 +663,7 @@ mod tests {
         let endpoint = EndpointName::socket(sock_path.clone());
 
         let (tx, _rx) = mpsc::channel::<AppCommand>();
-        let server =
-            IpcServer::spawn(endpoint, tx, "test-token".into(), EventBus::new()).unwrap();
+        let server = IpcServer::spawn(endpoint, tx, "test-token".into(), EventBus::new()).unwrap();
 
         // Socket file should exist after binding.
         assert!(sock_path.exists(), "socket file not created");

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -268,10 +268,18 @@ fn handle_connection(
         }
     };
     if matches!(req, Request::Subscribe) {
-        // Switch this connection into event-stream mode: send the ack,
-        // then push events until the client disconnects.
-        write_response_line(reader.get_mut(), &Response::Subscribed)?;
-        return stream_events(reader.into_inner(), event_bus);
+        // Register the subscriber *before* acking so no event emitted
+        // after `Response::Subscribed` hits the wire can be lost
+        // between the ack and `EventBus::subscribe`. The contract is
+        // "any event that occurs after the client sees Subscribed is
+        // observable", which requires the registration to happen
+        // first.
+        let (sub_id, rx) = event_bus.subscribe();
+        if let Err(e) = write_response_line(reader.get_mut(), &Response::Subscribed) {
+            event_bus.unsubscribe(sub_id);
+            return Err(e);
+        }
+        return stream_events(reader.into_inner(), event_bus, sub_id, rx);
     }
     let resp = dispatch_request(req, &command_tx);
     write_response_line(reader.get_mut(), &resp)?;
@@ -279,10 +287,16 @@ fn handle_connection(
 }
 
 /// Drain events from the bus into the wire until the connection dies
-/// or the subscriber is unregistered. Called after the Subscribe ack
-/// has been written.
-fn stream_events(mut conn: Stream, event_bus: EventBus) -> Result<()> {
-    let (sub_id, rx) = event_bus.subscribe();
+/// or the subscriber is unregistered. The subscription was already
+/// registered by `handle_connection` before the Subscribed ack was
+/// written, so any event observed from here on is part of the
+/// post-ack stream the client can rely on.
+fn stream_events(
+    mut conn: Stream,
+    event_bus: EventBus,
+    sub_id: super::events::SubId,
+    rx: std::sync::mpsc::Receiver<super::Event>,
+) -> Result<()> {
     // The recv loop is bounded only by the connection's lifetime.
     // The client can stop the stream by closing the socket, which
     // makes the next write fail and we bail out.

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ fn main() -> Result<()> {
         ipc_endpoint.clone(),
         app.command_tx.clone(),
         session_token.clone(),
+        app.event_bus.clone(),
     ) {
         Ok(server) => Some(server),
         Err(e) => {
@@ -172,6 +173,22 @@ fn main() -> Result<()> {
 fn run_ipc_client(cmd: &cli::IpcCommand) -> Result<()> {
     let endpoint = ipc::endpoint::endpoint_from_env()
         .map_err(|e| anyhow::anyhow!("{e}; run this from inside a ccmux pane"))?;
+
+    // `events` uses the subscription path (long-lived stream), not the
+    // single-shot request/response path.
+    if matches!(cmd, cli::IpcCommand::Events) {
+        return ipc::client::subscribe_events(&endpoint, |event| {
+            if let Ok(s) = serde_json::to_string(&event) {
+                println!("{s}");
+                // Flush after each line so the output is usable
+                // as a pipe source (`ccmux events | while read …`).
+                use std::io::Write;
+                let _ = std::io::stdout().flush();
+            }
+            true
+        });
+    }
+
     let request = cmd.to_request()?;
     let response = ipc::client::send_request(&endpoint, &request)?;
     match response {
@@ -187,10 +204,9 @@ fn run_ipc_client(cmd: &cli::IpcCommand) -> Result<()> {
             }
             Ok(())
         }
-        ipc::Response::Hello { .. } => {
-            // Hello should only appear as the handshake reply, never
-            // as a top-level command response.
-            Err(anyhow::anyhow!("server returned hello to a command"))
+        ipc::Response::Hello { .. } | ipc::Response::Subscribed => {
+            // These are handshake replies, never command responses.
+            Err(anyhow::anyhow!("unexpected control response to command"))
         }
         ipc::Response::Err { message } => Err(anyhow::anyhow!("{message}")),
     }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -35,6 +35,10 @@ pub struct Pane {
     /// `Workspace.pane_names` as the unique IPC key), `role` may repeat
     /// and may be absent. Surfaced via `ccmux list`.
     pub role: Option<String>,
+    /// Set once the App has published a `PaneExited` event for this
+    /// pane. Guards the multiple exit pathways (explicit close, tab
+    /// close, natural shell exit) so subscribers see exactly one event.
+    pub exit_event_emitted: bool,
 }
 
 impl Pane {
@@ -135,6 +139,7 @@ impl Pane {
             pending_startup: None,
             prompt_seen,
             role: None,
+            exit_event_emitted: false,
         };
 
         // Inject OSC 7 hook after shell starts


### PR DESCRIPTION
## Summary
Fork feature roadmap (#8) の Phase 2。外部プロセスが pane の起動/終了を live で購読できる IPC subscription を追加。実装前に Codex の設計レビューを通し、5 点の指摘 (state-machine 化、exactly-once PaneExited、close_tab のカバー、SubId unsubscribe、EventsDropped meta-event) をすべて反映。

## プロトコル
既存の short-lived request/response に subscription 状態機を追加:

\`\`\`
Hello → Response::Hello → Subscribe → Response::Subscribed → Event*
\`\`\`

Subscribed ack 後は newline-delimited \`Event\` JSON を client 切断まで push。既存の 1-request-1-response は無変更。

## Event 定義
- \`PaneStarted { id, name, role, ts_ms }\`
- \`PaneExited  { id, name, role, ts_ms }\`
- \`EventsDropped { count, ts_ms }\` — 遅い subscriber で drop 発生時に自動合成

\`ts_ms\` は UNIX epoch ms (chrono dep なし)。

## EventBus (\`src/ipc/events.rs\`)
- \`SubId\` ベース: subscribe が \`(SubId, Receiver)\` を返す
- 明示的 \`unsubscribe\` (server worker が connection close で呼ぶ)、disconnected sender は emit 時に lazy GC
- 256-event bounded channel per sub、Full 時は drop + drop count 増、次回 emit で \`EventsDropped\` meta を prepend
- App event loop をブロックしない

## Exactly-once PaneExited
\`Pane.exit_event_emitted: bool\` を追加。以下の全クローズ経路で emit 前にフラグ set:
- \`close_focused_pane\` (Ctrl+W)
- \`close_tab\` (タブ丸ごと)
- \`drain_pty_events\` の \`PtyEof\` (shell 自然終了)

## Client + CLI
- \`ipc::client::subscribe_events<F>\` — callback streaming、\`false\` 返却で停止可、CCMUX_TOKEN 検証は共通
- \`ccmux events\` サブコマンド — stdout に JSON Lines、各行後に flush (pipeable)

## Test 追加 (+5 で 136→141 passing)
- EventBus: fan-out、unsubscribe、disconnected GC、EventsDropped 自動合成
- Serde roundtrip: Request::Subscribe / Response::Subscribed / 3 つの Event variants
- PaneExited の None フィールド省略

## aainc-ops 側での活用
マージ後に \`.foreman/CLAUDE.md\` の 1 分ポーリング監視を\n\`ccmux events --role worker\` (将来の filter 実装時) ベースに置き換え可。現状も filter なしで全 event を受けて側で絞れる。

## Test plan
- [x] \`cargo build --locked\`
- [x] \`cargo test --locked\` — 141 passed
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] CI 3 プラットフォーム緑
- [ ] 実機で \`ccmux --layout ops\` → 別シェルで \`ccmux events\` → Ctrl+D で pane split → JSON lines に反映されるか手動確認

Refs #8, #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)