### PR TITLE
docs: codify upstream-PR opt-in policy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,5 +45,7 @@ cargo run            # Run the app
 ## Fork & Branching
 このリポジトリは `Shin-sibainu/ccmux` のフォーク。ブランチ運用 (main = 独自本流 / master = 上流ミラー) と上流同期手順は `BRANCHING.md` を参照。上流取り込みや逆 PR の作業時は `.claude/skills/upstream-sync/` Skill が自動発動する。
 
+**上流への逆 PR はユーザーからの明示的な指示がない限り提案・実行しない。** フォークで実装した機能について「汎用性があるので上流還元候補」といったラベルを umbrella Issue に残すのは OK だが、タスクの次候補として「upstream PR を出す」を勝手に積まない。上流の受け入れタイミングに依存して進捗が止まるのを避けるため、フォーク内の独自開発に集中する方針。
+
 ## Workflow Rules
 - **Every implementation must be reviewed by the evaluator agent** before reporting done. This is a Rust TUI app, so Playwright MCP is not available — the evaluator should perform static review (diff analysis, edge cases, logic correctness, key conflict checks, layout math consistency).


### PR DESCRIPTION
## Summary
個人のローカルメモリに留めていた "上流 (Shin-sibainu/ccmux) への逆 PR は明示指示がない限り提案・実行しない" 方針を CLAUDE.md に明文化。

これで:
- 別マシンで clone した時に同じ方針が引き継がれる
- 新規 Claude セッションが最初からこのルールを参照できる
- 共同作業者 (将来) にも可視化される

## Changes
- \`CLAUDE.md\` の Fork & Branching セクションに 1 パラグラフ追記

## Why CLAUDE.md
メモリはローカルパス依存 (\`~/.claude/projects/C--Users-iwama-Documents-work-ccmux/\`) なので、別 clone 先では失われる。リポジトリ方針はコミット対象にすべき。

No code change.