### PR TITLE
feat: forward mouse wheel to PTY in alt-screen panes (closes #52)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2218,82 +2218,8 @@ impl App {
                     // Keep selection visible until next click
                 }
             }
-            MouseEventKind::ScrollUp => {
-                let col = mouse.column;
-                let row = mouse.row;
-
-                if let Some(rect) = self.ws().last_file_tree_rect {
-                    if col >= rect.x
-                        && col < rect.x + rect.width
-                        && row >= rect.y
-                        && row < rect.y + rect.height
-                    {
-                        self.ws_mut().file_tree.scroll_up(3);
-                        return;
-                    }
-                }
-                if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x
-                        && col < rect.x + rect.width
-                        && row >= rect.y
-                        && row < rect.y + rect.height
-                    {
-                        self.ws_mut().preview.scroll_up(3);
-                        return;
-                    }
-                }
-                let pane_rects = self.ws().last_pane_rects.clone();
-                for (pane_id, rect) in pane_rects {
-                    if col >= rect.x
-                        && col < rect.x + rect.width
-                        && row >= rect.y
-                        && row < rect.y + rect.height
-                    {
-                        if let Some(pane) = self.ws().panes.get(&pane_id) {
-                            pane.scroll_up(3);
-                        }
-                        return;
-                    }
-                }
-            }
-            MouseEventKind::ScrollDown => {
-                let col = mouse.column;
-                let row = mouse.row;
-
-                if let Some(rect) = self.ws().last_file_tree_rect {
-                    if col >= rect.x
-                        && col < rect.x + rect.width
-                        && row >= rect.y
-                        && row < rect.y + rect.height
-                    {
-                        self.ws_mut().file_tree.scroll_down(3);
-                        return;
-                    }
-                }
-                if let Some(rect) = self.ws().last_preview_rect {
-                    if col >= rect.x
-                        && col < rect.x + rect.width
-                        && row >= rect.y
-                        && row < rect.y + rect.height
-                    {
-                        self.ws_mut().preview.scroll_down(3);
-                        return;
-                    }
-                }
-                let pane_rects = self.ws().last_pane_rects.clone();
-                for (pane_id, rect) in pane_rects {
-                    if col >= rect.x
-                        && col < rect.x + rect.width
-                        && row >= rect.y
-                        && row < rect.y + rect.height
-                    {
-                        if let Some(pane) = self.ws().panes.get(&pane_id) {
-                            pane.scroll_down(3);
-                        }
-                        return;
-                    }
-                }
-            }
+            MouseEventKind::ScrollUp => self.handle_wheel(mouse.column, mouse.row, false),
+            MouseEventKind::ScrollDown => self.handle_wheel(mouse.column, mouse.row, true),
             MouseEventKind::ScrollLeft => {
                 let col = mouse.column;
                 let row = mouse.row;
@@ -2335,6 +2261,94 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Dispatch a mouse-wheel event. Routes the event to whichever
+    /// widget the cursor sits over: file tree / preview use their own
+    /// scroll API; panes either scroll their vt100 scrollback (normal
+    /// shell) or forward the wheel to the PTY as an xterm mouse report
+    /// / arrow-key fallback when running an alternate-screen TUI
+    /// (Claude Code `/tui fullscreen`, vim, less, …). See Issue #52
+    /// and `Pane::wheel_forward_bytes` for the decision table.
+    ///
+    /// `CCMUX_DISABLE_MOUSE_FORWARD=1` forces the legacy behavior
+    /// everywhere (vt100 scrollback only), as an escape hatch for
+    /// nested ccmux or terminals with mismatched mouse-protocol
+    /// encoding.
+    fn handle_wheel(&mut self, col: u16, row: u16, scroll_down: bool) {
+        if let Some(rect) = self.ws().last_file_tree_rect {
+            if col >= rect.x
+                && col < rect.x + rect.width
+                && row >= rect.y
+                && row < rect.y + rect.height
+            {
+                if scroll_down {
+                    self.ws_mut().file_tree.scroll_down(3);
+                } else {
+                    self.ws_mut().file_tree.scroll_up(3);
+                }
+                return;
+            }
+        }
+        if let Some(rect) = self.ws().last_preview_rect {
+            if col >= rect.x
+                && col < rect.x + rect.width
+                && row >= rect.y
+                && row < rect.y + rect.height
+            {
+                if scroll_down {
+                    self.ws_mut().preview.scroll_down(3);
+                } else {
+                    self.ws_mut().preview.scroll_up(3);
+                }
+                return;
+            }
+        }
+
+        let disable_forward = std::env::var("CCMUX_DISABLE_MOUSE_FORWARD")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false);
+
+        let pane_rects = self.ws().last_pane_rects.clone();
+        for (pane_id, rect) in pane_rects {
+            if !(col >= rect.x
+                && col < rect.x + rect.width
+                && row >= rect.y
+                && row < rect.y + rect.height)
+            {
+                continue;
+            }
+            // Pane content area starts one cell inside the border.
+            let local_col = col.saturating_sub(rect.x).saturating_sub(1);
+            let local_row = row.saturating_sub(rect.y).saturating_sub(1);
+
+            let bytes = if disable_forward {
+                None
+            } else {
+                self.ws()
+                    .panes
+                    .get(&pane_id)
+                    .and_then(|p| p.wheel_forward_bytes(scroll_down, local_col, local_row))
+            };
+
+            if let Some(data) = bytes {
+                if let Some(pane) = self.ws_mut().panes.get_mut(&pane_id) {
+                    // Best-effort forward — a PTY write failure here
+                    // is non-fatal (Claude Code still renders without
+                    // the wheel event reaching it).
+                    let _ = pane.write_input(&data);
+                    self.dirty = true;
+                }
+            } else if let Some(pane) = self.ws().panes.get(&pane_id) {
+                if scroll_down {
+                    pane.scroll_down(3);
+                } else {
+                    pane.scroll_up(3);
+                }
+                self.dirty = true;
+            }
+            return;
         }
     }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -259,23 +259,23 @@ impl Pane {
     }
 
     /// Decide how a mouse-wheel event at `(local_col, local_row)` — pane
-    /// content-area coordinates, 0-origin — should be handled when the
-    /// pane is in alternate-screen mode. Returns:
+    /// content-area coordinates, 0-origin — should be handled. Returns:
     ///
     /// * `Some(bytes)` when the caller should forward those bytes to
     ///   the PTY instead of scrolling the vt100 scrollback. Two sub-
     ///   cases:
-    ///   - If the application enabled mouse reporting (e.g. Claude
-    ///     Code `/tui`, vim with `set mouse=a`), the bytes are an
-    ///     xterm mouse report encoded in whatever protocol the app
-    ///     selected (SGR / UTF-8 / Default).
-    ///   - If the app is alt-screen but did NOT enable mouse
-    ///     reporting (e.g. `less`), the bytes are an arrow-key escape
-    ///     so the wheel still moves the cursor, mirroring xterm /
-    ///     WezTerm behavior.
-    /// * `None` when the pane is **not** in alternate screen — the
-    ///   caller falls back to the normal `scroll_up` / `scroll_down`
-    ///   path that walks the vt100 scrollback.
+    ///   - **Mouse reporting enabled** (any `MouseProtocolMode` other
+    ///     than `None`), regardless of whether the app is in the
+    ///     alternate screen buffer: the bytes are an xterm mouse
+    ///     report encoded in the protocol the app selected (SGR /
+    ///     UTF-8 / Default). Claude Code `/tui fullscreen` lives
+    ///     here — it enables DECSET 1003 on the *main* screen.
+    ///   - **Alt screen but no mouse reporting** (e.g. `less`): the
+    ///     bytes are an arrow-key escape so the wheel still moves
+    ///     the cursor, mirroring xterm / WezTerm behavior.
+    /// * `None` for a plain shell on the main screen with no mouse
+    ///   reporting — the caller falls back to `scroll_up` /
+    ///   `scroll_down` and walks the vt100 scrollback.
     pub fn wheel_forward_bytes(
         &self,
         scroll_down: bool,

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -258,6 +258,53 @@ impl Pane {
         parser.screen().bracketed_paste()
     }
 
+    /// Decide how a mouse-wheel event at `(local_col, local_row)` — pane
+    /// content-area coordinates, 0-origin — should be handled when the
+    /// pane is in alternate-screen mode. Returns:
+    ///
+    /// * `Some(bytes)` when the caller should forward those bytes to
+    ///   the PTY instead of scrolling the vt100 scrollback. Two sub-
+    ///   cases:
+    ///   - If the application enabled mouse reporting (e.g. Claude
+    ///     Code `/tui`, vim with `set mouse=a`), the bytes are an
+    ///     xterm mouse report encoded in whatever protocol the app
+    ///     selected (SGR / UTF-8 / Default).
+    ///   - If the app is alt-screen but did NOT enable mouse
+    ///     reporting (e.g. `less`), the bytes are an arrow-key escape
+    ///     so the wheel still moves the cursor, mirroring xterm /
+    ///     WezTerm behavior.
+    /// * `None` when the pane is **not** in alternate screen — the
+    ///   caller falls back to the normal `scroll_up` / `scroll_down`
+    ///   path that walks the vt100 scrollback.
+    pub fn wheel_forward_bytes(
+        &self,
+        scroll_down: bool,
+        local_col: u16,
+        local_row: u16,
+    ) -> Option<Vec<u8>> {
+        let parser = self.parser.lock().unwrap_or_else(|e| e.into_inner());
+        let screen = parser.screen();
+        if !screen.alternate_screen() {
+            return None;
+        }
+        match screen.mouse_protocol_mode() {
+            vt100::MouseProtocolMode::None => Some(if scroll_down {
+                b"\x1b[B".to_vec()
+            } else {
+                b"\x1b[A".to_vec()
+            }),
+            _ => {
+                let button: u8 = if scroll_down { 65 } else { 64 };
+                Some(encode_mouse_wheel_report(
+                    button,
+                    local_col,
+                    local_row,
+                    screen.mouse_protocol_encoding(),
+                ))
+            }
+        }
+    }
+
     /// Check if Claude Code is running in this pane (by window title).
     pub fn is_claude_running(&self) -> bool {
         if let Ok(t) = self.title.lock() {
@@ -313,6 +360,62 @@ impl Pane {
 impl Drop for Pane {
     fn drop(&mut self) {
         self.kill();
+    }
+}
+
+/// Encode a mouse-wheel report for the given xterm protocol encoding.
+///
+/// `button` is the xterm button code (64 = wheel up, 65 = wheel down).
+/// `col` / `row` are pane-local content-area coordinates, **0-origin**
+/// — the encoder converts to the 1-origin form on the wire.
+///
+/// Supports SGR (recommended, CSI < ... M), UTF-8-based, and the
+/// legacy "Default" encoding. The Default form truncates coordinates
+/// past 223 because each cell is transmitted as `coord + 32` in a
+/// single byte — this is an xterm-era limitation and mirrors
+/// upstream terminals (WezTerm, Alacritty) behavior.
+pub fn encode_mouse_wheel_report(
+    button: u8,
+    col: u16,
+    row: u16,
+    encoding: vt100::MouseProtocolEncoding,
+) -> Vec<u8> {
+    let c1 = col.saturating_add(1);
+    let r1 = row.saturating_add(1);
+    match encoding {
+        vt100::MouseProtocolEncoding::Sgr => format!("\x1b[<{button};{c1};{r1}M").into_bytes(),
+        vt100::MouseProtocolEncoding::Utf8 => {
+            let mut v: Vec<u8> = vec![0x1b, b'[', b'M', button.saturating_add(32)];
+            encode_utf8_coord(&mut v, c1);
+            encode_utf8_coord(&mut v, r1);
+            v
+        }
+        vt100::MouseProtocolEncoding::Default => {
+            let col_byte = c1.saturating_add(32).min(255) as u8;
+            let row_byte = r1.saturating_add(32).min(255) as u8;
+            vec![
+                0x1b,
+                b'[',
+                b'M',
+                button.saturating_add(32),
+                col_byte,
+                row_byte,
+            ]
+        }
+    }
+}
+
+fn encode_utf8_coord(out: &mut Vec<u8>, coord: u16) {
+    // xterm UTF-8 mouse reporting: emit the coordinate + 32 as a
+    // UTF-8-encoded code point. Values up to 2015 fit.
+    let code = coord.saturating_add(32) as u32;
+    if code < 0x80 {
+        out.push(code as u8);
+    } else {
+        // Two-byte UTF-8 for values in [0x80, 0x7FF].
+        let c = code.min(0x7FF);
+        out.push(0xC0 | ((c >> 6) as u8));
+        out.push(0x80 | ((c & 0x3F) as u8));
     }
 }
 
@@ -586,6 +689,50 @@ fn detect_shell_unix() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wheel_report_sgr_up_matches_xterm_format() {
+        // xterm SGR wheel up: CSI < 64 ; col ; row M (1-origin coords)
+        let bytes = encode_mouse_wheel_report(64, 9, 4, vt100::MouseProtocolEncoding::Sgr);
+        assert_eq!(bytes, b"\x1b[<64;10;5M");
+    }
+
+    #[test]
+    fn wheel_report_sgr_down_matches_xterm_format() {
+        let bytes = encode_mouse_wheel_report(65, 0, 0, vt100::MouseProtocolEncoding::Sgr);
+        assert_eq!(bytes, b"\x1b[<65;1;1M");
+    }
+
+    #[test]
+    fn wheel_report_default_encoding_uses_single_byte_plus_32() {
+        // Legacy xterm: ESC [ M button+32 col+33 row+33 (1-origin + 32
+        // offset = col 0 -> 33, row 0 -> 33).
+        let bytes = encode_mouse_wheel_report(64, 0, 0, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 96, 33, 33]);
+    }
+
+    #[test]
+    fn wheel_report_default_truncates_past_223() {
+        // coord 300 + 32 offset = 332, clamped to 255 so the legacy
+        // byte doesn't wrap. This preserves xterm's well-known cap.
+        let bytes = encode_mouse_wheel_report(65, 300, 300, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes[0..4], [0x1b, b'[', b'M', 97]);
+        assert_eq!(bytes[4], 255);
+        assert_eq!(bytes[5], 255);
+    }
+
+    #[test]
+    fn wheel_report_utf8_multi_byte_for_wide_cols() {
+        // col=100 -> 1-origin 101, +32 = 133 (0x85) which must be
+        // encoded as 2-byte UTF-8, not a raw 0x85 byte.
+        let bytes = encode_mouse_wheel_report(64, 100, 0, vt100::MouseProtocolEncoding::Utf8);
+        assert_eq!(bytes[0..4], [0x1b, b'[', b'M', 96]);
+        // 133 as UTF-8: 0xC2 0x85
+        assert_eq!(bytes[4], 0xC2);
+        assert_eq!(bytes[5], 0x85);
+        // row=0 -> 1-origin 1, +32 = 33 (0x21), single byte
+        assert_eq!(bytes[6], 33);
+    }
 
     #[test]
     fn test_detect_shell_returns_valid_path() {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -284,22 +284,40 @@ impl Pane {
     ) -> Option<Vec<u8>> {
         let parser = self.parser.lock().unwrap_or_else(|e| e.into_inner());
         let screen = parser.screen();
-        if !screen.alternate_screen() {
-            return None;
-        }
-        match screen.mouse_protocol_mode() {
-            vt100::MouseProtocolMode::None => Some(if scroll_down {
-                b"\x1b[B".to_vec()
-            } else {
-                b"\x1b[A".to_vec()
-            }),
+        let alt = screen.alternate_screen();
+        let mode = screen.mouse_protocol_mode();
+        let encoding = screen.mouse_protocol_encoding();
+
+        // Decision order matters: an app that enabled mouse reporting
+        // expects the wheel even if it hasn't entered the alt screen.
+        // Claude Code's `/tui fullscreen` is exactly this case — it
+        // sets MouseProtocolMode::AnyMotion (DECSET 1003) without
+        // switching to the alternate screen buffer, so gating on
+        // `alternate_screen()` alone silently drops the event.
+        //
+        // - mouse reporting on  → encode wheel report in the app's
+        //   chosen protocol (works for both in-place TUIs like Claude
+        //   /tui and classic alt-screen TUIs like vim).
+        // - mouse reporting off + alt screen → xterm-style arrow
+        //   fallback so `less` and friends still move their cursor.
+        // - mouse reporting off + normal screen → None, let the caller
+        //   scroll vt100 scrollback (normal shell history).
+        match mode {
+            vt100::MouseProtocolMode::None => {
+                if alt {
+                    Some(if scroll_down {
+                        b"\x1b[B".to_vec()
+                    } else {
+                        b"\x1b[A".to_vec()
+                    })
+                } else {
+                    None
+                }
+            }
             _ => {
                 let button: u8 = if scroll_down { 65 } else { 64 };
                 Some(encode_mouse_wheel_report(
-                    button,
-                    local_col,
-                    local_row,
-                    screen.mouse_protocol_encoding(),
+                    button, local_col, local_row, encoding,
                 ))
             }
         }


### PR DESCRIPTION
## Summary
Issue #52 対応。alt-screen で動く TUI (Claude Code \`/tui fullscreen\`, vim, lazygit, less 等) でホイール操作が届くように、vt100 scrollback 一択だった wheel ハンドリングを **pane の live 状態に応じて分岐** するよう変更。

## 分岐ロジック (per-event, pane の vt100 state から判定)

| pane 状態 | 挙動 |
|---|---|
| alt-screen + mouse reporting 有効 | PTY に SGR / UTF-8 / Default encoding で mouse report を forward |
| alt-screen + mouse reporting 無効 | Up/Down 矢印キーを forward (xterm/WezTerm と同じ fallback) |
| non-alt-screen | 従来通り vt100 scrollback を ±3 行 |

## Codex 設計レビュー反映済 (Issue #52 本文参照)
- per-event 判定 (mid-session で mode が変わるため ラッチしない)
- encoding 動的選択 (SGR 固定は UTF-8 / Default TUI で壊れる)
- hover pane routing (focused pane ではない)
- 1 wheel tick = 1 mouse report (×3 倍率は scrollback UI 専用)
- opt-out env \`CCMUX_DISABLE_MOUSE_FORWARD=1\` (nested ccmux / 壊れた環境の逃げ道)

## 実装
- \`src/pane.rs\`: \`Pane::wheel_forward_bytes(scroll_down, local_col, local_row)\` と \`encode_mouse_wheel_report\` ヘルパー追加
- \`src/app.rs\`: \`handle_mouse_event\` の ScrollUp/ScrollDown branch を \`handle_wheel\` メソッドに集約、上記ロジック実装
- 既存 file tree / preview 側の scroll 挙動は無変更

## Test plan
- [x] \`cargo test\`: 211 passed (+4 new)
- [x] \`cargo clippy --all-targets -- -D warnings\`: clean
- [x] \`cargo fmt\`: applied
- [x] 新規 encoder 単体テスト: SGR up/down、Default legacy、223 cap truncation、UTF-8 multi-byte
- [ ] CI 3 プラットフォーム
- [ ] **実機検証**: Claude Code \`/tui fullscreen\` pane でホイール → 会話履歴スクロール、bash pane で従来通り scrollback、less で矢印 fallback、\`CCMUX_DISABLE_MOUSE_FORWARD=1\` で legacy 復帰

## Policy
マウス挙動の変更なので実機テスト後にマージ (視覚・入力系変更のルール適用)。

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)