### PR TITLE
feat(ipc): heartbeat for half-close detection + Err.code field (closes #28)

### DIFF
--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -79,8 +79,11 @@ fn converse(conn: Stream, request: &Request) -> Result<Response> {
         Response::Hello { session_token, .. } => {
             verify_session_token(&session_token, std::env::var(ENV_TOKEN).ok().as_deref())?;
         }
-        Response::Err { message } => {
-            return Err(anyhow!("server refused hello: {message}"));
+        Response::Err { message, code } => {
+            return Err(anyhow!(
+                "server refused hello: {}",
+                fmt_err(&message, &code)
+            ));
         }
         Response::Ok { .. } | Response::Subscribed => {
             return Err(anyhow!("unexpected response to hello"));
@@ -121,8 +124,11 @@ where
         Response::Hello { session_token, .. } => {
             verify_session_token(&session_token, std::env::var(ENV_TOKEN).ok().as_deref())?;
         }
-        Response::Err { message } => {
-            return Err(anyhow!("server refused hello: {message}"));
+        Response::Err { message, code } => {
+            return Err(anyhow!(
+                "server refused hello: {}",
+                fmt_err(&message, &code)
+            ));
         }
         _ => return Err(anyhow!("unexpected response to hello")),
     }
@@ -131,8 +137,8 @@ where
     write_request_line(reader.get_mut(), &Request::Subscribe)?;
     match read_response_line(&mut reader)? {
         Response::Subscribed => {}
-        Response::Err { message } => {
-            return Err(anyhow!("subscribe refused: {message}"));
+        Response::Err { message, code } => {
+            return Err(anyhow!("subscribe refused: {}", fmt_err(&message, &code)));
         }
         other => return Err(anyhow!("unexpected response to subscribe: {other:?}")),
     }
@@ -154,6 +160,15 @@ where
         if !on_event(event) {
             return Ok(());
         }
+    }
+}
+
+/// Render an error `message` plus optional machine-readable `code` as
+/// a single human string. Shell-visible so operators can grep by code.
+fn fmt_err(message: &str, code: &Option<String>) -> String {
+    match code {
+        Some(c) => format!("[{c}] {message}"),
+        None => message.to_string(),
     }
 }
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -155,8 +155,16 @@ where
         if trimmed.is_empty() {
             continue;
         }
-        let event: Event = serde_json::from_str(trimmed)
-            .with_context(|| format!("parse event line: {trimmed:?}"))?;
+        // Forward-compat: skip events whose `type` tag this client
+        // doesn't know about. A future ccmux server may emit new
+        // Event variants, and older subscribers should tolerate them
+        // rather than abort the whole stream. Genuine parse errors on
+        // known variants still propagate to the caller on the next
+        // well-formed line.
+        let event: Event = match serde_json::from_str(trimmed) {
+            Ok(ev) => ev,
+            Err(_) => continue,
+        };
         if !on_event(event) {
             return Ok(());
         }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -158,17 +158,47 @@ where
         // Forward-compat: skip events whose `type` tag this client
         // doesn't know about. A future ccmux server may emit new
         // Event variants, and older subscribers should tolerate them
-        // rather than abort the whole stream. Genuine parse errors on
-        // known variants still propagate to the caller on the next
-        // well-formed line.
-        let event: Event = match serde_json::from_str(trimmed) {
-            Ok(ev) => ev,
-            Err(_) => continue,
-        };
-        if !on_event(event) {
-            return Ok(());
+        // rather than abort the whole stream.
+        //
+        // Narrowly scoped: we first parse to a `Value`, and only the
+        // specific case of "well-formed JSON object with a string
+        // `type` we don't recognize" is dropped silently. Malformed
+        // JSON or shape mismatches on known variants still surface
+        // as errors, because hiding those would make wire bugs
+        // invisible.
+        match serde_json::from_str::<Event>(trimmed) {
+            Ok(event) => {
+                if !on_event(event) {
+                    return Ok(());
+                }
+            }
+            Err(_) => {
+                if is_unknown_event_variant(trimmed) {
+                    continue;
+                }
+                return Err(anyhow!("parse event line: {trimmed:?}"));
+            }
         }
     }
+}
+
+/// True when `line` is valid JSON for an object whose `type` field is
+/// a string but not one of the [`Event`] variants this client knows
+/// about. Only this narrow case is swallowed by the subscribe loop;
+/// malformed JSON or wrong shapes on known variants still surface.
+fn is_unknown_event_variant(line: &str) -> bool {
+    let value: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let ty = match value.get("type").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return false,
+    };
+    !matches!(
+        ty,
+        "pane_started" | "pane_exited" | "events_dropped" | "heartbeat"
+    )
 }
 
 /// Render an error `message` plus optional machine-readable `code` as
@@ -234,6 +264,38 @@ fn read_response_line<R: BufRead>(r: &mut R) -> Result<Response> {
 mod tests {
     use super::*;
     use crate::ipc::{Direction, PaneRef};
+
+    #[test]
+    fn unknown_event_variant_is_detected() {
+        assert!(is_unknown_event_variant(
+            r#"{"type":"pane_renamed","id":1}"#
+        ));
+    }
+
+    #[test]
+    fn known_event_variant_is_not_skipped() {
+        assert!(!is_unknown_event_variant(
+            r#"{"type":"heartbeat","ts_ms":1}"#
+        ));
+        assert!(!is_unknown_event_variant(
+            r#"{"type":"pane_started","id":1,"ts_ms":1}"#
+        ));
+    }
+
+    #[test]
+    fn malformed_json_is_not_classified_as_unknown_variant() {
+        // Broken JSON must surface as an error, not be silently
+        // dropped as "unknown event".
+        assert!(!is_unknown_event_variant(r#"{"type":"heartbeat""#));
+        assert!(!is_unknown_event_variant("not json at all"));
+    }
+
+    #[test]
+    fn value_without_type_field_is_not_classified_as_unknown_variant() {
+        // A JSON object with no `type` is a shape violation on a
+        // known variant, not a forward-compat skip.
+        assert!(!is_unknown_event_variant(r#"{"id":1,"ts_ms":1}"#));
+    }
 
     #[test]
     fn write_request_line_is_newline_terminated() {

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -180,9 +180,34 @@ pub enum Response {
     /// server follows this with newline-delimited [`Event`] records
     /// until the client disconnects.
     Subscribed,
-    /// Server-side failure. `message` is human-readable and not
-    /// machine-parseable; clients should match on `code` if added later.
-    Err { message: String },
+    /// Server-side failure. `message` is human-readable; `code` is a
+    /// stable short identifier for programmatic matching (see the
+    /// `err_code` module). `code` is optional for backwards
+    /// compatibility with clients built against the pre-coded protocol.
+    Err {
+        message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+    },
+}
+
+/// Stable short identifiers for [`Response::Err::code`]. These are
+/// part of the IPC contract — rename with care; new ones can be added
+/// freely. Clients should treat unknown codes as generic errors.
+pub mod err_code {
+    /// The server is shutting down and cannot accept new commands.
+    pub const SHUTTING_DOWN: &str = "shutting_down";
+    /// The App event loop did not respond within the server-side
+    /// budget. Usually means the UI thread is wedged.
+    pub const APP_TIMEOUT: &str = "app_timeout";
+    /// Request JSON failed to parse.
+    pub const PARSE: &str = "parse";
+    /// Protocol violation (wrong message at wrong time, duplicate
+    /// hello, Subscribe reaching the one-shot dispatcher, etc.).
+    pub const PROTOCOL: &str = "protocol";
+    /// A sibling server-side invariant was violated while serializing
+    /// the response payload.
+    pub const INTERNAL: &str = "internal";
 }
 
 /// Server-pushed lifecycle event on a subscribed connection. Emitted
@@ -223,6 +248,12 @@ pub enum Event {
     /// has caused real events to be dropped. `count` is the number of
     /// events discarded since the last delivered event.
     EventsDropped { count: u64, ts_ms: u64 },
+    /// Periodic keep-alive emitted while no real events are in flight.
+    /// Its only purpose is to trigger a wire write so the server can
+    /// detect half-closed connections (client dead but OS buffer still
+    /// accepting). Clients can safely ignore it, or surface it as a
+    /// liveness indicator.
+    Heartbeat { ts_ms: u64 },
 }
 
 impl Response {
@@ -237,6 +268,13 @@ impl Response {
     pub fn err(message: impl Into<String>) -> Self {
         Response::Err {
             message: message.into(),
+            code: None,
+        }
+    }
+    pub fn err_coded(code: &'static str, message: impl Into<String>) -> Self {
+        Response::Err {
+            message: message.into(),
+            code: Some(code.to_string()),
         }
     }
 }
@@ -438,6 +476,46 @@ mod tests {
         let s = serde_json::to_string(&ev).unwrap();
         assert!(!s.contains("\"name\""), "should omit name: {s}");
         assert!(!s.contains("\"role\""), "should omit role: {s}");
+    }
+
+    #[test]
+    fn heartbeat_event_roundtrips() {
+        let ev = Event::Heartbeat { ts_ms: 123 };
+        let parsed: Event = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn response_err_code_is_omitted_when_none() {
+        let r = Response::err("plain");
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(!s.contains("\"code\""), "should omit code: {s}");
+    }
+
+    #[test]
+    fn response_err_coded_roundtrips() {
+        let r = Response::err_coded(err_code::PROTOCOL, "boom");
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"code\""), "{s}");
+        assert!(s.contains("protocol"), "{s}");
+        let parsed: Response = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn response_err_without_code_parses_into_none() {
+        // Pre-coded-protocol clients / servers don't emit `code` at
+        // all. Confirm we round-trip their payload into Err.code = None
+        // without rejecting the message.
+        let legacy = r#"{"status":"err","message":"older peer"}"#;
+        let parsed: Response = serde_json::from_str(legacy).unwrap();
+        match parsed {
+            Response::Err { message, code } => {
+                assert_eq!(message, "older peer");
+                assert_eq!(code, None);
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -191,9 +191,28 @@ pub enum Response {
     },
 }
 
-/// Stable short identifiers for [`Response::Err::code`]. These are
-/// part of the IPC contract — rename with care; new ones can be added
-/// freely. Clients should treat unknown codes as generic errors.
+/// Stable short identifiers for [`Response::Err::code`].
+///
+/// # Stability
+///
+/// These string values are **wire ABI**, not internal symbols.
+/// Changing an existing constant's value is a breaking protocol
+/// change and requires a deprecation window:
+///
+/// 1. Introduce the new code alongside the old one (both servers emit
+///    the old value; old clients keep matching).
+/// 2. Flip servers to emit the new value in the next minor release,
+///    keeping the old constant exported so clients still build.
+/// 3. Remove the old constant only after external clients (including
+///    `aainc-ops`) have migrated.
+///
+/// Adding a new code is additive and safe — clients must treat
+/// unknown codes as generic errors (fall back to `message`).
+///
+/// Heartbeat events (`Event::Heartbeat`) follow the same rule: new
+/// event variants are additive, and clients skip unknown `type`
+/// tags instead of aborting the stream (see
+/// [`crate::ipc::client::subscribe_events`]).
 pub mod err_code {
     /// The server is shutting down and cannot accept new commands.
     pub const SHUTTING_DOWN: &str = "shutting_down";

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -300,13 +300,25 @@ fn handle_connection(
 /// slot until the next pane lifecycle event — which may be hours
 /// away on a quiet session.
 fn stream_events(
-    mut conn: Stream,
+    conn: Stream,
     event_bus: EventBus,
     sub_id: super::events::SubId,
     rx: std::sync::mpsc::Receiver<super::Event>,
 ) -> Result<()> {
+    stream_events_inner(conn, rx, HEARTBEAT_INTERVAL);
+    event_bus.unsubscribe(sub_id);
+    Ok(())
+}
+
+/// Inner loop split out so tests can drive it with a `Vec<u8>` sink
+/// and a sub-second interval.
+fn stream_events_inner<W: Write>(
+    mut sink: W,
+    rx: std::sync::mpsc::Receiver<super::Event>,
+    heartbeat_interval: Duration,
+) {
     loop {
-        let event = match rx.recv_timeout(HEARTBEAT_INTERVAL) {
+        let event = match rx.recv_timeout(heartbeat_interval) {
             Ok(ev) => ev,
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Event::Heartbeat {
                 ts_ms: now_ms_ipc(),
@@ -318,12 +330,10 @@ fn stream_events(
             Err(_) => continue,
         };
         json.push('\n');
-        if conn.write_all(json.as_bytes()).is_err() || conn.flush().is_err() {
+        if sink.write_all(json.as_bytes()).is_err() || sink.flush().is_err() {
             break;
         }
     }
-    event_bus.unsubscribe(sub_id);
-    Ok(())
 }
 
 /// How often the subscribe stream emits a keep-alive when idle.
@@ -491,12 +501,15 @@ fn forward_unit(
 ) -> Response {
     let (reply_tx, reply_rx) = oneshot::channel();
     if command_tx.send(build(reply_tx)).is_err() {
-        return Response::err("app shutting down");
+        return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
     }
     match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
         Ok(Ok(_)) => Response::ok_unit(),
+        // App-originated error strings pass through uncoded for now —
+        // plumbing a stable code through AppCommand replies is a
+        // follow-up (see Issue #28 non-goals).
         Ok(Err(msg)) => Response::err(msg),
-        Err(e) => Response::err(format!("app did not respond: {e}")),
+        Err(e) => Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}")),
     }
 }
 
@@ -648,6 +661,48 @@ mod tests {
             }
             other => panic!("expected Ok, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn forward_unit_shutting_down_is_coded() {
+        // Drop the receiver to simulate the App having shut down; the
+        // send should fail and the error must carry the SHUTTING_DOWN
+        // code, not just a free-form message.
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        drop(rx);
+        let resp = dispatch_request(
+            Request::Focus {
+                target: PaneRef::Focused,
+            },
+            &tx,
+        );
+        match resp {
+            Response::Err { code, .. } => {
+                assert_eq!(code.as_deref(), Some(err_code::SHUTTING_DOWN))
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_events_emits_heartbeat_when_idle() {
+        use std::io::Cursor;
+        use std::sync::mpsc as m;
+        let (tx, rx) = m::channel::<Event>();
+        // Run the inner loop on a worker with a short heartbeat
+        // interval; after ~150 ms at 50 ms interval we expect at
+        // least one heartbeat line. Dropping the sender ends the
+        // loop so we can join and inspect the collected bytes.
+        let handle = thread::spawn(move || {
+            let mut sink = Cursor::new(Vec::<u8>::new());
+            stream_events_inner(&mut sink, rx, Duration::from_millis(50));
+            sink.into_inner()
+        });
+        thread::sleep(Duration::from_millis(150));
+        drop(tx);
+        let bytes = handle.join().unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains("\"heartbeat\""), "no heartbeat in {text:?}");
     }
 
     #[test]

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -29,7 +29,7 @@ use interprocess::local_socket::{prelude::*, ListenerOptions, Stream};
 
 use super::endpoint::{EndpointKind, EndpointName};
 use super::events::EventBus;
-use super::{Request, Response, APP_REPLY_TIMEOUT};
+use super::{err_code, Event, Request, Response, APP_REPLY_TIMEOUT};
 use crate::app::AppCommand;
 
 /// Upper bound for waiting on the accept thread during shutdown.
@@ -232,7 +232,7 @@ fn handle_connection(
         Err(e) => {
             return write_response_line(
                 reader.get_mut(),
-                &Response::err(format!("parse error on hello: {e}")),
+                &Response::err_coded(err_code::PARSE, format!("parse error on hello: {e}")),
             );
         }
     };
@@ -247,7 +247,7 @@ fn handle_connection(
         _ => {
             write_response_line(
                 reader.get_mut(),
-                &Response::err("first message must be hello"),
+                &Response::err_coded(err_code::PROTOCOL, "first message must be hello"),
             )?;
             return Ok(());
         }
@@ -263,7 +263,7 @@ fn handle_connection(
         Err(e) => {
             return write_response_line(
                 reader.get_mut(),
-                &Response::err(format!("parse error: {e}")),
+                &Response::err_coded(err_code::PARSE, format!("parse error: {e}")),
             );
         }
     };
@@ -291,16 +291,28 @@ fn handle_connection(
 /// registered by `handle_connection` before the Subscribed ack was
 /// written, so any event observed from here on is part of the
 /// post-ack stream the client can rely on.
+///
+/// If no real event shows up within [`HEARTBEAT_INTERVAL`], the loop
+/// wakes up and writes a [`Event::Heartbeat`] to the wire. Its only
+/// purpose is to force an I/O write: if the peer's read side is dead
+/// (half-close) and the OS send buffer has filled, the write fails
+/// and we unsubscribe promptly instead of holding a stale subscriber
+/// slot until the next pane lifecycle event — which may be hours
+/// away on a quiet session.
 fn stream_events(
     mut conn: Stream,
     event_bus: EventBus,
     sub_id: super::events::SubId,
     rx: std::sync::mpsc::Receiver<super::Event>,
 ) -> Result<()> {
-    // The recv loop is bounded only by the connection's lifetime.
-    // The client can stop the stream by closing the socket, which
-    // makes the next write fail and we bail out.
-    while let Ok(event) = rx.recv() {
+    loop {
+        let event = match rx.recv_timeout(HEARTBEAT_INTERVAL) {
+            Ok(ev) => ev,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Event::Heartbeat {
+                ts_ms: now_ms_ipc(),
+            },
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        };
         let mut json = match serde_json::to_string(&event) {
             Ok(s) => s,
             Err(_) => continue,
@@ -312,6 +324,20 @@ fn stream_events(
     }
     event_bus.unsubscribe(sub_id);
     Ok(())
+}
+
+/// How often the subscribe stream emits a keep-alive when idle.
+/// 30 s is short enough that a dropped client is released from the
+/// subscriber table before it matters, and long enough that chatty
+/// heartbeat noise in logs stays negligible.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+fn now_ms_ipc() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 fn read_line_or_eof<R: BufRead>(reader: &mut R, buf: &mut String) -> Result<Option<()>> {
@@ -329,21 +355,27 @@ fn write_response_line<W: Write>(w: &mut W, resp: &Response) -> Result<()> {
 
 fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
     match req {
-        Request::Hello { .. } => Response::err("unexpected duplicate hello"),
+        Request::Hello { .. } => {
+            Response::err_coded(err_code::PROTOCOL, "unexpected duplicate hello")
+        }
         Request::List => {
             let (reply_tx, reply_rx) = oneshot::channel();
             if command_tx
                 .send(AppCommand::List { reply: reply_tx })
                 .is_err()
             {
-                return Response::err("app shutting down");
+                return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(list) => match serde_json::to_value(&list) {
                     Ok(v) => Response::ok_value(v),
-                    Err(e) => Response::err(format!("serialize pane list: {e}")),
+                    Err(e) => {
+                        Response::err_coded(err_code::INTERNAL, format!("serialize pane list: {e}"))
+                    }
                 },
-                Err(e) => Response::err(format!("app did not respond: {e}")),
+                Err(e) => {
+                    Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
+                }
             }
         }
         Request::Send {
@@ -378,12 +410,14 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
                 })
                 .is_err()
             {
-                return Response::err("app shutting down");
+                return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(Ok(new_id)) => Response::ok_value(serde_json::json!({ "id": new_id })),
                 Ok(Err(msg)) => Response::err(msg),
-                Err(e) => Response::err(format!("app did not respond: {e}")),
+                Err(e) => {
+                    Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
+                }
             }
         }
         Request::NewTab {
@@ -403,19 +437,23 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
                 })
                 .is_err()
             {
-                return Response::err("app shutting down");
+                return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(Ok(new_id)) => Response::ok_value(serde_json::json!({ "id": new_id })),
                 Ok(Err(msg)) => Response::err(msg),
-                Err(e) => Response::err(format!("app did not respond: {e}")),
+                Err(e) => {
+                    Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
+                }
             }
         }
         // Subscribe is handled by the connection handler directly — it
         // switches the wire into event-stream mode rather than
         // round-tripping through App commands. If we see it here, the
         // handler called us by mistake; refuse rather than hang.
-        Request::Subscribe => Response::err("subscribe should be handled inline"),
+        Request::Subscribe => {
+            Response::err_coded(err_code::PROTOCOL, "subscribe should be handled inline")
+        }
         Request::Inspect {
             target,
             lines,
@@ -431,12 +469,14 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
                 })
                 .is_err()
             {
-                return Response::err("app shutting down");
+                return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(Ok(payload)) => Response::ok_value(payload),
                 Ok(Err(msg)) => Response::err(msg),
-                Err(e) => Response::err(format!("app did not respond: {e}")),
+                Err(e) => {
+                    Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
+                }
             }
         }
     }
@@ -524,7 +564,7 @@ mod tests {
         );
         handle.join().unwrap();
         match resp {
-            Response::Err { message } => assert!(message.contains("pane not found")),
+            Response::Err { message, .. } => assert!(message.contains("pane not found")),
             other => panic!("expected Err, got {other:?}"),
         }
     }
@@ -616,7 +656,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<AppCommand>();
         let resp = dispatch_request(Request::Hello { client_pid: 1 }, &tx);
         match resp {
-            Response::Err { message } => assert!(message.contains("hello")),
+            Response::Err { message, .. } => assert!(message.contains("hello")),
             other => panic!("expected Err, got {other:?}"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,13 @@ fn run_ipc_client(cmd: &cli::IpcCommand) -> Result<()> {
             // These are handshake replies, never command responses.
             Err(anyhow::anyhow!("unexpected control response to command"))
         }
-        ipc::Response::Err { message } => Err(anyhow::anyhow!("{message}")),
+        ipc::Response::Err { message, code } => {
+            if let Some(c) = code {
+                Err(anyhow::anyhow!("[{c}] {message}"))
+            } else {
+                Err(anyhow::anyhow!("{message}"))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Issue #28 で追跡していた PR #27 Codex レビューの Should-fix 2 件を解消。

### 1. Half-close 遅延検知 — heartbeat 方式
`stream_events` が `recv_timeout(30s)` で待機し、実イベントがない間は `Event::Heartbeat { ts_ms }` を wire に書き出す。クライアントが read 側を閉じたまま OS の送信バッファが埋まるケースで、次の書き込み失敗を能動的に引き起こして subscriber テーブルを早期に解放する。

- 30 秒間隔は「quiet な workspace でも subscriber が長時間残らない」vs「ログノイズを最小限に」のバランス
- クライアントは `Event::Heartbeat` を無視しても liveness indicator として使ってもよい

### 2. Machine-readable error codes
`Response::Err` に `code: Option<String>` を追加 (`#[serde(default, skip_serializing_if)]` で後方互換)。ccmux サーバー側で発行される以下の定型エラーにコードを付与:

- \`shutting_down\` — app shutting down
- \`app_timeout\` — app did not respond
- \`parse\` — JSON parse error
- \`protocol\` — duplicate hello / wrong ordering / Subscribe が dispatch_request に到達した等
- \`internal\` — サーバー内部のシリアライズ失敗

クライアント側は `fmt_err` で `[code] message` 形式に整形して表示。

## スコープ外 (follow-up)
App 由来のエラー (`Ok(Err(msg))` from oneshot reply, 例: pane not found) は今回コード化していない。AppCommand reply 型に `Result<T, CodedError>` を通す別 PR で対応する。

## Test plan
- [x] 既存 test 全通 (157 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` 緑
- [x] \`cargo fmt\` 適用済
- [x] 新規 test: heartbeat event round-trip, Err code omit when None, coded err round-trip, legacy Err without code parses to None
- [ ] CI 3 プラットフォーム

Refs #28, #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)