### PR TITLE
chore: bump version to 0.5.7-fork.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.6-fork.1"
+version = "0.5.7-fork.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccmux"
-version = "0.5.6-fork.1"
+version = "0.5.7-fork.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.6-fork.1",
+  "version": "0.5.7-fork.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
次リリース v0.5.7-fork.1 のバージョン bump。

Cargo.toml / npm/package.json / Cargo.lock を同期。

## Release highlights (0.5.6-fork.1 → 0.5.7-fork.1)

### IPC
- \`ccmux events --timeout/--count\` 追加 (#31)
- \`ccmux inspect\` pane screen snapshot API (#33)
- Subscribe ストリームに 30 秒間隔の Heartbeat 追加、half-close 検知 (#42)
- \`Response::Err.code\` wire ABI + err_code module (#42, #46)
- App 由来エラーも coded に移行 (pane_not_found / split_refused / io_error 他) (#46)
- Subscribe 側 unknown event variant の forward-compat skip (#42)

### IME
- Composition overlay (Phase 4b PoC), Ctrl+; で起動 (#36)
- \`[ime]\` config section + \`--ime\` CLI flag (hotkey | off) (#39, #44)
- always モード (focus-triggered persistent overlay, JP IME 対応) (#40, #45)
- Windows Terminal / conpty の caret flicker 回避

### aainc-ops 連携 (外部リポ)
- \`.foreman/CLAUDE.md\` に code ベース error handling + Heartbeat ガイド追加 (happy-ryo/aainc-ops#5)
- ccmux 0.5.7+ が前提の Foreman 運用ドキュメント整備完了

## Release process
このマージ後:
1. \`git tag v0.5.7-fork.1 && git push origin v0.5.7-fork.1\`
2. CI が自動で: 4 プラットフォーム release build / GitHub Release / npm publish (trusted publishing)

## Test plan
- [x] cargo build --release
- [x] Cargo.lock 更新済み
- [ ] CI 3 プラットフォーム