### PR TITLE
feat: ccmux inspect — pane screen snapshot API (Phase 3, closes #32)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2190,11 +2190,15 @@ impl App {
             .map(|(row, text)| serde_json::json!({ "row": row, "text": text }))
             .collect();
 
+        // Build `pane` so `name` is omitted when the pane has no
+        // registered IPC name, matching the existing `PaneInfo`
+        // convention of omitting absent optionals.
+        let mut pane_obj = serde_json::json!({ "id": pane_id });
+        if let Some(n) = pane_name {
+            pane_obj["name"] = serde_json::Value::String(n);
+        }
         let mut payload = serde_json::json!({
-            "pane": {
-                "id": pane_id,
-                "name": pane_name,
-            },
+            "pane": pane_obj,
             "screen": {
                 "rows": rows,
                 "cols": cols,

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,6 +57,14 @@ pub enum AppCommand {
         role: Option<String>,
         reply: oneshot::Sender<std::result::Result<usize, String>>,
     },
+    /// Snapshot the visible screen of the target pane. See
+    /// [`ipc::Request::Inspect`] for the response shape.
+    Inspect {
+        target: PaneRef,
+        lines: Option<usize>,
+        include_cursor: bool,
+        reply: oneshot::Sender<std::result::Result<serde_json::Value, String>>,
+    },
 }
 
 /// Resolve a [`PaneRef`] to a concrete pane id.
@@ -2091,7 +2099,121 @@ impl App {
                 let result = self.handle_new_tab(command, name, label, role);
                 let _ = reply.send(result);
             }
+            AppCommand::Inspect {
+                target,
+                lines,
+                include_cursor,
+                reply,
+            } => {
+                let result = self.handle_inspect(&target, lines, include_cursor);
+                let _ = reply.send(result);
+            }
         }
+    }
+
+    fn handle_inspect(
+        &self,
+        target: &PaneRef,
+        lines: Option<usize>,
+        include_cursor: bool,
+    ) -> std::result::Result<serde_json::Value, String> {
+        let ws = self.ws();
+        let pane_id = ws
+            .resolve_pane_ref(target)
+            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+        let pane = ws
+            .panes
+            .get(&pane_id)
+            .ok_or_else(|| "pane vanished".to_string())?;
+
+        let pane_name = ws
+            .pane_names
+            .iter()
+            .find(|(_, id)| **id == pane_id)
+            .map(|(n, _)| n.clone());
+
+        // Snapshot the vt100 state under the lock, release it before
+        // JSON serialization.
+        let (rows, cols, line_start, line_count, collected, cursor) = {
+            let parser = pane
+                .parser
+                .lock()
+                .map_err(|_| "vt100 parser lock poisoned".to_string())?;
+            let screen = parser.screen();
+            let size = screen.size();
+            let total_rows = size.0 as usize;
+            let total_cols = size.1 as usize;
+
+            let want: usize = lines.map(|n| n.min(total_rows)).unwrap_or(total_rows);
+            let start: usize = total_rows.saturating_sub(want);
+            let end: usize = total_rows;
+
+            let mut collected: Vec<(usize, String)> = Vec::with_capacity(end - start);
+            for row in start..end {
+                let mut s = String::with_capacity(total_cols);
+                for col in 0..total_cols {
+                    if let Some(cell) = screen.cell(row as u16, col as u16) {
+                        s.push_str(cell.contents());
+                    }
+                }
+                // Trim trailing spaces but preserve the row's existence
+                // so callers can rely on positional indexing.
+                let trimmed = s.trim_end().to_string();
+                collected.push((row, trimmed));
+            }
+
+            let cursor = if include_cursor {
+                let (crow, ccol) = screen.cursor_position();
+                Some((!screen.hide_cursor(), crow as usize, ccol as usize))
+            } else {
+                None
+            };
+
+            (
+                total_rows,
+                total_cols,
+                start,
+                end - start,
+                collected,
+                cursor,
+            )
+        };
+
+        let text = collected
+            .iter()
+            .map(|(_, s)| s.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let lines_json: Vec<serde_json::Value> = collected
+            .into_iter()
+            .map(|(row, text)| serde_json::json!({ "row": row, "text": text }))
+            .collect();
+
+        let mut payload = serde_json::json!({
+            "pane": {
+                "id": pane_id,
+                "name": pane_name,
+            },
+            "screen": {
+                "rows": rows,
+                "cols": cols,
+                "line_start": line_start,
+                "line_count": line_count,
+            },
+            "lines": lines_json,
+            "text": text,
+        });
+
+        if let Some((visible, crow, ccol)) = cursor {
+            payload["cursor"] = serde_json::json!({
+                "visible": visible,
+                "row": crow,
+                "col": ccol,
+            });
+        }
+
+        Ok(payload)
     }
 
     fn handle_new_tab(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,25 @@ pub enum IpcCommand {
         #[arg(long)]
         role: Option<String>,
     },
+    /// Snapshot the visible screen of a pane. Returns JSON with one
+    /// entry per screen row so callers can match against fixed
+    /// positions (e.g. a status-bar row) without re-flowing blank rows.
+    Inspect {
+        /// Pane name. Defaults to the focused pane.
+        #[arg(long, conflicts_with_all = ["id", "focused"])]
+        name: Option<String>,
+        #[arg(long, conflicts_with_all = ["name", "focused"])]
+        id: Option<usize>,
+        #[arg(long, conflicts_with_all = ["name", "id"])]
+        focused: bool,
+        /// Limit to the bottom N rows of the screen grid (blank rows
+        /// preserved). Omit to return the full visible screen.
+        #[arg(long)]
+        lines: Option<usize>,
+        /// Include the cursor position and visibility in the payload.
+        #[arg(long)]
+        cursor: bool,
+    },
     /// Subscribe to pane lifecycle events. Streams one JSON object per
     /// line to stdout until the ccmux server closes the connection or
     /// one of `--timeout` / `--count` stops the drain. Pipeable into
@@ -192,6 +211,17 @@ impl IpcCommand {
                 })
             }
             IpcCommand::Events { .. } => Ok(Request::Subscribe),
+            IpcCommand::Inspect {
+                name,
+                id,
+                focused,
+                lines,
+                cursor,
+            } => Ok(Request::Inspect {
+                target: pick_ref(name, id, *focused)?,
+                lines: *lines,
+                include_cursor: *cursor,
+            }),
         }
     }
 }
@@ -530,6 +560,74 @@ mod tests {
         let cli = Cli::try_parse_from(["ccmux", "events", "--count", "3"]).unwrap();
         let req = cli.command.unwrap().to_request().unwrap();
         assert!(matches!(req, crate::ipc::Request::Subscribe));
+    }
+
+    #[test]
+    fn parses_inspect_focused_default() {
+        let cli = Cli::try_parse_from(["ccmux", "inspect"]).unwrap();
+        match cli.command {
+            Some(IpcCommand::Inspect {
+                name,
+                id,
+                focused,
+                lines,
+                cursor,
+            }) => {
+                assert!(name.is_none());
+                assert!(id.is_none());
+                assert!(!focused);
+                assert!(lines.is_none());
+                assert!(!cursor);
+            }
+            other => panic!("expected Inspect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_inspect_with_name_lines_cursor() {
+        let cli = Cli::try_parse_from([
+            "ccmux",
+            "inspect",
+            "--name",
+            "worker-foo",
+            "--lines",
+            "4",
+            "--cursor",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(IpcCommand::Inspect {
+                name,
+                lines,
+                cursor,
+                ..
+            }) => {
+                assert_eq!(name.as_deref(), Some("worker-foo"));
+                assert_eq!(lines, Some(4));
+                assert!(cursor);
+            }
+            other => panic!("expected Inspect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inspect_to_request_preserves_fields() {
+        let cli =
+            Cli::try_parse_from(["ccmux", "inspect", "--id", "7", "--lines", "2", "--cursor"])
+                .unwrap();
+        let req = cli.command.unwrap().to_request().unwrap();
+        match req {
+            crate::ipc::Request::Inspect {
+                target,
+                lines,
+                include_cursor,
+            } => {
+                assert!(matches!(target, crate::ipc::PaneRef::Id(7)));
+                assert_eq!(lines, Some(2));
+                assert!(include_cursor);
+            }
+            other => panic!("expected Inspect, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -107,6 +107,25 @@ pub enum Request {
     /// [`Event`] JSON Lines until the client disconnects. No further
     /// [`Request`]s are accepted on this connection.
     Subscribe,
+    /// Snapshot the current visible screen of the target pane.
+    /// Returns the plain-text contents in row-addressable form so
+    /// orchestrators can detect prompts like "Allow this tool use?",
+    /// error banners, or mode indicators without relying on worker
+    /// self-reports.
+    ///
+    /// `lines = Some(N)` limits the response to the bottom `N` rows
+    /// of the screen grid (including blank rows — the row layout is
+    /// preserved on purpose so callers can match against fixed
+    /// positions like the status bar). `None` returns the full
+    /// visible screen. `include_cursor = true` adds a `cursor`
+    /// object to the payload.
+    Inspect {
+        target: PaneRef,
+        #[serde(default)]
+        lines: Option<usize>,
+        #[serde(default)]
+        include_cursor: bool,
+    },
 }
 
 /// Identifies a pane in a request. Names are user-friendly and stable
@@ -429,5 +448,41 @@ mod tests {
         };
         let parsed: Event = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn inspect_request_roundtrips_with_defaults() {
+        let r = Request::Inspect {
+            target: PaneRef::Focused,
+            lines: None,
+            include_cursor: false,
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn inspect_request_roundtrips_with_lines_and_cursor() {
+        let r = Request::Inspect {
+            target: PaneRef::Name("worker-foo".into()),
+            lines: Some(4),
+            include_cursor: true,
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn inspect_request_accepts_minimal_json() {
+        // `lines` and `include_cursor` default so a minimal
+        // `{cmd: inspect, target: ...}` must still parse.
+        let minimal = r#"{"cmd":"inspect","target":{"focused":null}}"#;
+        let parsed: Request = serde_json::from_str(minimal).unwrap();
+        match parsed {
+            Request::Inspect {
+                target: PaneRef::Focused,
+                lines: None,
+                include_cursor: false,
+            } => {}
+            other => panic!("expected Inspect defaults, got {other:?}"),
+        }
     }
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -416,6 +416,29 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
         // round-tripping through App commands. If we see it here, the
         // handler called us by mistake; refuse rather than hang.
         Request::Subscribe => Response::err("subscribe should be handled inline"),
+        Request::Inspect {
+            target,
+            lines,
+            include_cursor,
+        } => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if command_tx
+                .send(AppCommand::Inspect {
+                    target,
+                    lines,
+                    include_cursor,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return Response::err("app shutting down");
+            }
+            match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+                Ok(Ok(payload)) => Response::ok_value(payload),
+                Ok(Err(msg)) => Response::err(msg),
+                Err(e) => Response::err(format!("app did not respond: {e}")),
+            }
+        }
     }
 }
 
@@ -641,6 +664,63 @@ mod tests {
         );
         handle.join().unwrap();
         assert!(matches!(resp, Response::Ok { .. }));
+    }
+
+    #[test]
+    fn dispatch_inspect_forwards_payload() {
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::Inspect {
+                lines,
+                include_cursor,
+                reply,
+                ..
+            }) = rx.recv()
+            {
+                assert_eq!(lines, Some(3));
+                assert!(include_cursor);
+                let payload = serde_json::json!({
+                    "pane": { "id": 7, "name": "worker-foo" },
+                    "screen": { "rows": 24, "cols": 80, "line_start": 21, "line_count": 3 },
+                    "lines": [
+                        { "row": 21, "text": "" },
+                        { "row": 22, "text": "" },
+                        { "row": 23, "text": "Allow this tool use? (y/n)" },
+                    ],
+                    "text": "\n\nAllow this tool use? (y/n)",
+                    "cursor": { "visible": true, "row": 23, "col": 0 },
+                });
+                reply.send(Ok(payload)).unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::Inspect {
+                target: PaneRef::Name("worker-foo".into()),
+                lines: Some(3),
+                include_cursor: true,
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        match resp {
+            Response::Ok { data } => {
+                assert_eq!(
+                    data.get("pane")
+                        .and_then(|p| p.get("id"))
+                        .and_then(|v| v.as_u64()),
+                    Some(7)
+                );
+                assert_eq!(
+                    data.get("cursor")
+                        .and_then(|c| c.get("visible"))
+                        .and_then(|v| v.as_bool()),
+                    Some(true)
+                );
+                let lines = data.get("lines").and_then(|v| v.as_array()).unwrap();
+                assert_eq!(lines.len(), 3);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
Phase 3 (#32): orchestrator が pane の表示内容を構造化 JSON で取得できる \`ccmux inspect\` を追加。事前の Codex 設計レビューで API 仕様確定。

## 契約
\`\`\`
ccmux inspect [--name NAME | --id ID | --focused] [--lines N] [--cursor]
\`\`\`

Response:
\`\`\`json
{
  \"pane\":   { \"id\": 7, \"name\": \"worker-foo\" },
  \"screen\": { \"rows\": 24, \"cols\": 80, \"line_start\": 21, \"line_count\": 3 },
  \"cursor\": { \"visible\": true, \"row\": 23, \"col\": 0 },
  \"lines\":  [
    { \"row\": 21, \"text\": \"\" },
    { \"row\": 22, \"text\": \"\" },
    { \"row\": 23, \"text\": \"Allow this tool use? (y/n)\" }
  ],
  \"text\": \"\n\nAllow this tool use? (y/n)\"
}
\`\`\`

- \`lines: Some(N)\` = 画面グリッドの下 N 行 (空行保持)、\`None\` = 全画面
- \`cursor\` は \`--cursor\` フラグ時のみ含む
- 各行は trailing space trim、行数と座標は screen-relative (0-based)
- plain text のみ、ANSI 属性なし
- scrollback は scope 外 (Phase 3 では visible screen のみ)

## 主なユースケース (aainc-ops)
- APPROVAL_BLOCKED 検出 (\"Allow this tool use?\" を \`text\` で substring match)
- ERROR 検出 (\"API Error\", \"rate limit\")
- Plan モード mode 切替確認 (ステータスバー行を \`lines[row]\` で pinpoint)

## 実装ポイント
- vt100 Mutex を lock → screen.cell(row, col).contents() で抽出 → unlock → JSON シリアライズ
- \`screen.cursor_position()\` の raw 座標、\`screen.hide_cursor()\` の反転で visibility

## Test coverage (+7、146 → 153 passing)
- CLI parse: default/full/partial フラグ、\`to_request\` マッピング
- IPC serde: roundtrip 2 パターン + minimal JSON
- Server dispatch: AppCommand 受け渡しと Response ペイロード構造

## スコープ外
- \`contents_formatted()\` による ANSI 属性
- scrollback 履歴抽出
- \`ScreenChanged\` event (将来 \`ccmux events\` 拡張)

## 上流還元候補
汎用機能なので \`upstream-pr/pane-inspect\` で Shin-sibainu/ccmux へ PR 検討。

Closes #32
Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)