### PR TITLE
feat(ipc): code App-originated errors (closes #43)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,12 +28,12 @@ pub enum AppCommand {
         target: PaneRef,
         data: Vec<u8>,
         append_enter: bool,
-        reply: oneshot::Sender<std::result::Result<(), String>>,
+        reply: oneshot::Sender<std::result::Result<(), ipc::CodedError>>,
     },
     /// Move keyboard focus to the target pane in the active workspace.
     Focus {
         target: PaneRef,
-        reply: oneshot::Sender<std::result::Result<(), String>>,
+        reply: oneshot::Sender<std::result::Result<(), ipc::CodedError>>,
     },
     /// Split the target pane. If `command` is given, it's queued on the
     /// new pane and flushed when its shell prompt appears. If `name` is
@@ -45,7 +45,7 @@ pub enum AppCommand {
         command: Option<String>,
         name: Option<String>,
         role: Option<String>,
-        reply: oneshot::Sender<std::result::Result<usize, String>>,
+        reply: oneshot::Sender<std::result::Result<usize, ipc::CodedError>>,
     },
     /// Open a new tab with a fresh single pane. Focus switches to the
     /// new tab (mirrors the Alt+T keybinding). Returns the new pane's
@@ -55,7 +55,7 @@ pub enum AppCommand {
         name: Option<String>,
         label: Option<String>,
         role: Option<String>,
-        reply: oneshot::Sender<std::result::Result<usize, String>>,
+        reply: oneshot::Sender<std::result::Result<usize, ipc::CodedError>>,
     },
     /// Snapshot the visible screen of the target pane. See
     /// [`ipc::Request::Inspect`] for the response shape.
@@ -63,7 +63,7 @@ pub enum AppCommand {
         target: PaneRef,
         lines: Option<usize>,
         include_cursor: bool,
-        reply: oneshot::Sender<std::result::Result<serde_json::Value, String>>,
+        reply: oneshot::Sender<std::result::Result<serde_json::Value, ipc::CodedError>>,
     },
 }
 
@@ -2558,15 +2558,18 @@ impl App {
         target: &PaneRef,
         lines: Option<usize>,
         include_cursor: bool,
-    ) -> std::result::Result<serde_json::Value, String> {
+    ) -> std::result::Result<serde_json::Value, ipc::CodedError> {
         let ws = self.ws();
-        let pane_id = ws
-            .resolve_pane_ref(target)
-            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+        let pane_id = ws.resolve_pane_ref(target).ok_or_else(|| {
+            ipc::CodedError::new(
+                ipc::err_code::PANE_NOT_FOUND,
+                format!("pane not found: {target:?}"),
+            )
+        })?;
         let pane = ws
             .panes
             .get(&pane_id)
-            .ok_or_else(|| "pane vanished".to_string())?;
+            .ok_or_else(|| ipc::CodedError::new(ipc::err_code::PANE_VANISHED, "pane vanished"))?;
 
         let pane_name = ws
             .pane_names
@@ -2577,10 +2580,9 @@ impl App {
         // Snapshot the vt100 state under the lock, release it before
         // JSON serialization.
         let (rows, cols, line_start, line_count, collected, cursor) = {
-            let parser = pane
-                .parser
-                .lock()
-                .map_err(|_| "vt100 parser lock poisoned".to_string())?;
+            let parser = pane.parser.lock().map_err(|_| {
+                ipc::CodedError::new(ipc::err_code::INTERNAL, "vt100 parser lock poisoned")
+            })?;
             let screen = parser.screen();
             let size = screen.size();
             let total_rows = size.0 as usize;
@@ -2668,12 +2670,13 @@ impl App {
         name: Option<String>,
         label: Option<String>,
         role: Option<String>,
-    ) -> std::result::Result<usize, String> {
+    ) -> std::result::Result<usize, ipc::CodedError> {
         // Delegate to the existing keybinding-driven new_tab so we
         // don't drift from the interactive behavior (pane id bookkeeping,
         // active_tab update, cwd inheritance). The freshly-created tab
         // becomes the active one, so `ws_mut()` points at it.
-        self.new_tab().map_err(|e| e.to_string())?;
+        self.new_tab()
+            .map_err(|e| ipc::CodedError::new(ipc::err_code::IO_ERROR, e.to_string()))?;
         let new_pane_id = self.ws().focused_pane_id;
         if let Some(pane) = self.ws_mut().panes.get_mut(&new_pane_id) {
             if let Some(cmd) = command {
@@ -2702,29 +2705,34 @@ impl App {
         target: &PaneRef,
         data: &[u8],
         append_enter: bool,
-    ) -> std::result::Result<(), String> {
-        let pane_id = self
-            .ws()
-            .resolve_pane_ref(target)
-            .ok_or_else(|| format!("pane not found: {target:?}"))?;
-        let pane = self
-            .ws_mut()
-            .panes
-            .get_mut(&pane_id)
-            .ok_or_else(|| "pane vanished".to_string())?;
-        pane.write_input(data).map_err(|e| e.to_string())?;
+    ) -> std::result::Result<(), ipc::CodedError> {
+        let pane_id = self.ws().resolve_pane_ref(target).ok_or_else(|| {
+            ipc::CodedError::new(
+                ipc::err_code::PANE_NOT_FOUND,
+                format!("pane not found: {target:?}"),
+            )
+        })?;
+        let pane =
+            self.ws_mut().panes.get_mut(&pane_id).ok_or_else(|| {
+                ipc::CodedError::new(ipc::err_code::PANE_VANISHED, "pane vanished")
+            })?;
+        pane.write_input(data)
+            .map_err(|e| ipc::CodedError::new(ipc::err_code::IO_ERROR, e.to_string()))?;
         if append_enter {
-            pane.write_input(b"\r").map_err(|e| e.to_string())?;
+            pane.write_input(b"\r")
+                .map_err(|e| ipc::CodedError::new(ipc::err_code::IO_ERROR, e.to_string()))?;
         }
         self.dirty = true;
         Ok(())
     }
 
-    fn handle_focus(&mut self, target: &PaneRef) -> std::result::Result<(), String> {
-        let pane_id = self
-            .ws()
-            .resolve_pane_ref(target)
-            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+    fn handle_focus(&mut self, target: &PaneRef) -> std::result::Result<(), ipc::CodedError> {
+        let pane_id = self.ws().resolve_pane_ref(target).ok_or_else(|| {
+            ipc::CodedError::new(
+                ipc::err_code::PANE_NOT_FOUND,
+                format!("pane not found: {target:?}"),
+            )
+        })?;
         let ws = self.ws_mut();
         ws.focused_pane_id = pane_id;
         ws.focus_target = FocusTarget::Pane;
@@ -2739,11 +2747,13 @@ impl App {
         command: Option<String>,
         name: Option<String>,
         role: Option<String>,
-    ) -> std::result::Result<usize, String> {
-        let target_pane_id = self
-            .ws()
-            .resolve_pane_ref(target)
-            .ok_or_else(|| format!("pane not found: {target:?}"))?;
+    ) -> std::result::Result<usize, ipc::CodedError> {
+        let target_pane_id = self.ws().resolve_pane_ref(target).ok_or_else(|| {
+            ipc::CodedError::new(
+                ipc::err_code::PANE_NOT_FOUND,
+                format!("pane not found: {target:?}"),
+            )
+        })?;
         let prev_focus = self.ws().focused_pane_id;
         self.ws_mut().focused_pane_id = target_pane_id;
         let split_dir = match direction {
@@ -2751,14 +2761,17 @@ impl App {
             ipc::Direction::Horizontal => SplitDirection::Horizontal,
         };
         self.split_focused_pane(split_dir)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| ipc::CodedError::new(ipc::err_code::IO_ERROR, e.to_string()))?;
         let new_pane_id = self.ws().focused_pane_id;
         // split_focused_pane is a no-op (keeps focus) when the pane is
         // too small or the workspace is already at MAX_PANES; detect
         // that by checking whether focus actually advanced.
         if new_pane_id == target_pane_id {
             self.ws_mut().focused_pane_id = prev_focus;
-            return Err("split refused (max panes reached or pane too small)".to_string());
+            return Err(ipc::CodedError::new(
+                ipc::err_code::SPLIT_REFUSED,
+                "split refused (max panes reached or pane too small)",
+            ));
         }
         if let Some(pane) = self.ws_mut().panes.get_mut(&new_pane_id) {
             if let Some(cmd) = command {

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -227,6 +227,82 @@ pub mod err_code {
     /// A sibling server-side invariant was violated while serializing
     /// the response payload.
     pub const INTERNAL: &str = "internal";
+    /// The referenced pane (by id, name, or Focused) does not exist
+    /// in the active workspace.
+    pub const PANE_NOT_FOUND: &str = "pane_not_found";
+    /// A pane id resolved on lookup but disappeared before the App
+    /// could act on it (close / exit race). Rare.
+    pub const PANE_VANISHED: &str = "pane_vanished";
+    /// The workspace cannot accept another split — either the
+    /// MAX_PANES cap is reached or the target pane is already at
+    /// the minimum geometry.
+    pub const SPLIT_REFUSED: &str = "split_refused";
+    /// PTY write / spawn / OS-level I/O failure surfaced to the
+    /// client so it can distinguish "setup broken" from "request
+    /// invalid".
+    pub const IO_ERROR: &str = "io_error";
+}
+
+/// App-side error carrying a free-form message plus an optional
+/// stable code from [`err_code`]. Replaces the previous
+/// `Result<T, String>` reply shape on [`crate::app::AppCommand`] so
+/// ccmux clients (including `aainc-ops`) can match on the code
+/// instead of grepping human-readable text.
+///
+/// Uncoded variants still work — older App paths or new cases that
+/// don't warrant a stable code yet can call
+/// [`CodedError::uncoded`], and the wire response still carries the
+/// message so humans can read it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodedError {
+    pub message: String,
+    pub code: Option<&'static str>,
+}
+
+impl CodedError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: Some(code),
+        }
+    }
+
+    pub fn uncoded(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: None,
+        }
+    }
+
+    /// Convert into a wire [`Response::Err`], preserving the code
+    /// when present.
+    pub fn into_response(self) -> Response {
+        match self.code {
+            Some(c) => Response::err_coded(c, self.message),
+            None => Response::err(self.message),
+        }
+    }
+}
+
+impl std::fmt::Display for CodedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.code {
+            Some(c) => write!(f, "[{c}] {}", self.message),
+            None => f.write_str(&self.message),
+        }
+    }
+}
+
+impl From<String> for CodedError {
+    fn from(s: String) -> Self {
+        CodedError::uncoded(s)
+    }
+}
+
+impl From<&str> for CodedError {
+    fn from(s: &str) -> Self {
+        CodedError::uncoded(s.to_string())
+    }
 }
 
 /// Server-pushed lifecycle event on a subscribed connection. Emitted

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -614,7 +614,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn coded_error_display_includes_code_prefix() {
         let e = CodedError::new(err_code::PANE_NOT_FOUND, "pane not found: Id(3)");
         let s = e.to_string();

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -614,6 +614,59 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn coded_error_display_includes_code_prefix() {
+        let e = CodedError::new(err_code::PANE_NOT_FOUND, "pane not found: Id(3)");
+        let s = e.to_string();
+        assert!(s.contains("[pane_not_found]"), "{s}");
+        assert!(s.contains("pane not found"), "{s}");
+    }
+
+    #[test]
+    fn coded_error_uncoded_display_has_no_prefix() {
+        let e = CodedError::uncoded("plain message");
+        assert_eq!(e.to_string(), "plain message");
+    }
+
+    #[test]
+    fn coded_error_from_string_is_uncoded() {
+        let e: CodedError = String::from("boom").into();
+        assert_eq!(e.code, None);
+        assert_eq!(e.message, "boom");
+    }
+
+    #[test]
+    fn coded_error_from_str_is_uncoded() {
+        let e: CodedError = "boom".into();
+        assert_eq!(e.code, None);
+        assert_eq!(e.message, "boom");
+    }
+
+    #[test]
+    fn coded_error_into_response_preserves_code() {
+        let e = CodedError::new(err_code::SPLIT_REFUSED, "too small");
+        match e.into_response() {
+            Response::Err { message, code } => {
+                assert_eq!(message, "too small");
+                assert_eq!(code.as_deref(), Some(err_code::SPLIT_REFUSED));
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coded_error_into_response_omits_missing_code() {
+        let e = CodedError::uncoded("no code");
+        match e.into_response() {
+            Response::Err { message, code } => {
+                assert_eq!(message, "no code");
+                assert_eq!(code, None);
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn events_dropped_meta_event_roundtrips() {
         let ev = Event::EventsDropped {
             count: 17,

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -424,7 +424,7 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(Ok(new_id)) => Response::ok_value(serde_json::json!({ "id": new_id })),
-                Ok(Err(msg)) => Response::err(msg),
+                Ok(Err(err)) => err.into_response(),
                 Err(e) => {
                     Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
                 }
@@ -451,7 +451,7 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(Ok(new_id)) => Response::ok_value(serde_json::json!({ "id": new_id })),
-                Ok(Err(msg)) => Response::err(msg),
+                Ok(Err(err)) => err.into_response(),
                 Err(e) => {
                     Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
                 }
@@ -483,7 +483,7 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
             }
             match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
                 Ok(Ok(payload)) => Response::ok_value(payload),
-                Ok(Err(msg)) => Response::err(msg),
+                Ok(Err(err)) => err.into_response(),
                 Err(e) => {
                     Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
                 }
@@ -497,7 +497,7 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
 /// variants share this exact shape.
 fn forward_unit(
     command_tx: &Sender<AppCommand>,
-    build: impl FnOnce(oneshot::Sender<std::result::Result<(), String>>) -> AppCommand,
+    build: impl FnOnce(oneshot::Sender<std::result::Result<(), super::CodedError>>) -> AppCommand,
 ) -> Response {
     let (reply_tx, reply_rx) = oneshot::channel();
     if command_tx.send(build(reply_tx)).is_err() {
@@ -508,7 +508,7 @@ fn forward_unit(
         // App-originated error strings pass through uncoded for now —
         // plumbing a stable code through AppCommand replies is a
         // follow-up (see Issue #28 non-goals).
-        Ok(Err(msg)) => Response::err(msg),
+        Ok(Err(err)) => err.into_response(),
         Err(e) => Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}")),
     }
 }
@@ -559,6 +559,41 @@ mod tests {
         );
         handle.join().unwrap();
         assert!(matches!(resp, Response::Ok { .. }));
+    }
+
+    #[test]
+    fn dispatch_focus_routes_app_coded_error_to_wire() {
+        // When the App reply carries a code (new behavior on the
+        // AppCommand reply type), the wire Response::Err must
+        // surface that same code so clients can match on it.
+        let (tx, rx) = mpsc::channel::<AppCommand>();
+        let handle = thread::spawn(move || {
+            if let Ok(AppCommand::Focus { reply, .. }) = rx.recv() {
+                reply
+                    .send(Err(super::super::CodedError::new(
+                        super::super::err_code::PANE_NOT_FOUND,
+                        "pane not found: Id(999)",
+                    )))
+                    .unwrap();
+            }
+        });
+        let resp = dispatch_request(
+            Request::Focus {
+                target: PaneRef::Id(999),
+            },
+            &tx,
+        );
+        handle.join().unwrap();
+        match resp {
+            Response::Err { message, code } => {
+                assert!(message.contains("pane not found"));
+                assert_eq!(
+                    code.as_deref(),
+                    Some(super::super::err_code::PANE_NOT_FOUND)
+                );
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Issue #43 対応。PR #42 でサーバー層のエラーには code を付与したが、App 由来 (`Ok(Err(msg))`) はまだ free-form String のままだった。aainc-ops 等のクライアントが \"pane not found\" substring match で分岐する fragile な状態を解消する。

## 変更内容

### 新規 \`ipc::CodedError\`
```rust
pub struct CodedError {
    pub message: String,
    pub code: Option<&'static str>,
}
```

- \`AppCommand\` の \`reply: Result<T, String>\` を \`Result<T, CodedError>\` に変更
- \`handle_send\` / \`handle_focus\` / \`handle_split\` / \`handle_new_tab\` / \`handle_inspect\` が適切な code を付与
- \`From<String>\` / \`From<&str>\` impl で既存テストの \`.into()\` は uncoded として互換維持

### 追加 error code
| Code | 用途 |
|---|---|
| \`pane_not_found\` | 指定 pane (id/name/Focused) が存在しない |
| \`pane_vanished\` | resolve 成功後に消えたレース |
| \`split_refused\` | MAX_PANES 到達 / pane too small |
| \`io_error\` | PTY write / spawn / OS レベル失敗 |
| \`internal\` | parser lock poison 等 (既存) |

### server.rs ルーティング
\`Ok(Err(err)) => err.into_response()\` で CodedError をそのまま wire に反映。

## Test plan
- [x] cargo test: 200 passed (+1 new: \`dispatch_focus_routes_app_coded_error_to_wire\`)
- [x] cargo clippy --all-targets -- -D warnings: clean
- [x] cargo fmt: applied
- [x] 既存の \`dispatch_focus_err_when_app_replies_err\` は From<&str> 経由で uncoded のまま互換
- [ ] CI 3 プラットフォーム

## Backward compatibility
- Wire protocol: `Response::Err.code` は PR #42 以降 Some のケース既に実装済み。今回 App 由来 も Some で来るようになるだけ → 古いクライアントは code を無視するので影響なし
- aainc-ops: 現状 substring match は引き続き機能。将来 code ベースに切替える時の下地

## Non-goals
- aainc-ops 側の code ベース切替 → 別リポで対応
- 個別 App 動作のエラー可視化改善 (例: CLI コマンドなど) → 必要なら別 Issue

Refs #43, #42, #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)