### PR TITLE
chore: bump version to 0.5.7-fork.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.7-fork.1"
+version = "0.5.7-fork.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccmux"
-version = "0.5.7-fork.1"
+version = "0.5.7-fork.2"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.7-fork.1",
+  "version": "0.5.7-fork.2",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
Patch release。v0.5.7-fork.1 以降の変更 (PR #53 マウスホイール forward) を束ねる。

## Release highlights (0.5.7-fork.1 → 0.5.7-fork.2)

- **マウスホイール forward** (#52, #53): alt-screen TUI またはマウスレポート有効な pane (Claude Code \`/tui fullscreen\`, vim, lazygit 等) でホイールが届くように。主画面 + mouse reporting の Claude /tui もカバー。
- less などマウス無効 alt-screen アプリには矢印キー fallback。
- 通常シェル pane の vt100 scrollback 挙動は無変更。
- \`CCMUX_DISABLE_MOUSE_FORWARD=1\` で旧挙動に戻せる escape hatch。

破壊的変更なし。v0.5.7-fork.1 からのドロップイン。

## Release process
このマージ後:
1. \`git tag v0.5.7-fork.2 && git push origin v0.5.7-fork.2\`
2. CI 自動で 4 プラットフォーム release build / GitHub Release / npm publish (next タグ)

## Test plan
- [x] Cargo.toml / npm/package.json / Cargo.lock 同期
- [x] 実機で Claude /tui fullscreen のホイールスクロール確認 (PR #53)
- [ ] CI 3 プラットフォーム