### PR TITLE
chore: bump version to 0.5.6-fork.1 (Phase 2 prerelease)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.5-fork.1"
+version = "0.5.6-fork.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccmux"
-version = "0.5.5-fork.1"
+version = "0.5.6-fork.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.5-fork.1",
+  "version": "0.5.6-fork.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
Phase 2 (#27: pane lifecycle events + \`ccmux events\`) を npm \`@next\` タグに載せるための prerelease bump。\`latest\` タグ (stable 0.5.4) は据え置き。

## 変更
- \`Cargo.toml\`: 0.5.5-fork.1 → 0.5.6-fork.1
- \`npm/package.json\`: 同上
- \`Cargo.lock\`: 追従

## Release flow (マージ後)
1. \`git tag v0.5.6-fork.1 && git push origin v0.5.6-fork.1\`
2. CI (\`release.yml\`) が 4 プラットフォーム build + GitHub Release + npm publish (dist-tag=\`next\` なのは tag 名にハイフンが含まれるため自動判定)
3. 他マシンで \`npm install -g ccmux-fork@next\` で Phase 2 が使える

## Test plan
- [x] \`cargo build --release --locked\`
- [x] \`cargo test --locked\`
- [ ] CI 3 プラットフォーム緑
- [ ] マージ後 tag push → release workflow 成功
- [ ] \`npm view ccmux-fork@next version\` が \`0.5.6-fork.1\` を返す