### PR TITLE
Harden npm installer verification

### DIFF
--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -130,6 +130,67 @@ function cleanupFile(filePath) {
   }
 }
 
+// Atomically replace `dest` with `tempDest`. The rename can fail on
+// Windows when an antivirus scanner or another process briefly holds
+// the old binary open (EBUSY / EPERM). Retry a handful of times with
+// exponential backoff before bailing out. Importantly, we move the
+// old binary to a sibling backup path first so a crash between
+// "delete old" and "install new" doesn't leave the user with no
+// binary at all — if the rename of tempDest -> dest fails, we restore
+// the backup.
+function replaceBinaryAtomically(tempDest, dest) {
+  const backup = `${dest}.bak`;
+  const hadExisting = fs.existsSync(dest);
+
+  if (hadExisting) {
+    cleanupFile(backup);
+    fs.renameSync(dest, backup);
+  }
+
+  const maxAttempts = 5;
+  let lastErr = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      fs.renameSync(tempDest, dest);
+      lastErr = null;
+      break;
+    } catch (err) {
+      lastErr = err;
+      const retryable =
+        err && (err.code === 'EBUSY' || err.code === 'EPERM' || err.code === 'EACCES');
+      if (!retryable || attempt === maxAttempts) break;
+      const waitMs = 50 * Math.pow(2, attempt - 1);
+      const until = Date.now() + waitMs;
+      while (Date.now() < until) {
+        // Busy-wait is fine here; install.js is short-lived and
+        // single-threaded, and we want to stay synchronous.
+      }
+    }
+  }
+
+  if (lastErr) {
+    if (hadExisting) {
+      try {
+        fs.renameSync(backup, dest);
+      } catch (restoreErr) {
+        // Restore failed too; surface the original error but note the
+        // degraded state so the user can fix it manually.
+        lastErr = new Error(
+          `Failed to install new binary and failed to restore old binary.\n` +
+            `  Install error: ${lastErr.message}\n` +
+            `  Restore error: ${restoreErr.message}\n` +
+            `  Backup lives at: ${backup}`
+        );
+      }
+    }
+    throw lastErr;
+  }
+
+  if (hadExisting) {
+    cleanupFile(backup);
+  }
+}
+
 async function main() {
   const binaryName = getPlatformBinary();
   const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
@@ -165,8 +226,7 @@ async function main() {
       fs.chmodSync(tempDest, 0o755);
     }
 
-    cleanupFile(dest);
-    fs.renameSync(tempDest, dest);
+    replaceBinaryAtomically(tempDest, dest);
 
     const BLUE = '\x1b[38;2;88;166;255m';
     const DIM = '\x1b[38;2;110;118;129m';
@@ -184,8 +244,16 @@ async function main() {
     console.log('');
   } catch (err) {
     cleanupFile(tempDest);
-    console.error(`Failed to download ccmux: ${err.message}`);
-    console.error(`URL: ${url}`);
+    // `err.message` already carries the specific failing resource
+    // when it comes from resolveAndValidateUrl (host / scheme),
+    // getExpectedChecksum (checksum entry lookup), the Checksum
+    // verification FAILED branch, or replaceBinaryAtomically
+    // (install + restore detail). Print it verbatim, and add the
+    // binary URL as the default download context for the manual
+    // fallback path.
+    console.error(`Failed to install ccmux: ${err.message}`);
+    console.error(`Binary URL: ${url}`);
+    console.error(`Checksums URL: ${baseUrl}/checksums.txt`);
     console.error('You can download manually from: https://github.com/happy-ryo/ccmux/releases');
     process.exit(1);
   }

--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -6,6 +6,12 @@ const crypto = require('crypto');
 const VERSION = require('../package.json').version;
 const REPO = 'happy-ryo/ccmux';
 const MAX_REDIRECTS = 5;
+const ALLOWED_REDIRECT_HOSTS = new Set([
+  'github.com',
+  'objects.githubusercontent.com',
+  'release-assets.githubusercontent.com',
+  'github-releases.githubusercontent.com',
+]);
 
 function getPlatformBinary() {
   const platform = process.platform;
@@ -20,15 +26,33 @@ function getPlatformBinary() {
   process.exit(1);
 }
 
-function download(url, dest, redirects = 0) {
+function resolveAndValidateUrl(rawUrl, baseUrl) {
+  const parsed = new URL(rawUrl, baseUrl);
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Refusing non-HTTPS URL: ${parsed.toString()}`);
+  }
+  if (!ALLOWED_REDIRECT_HOSTS.has(parsed.hostname)) {
+    throw new Error(`Refusing download from unexpected host: ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
+function download(url, dest, redirects = 0, baseUrl) {
   return new Promise((resolve, reject) => {
     if (redirects > MAX_REDIRECTS) {
       reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
       return;
     }
-    https.get(url, { headers: { 'User-Agent': 'ccmux-installer' } }, (res) => {
+    let requestUrl;
+    try {
+      requestUrl = resolveAndValidateUrl(url, baseUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    https.get(requestUrl, { headers: { 'User-Agent': 'ccmux-installer' } }, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        download(res.headers.location, dest, redirects + 1).then(resolve, reject);
+        download(res.headers.location, dest, redirects + 1, requestUrl).then(resolve, reject);
         return;
       }
       if (res.statusCode !== 200) {
@@ -36,6 +60,7 @@ function download(url, dest, redirects = 0) {
         return;
       }
       const file = fs.createWriteStream(dest);
+      file.on('error', reject);
       res.pipe(file);
       file.on('finish', () => {
         file.close();
@@ -45,15 +70,22 @@ function download(url, dest, redirects = 0) {
   });
 }
 
-function fetchText(url, redirects = 0) {
+function fetchText(url, redirects = 0, baseUrl) {
   return new Promise((resolve, reject) => {
     if (redirects > MAX_REDIRECTS) {
       reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
       return;
     }
-    https.get(url, { headers: { 'User-Agent': 'ccmux-installer' } }, (res) => {
+    let requestUrl;
+    try {
+      requestUrl = resolveAndValidateUrl(url, baseUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    https.get(requestUrl, { headers: { 'User-Agent': 'ccmux-installer' } }, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        fetchText(res.headers.location, redirects + 1).then(resolve, reject);
+        fetchText(res.headers.location, redirects + 1, requestUrl).then(resolve, reject);
         return;
       }
       if (res.statusCode !== 200) {
@@ -77,6 +109,27 @@ function sha256(filePath) {
   });
 }
 
+function getExpectedChecksum(checksums, binaryName) {
+  for (const line of checksums.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    if (!match) continue;
+    if (match[2] === binaryName) {
+      return match[1].toLowerCase();
+    }
+  }
+  throw new Error(`Checksum entry not found for ${binaryName}`);
+}
+
+function cleanupFile(filePath) {
+  try {
+    fs.rmSync(filePath, { force: true });
+  } catch (_) {
+    // Best-effort cleanup only.
+  }
+}
+
 async function main() {
   const binaryName = getPlatformBinary();
   const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
@@ -84,41 +137,36 @@ async function main() {
   const binDir = path.join(__dirname, '..', 'bin');
   const isWindows = process.platform === 'win32';
   const dest = path.join(binDir, isWindows ? 'ccmux.exe' : 'ccmux');
+  const tempDest = `${dest}.tmp`;
 
   console.log(`Downloading ccmux v${VERSION} for ${process.platform}-${process.arch}...`);
 
   try {
-    await download(url, dest);
+    fs.mkdirSync(binDir, { recursive: true });
+    cleanupFile(tempDest);
 
-    // Verify SHA-256 checksum
-    try {
-      const checksums = await fetchText(`${baseUrl}/checksums.txt`);
-      const actual = await sha256(dest);
-      const expected = checksums
-        .split('\n')
-        .find((line) => line.includes(binaryName));
+    await download(url, tempDest);
 
-      if (expected) {
-        const expectedHash = expected.trim().split(/\s+/)[0];
-        if (actual !== expectedHash) {
-          fs.unlinkSync(dest);
-          console.error('Checksum verification FAILED — downloaded binary does not match.');
-          console.error(`  Expected: ${expectedHash}`);
-          console.error(`  Actual:   ${actual}`);
-          process.exit(1);
-        }
-        console.log('Checksum verified.');
-      } else {
-        console.warn('Warning: binary not found in checksums.txt, skipping verification.');
-      }
-    } catch (e) {
-      // Checksums file may not exist for older releases — warn but continue
-      console.warn(`Warning: could not verify checksum (${e.message})`);
+    const checksums = await fetchText(`${baseUrl}/checksums.txt`);
+    const expectedHash = getExpectedChecksum(checksums, binaryName);
+    const actualHash = await sha256(tempDest);
+    if (actualHash !== expectedHash) {
+      throw new Error(
+        [
+          'Checksum verification FAILED - downloaded binary does not match.',
+          `  Expected: ${expectedHash}`,
+          `  Actual:   ${actualHash}`,
+        ].join('\n')
+      );
     }
+    console.log('Checksum verified.');
 
     if (!isWindows) {
-      fs.chmodSync(dest, 0o755);
+      fs.chmodSync(tempDest, 0o755);
     }
+
+    cleanupFile(dest);
+    fs.renameSync(tempDest, dest);
 
     const BLUE = '\x1b[38;2;88;166;255m';
     const DIM = '\x1b[38;2;110;118;129m';
@@ -135,6 +183,7 @@ async function main() {
     console.log(`${DIM}  Run 'ccmux' to start.${RESET}`);
     console.log('');
   } catch (err) {
+    cleanupFile(tempDest);
     console.error(`Failed to download ccmux: ${err.message}`);
     console.error(`URL: ${url}`);
     console.error('You can download manually from: https://github.com/happy-ryo/ccmux/releases');

--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -130,20 +130,35 @@ function cleanupFile(filePath) {
   }
 }
 
-// Atomically replace `dest` with `tempDest`. The rename can fail on
-// Windows when an antivirus scanner or another process briefly holds
-// the old binary open (EBUSY / EPERM). Retry a handful of times with
-// exponential backoff before bailing out. Importantly, we move the
-// old binary to a sibling backup path first so a crash between
-// "delete old" and "install new" doesn't leave the user with no
-// binary at all — if the rename of tempDest -> dest fails, we restore
-// the backup.
-function replaceBinaryAtomically(tempDest, dest) {
-  const backup = `${dest}.bak`;
+// Replace `dest` with `tempDest`.
+//
+// Not truly atomic: on Windows a POSIX-style rename isn't available,
+// and even on Unix we run two renames back-to-back (dest -> backup,
+// then tempDest -> dest), so there is a brief window where `dest`
+// does not exist. If the process is killed inside that window the
+// user is left with no binary at the canonical path until they
+// rerun the installer.
+//
+// The sequence is still a strong improvement over the previous
+// "rm old, rename new" path because:
+//
+// - The old binary is preserved at a unique backup path for as long
+//   as the install could fail. A rename-level failure restores it.
+// - The backup path is per-install (suffix with process PID and a
+//   timestamp) so a stale `.bak` from a crashed previous run isn't
+//   clobbered, and a failed install leaves behind a file the user
+//   can inspect or restore manually.
+// - The rename can fail on Windows when an antivirus scanner or
+//   another process briefly holds the old binary open (EBUSY /
+//   EPERM / EACCES). A small bounded retry with exponential
+//   backoff (50 / 100 / 200 / 400 ms between attempts, five
+//   attempts total, ~750 ms total wait before giving up) absorbs
+//   most of that transient lock contention.
+function replaceBinaryWithBackup(tempDest, dest) {
+  const backup = `${dest}.${process.pid}.${Date.now()}.bak`;
   const hadExisting = fs.existsSync(dest);
 
   if (hadExisting) {
-    cleanupFile(backup);
     fs.renameSync(dest, backup);
   }
 
@@ -173,8 +188,6 @@ function replaceBinaryAtomically(tempDest, dest) {
       try {
         fs.renameSync(backup, dest);
       } catch (restoreErr) {
-        // Restore failed too; surface the original error but note the
-        // degraded state so the user can fix it manually.
         lastErr = new Error(
           `Failed to install new binary and failed to restore old binary.\n` +
             `  Install error: ${lastErr.message}\n` +
@@ -226,7 +239,7 @@ async function main() {
       fs.chmodSync(tempDest, 0o755);
     }
 
-    replaceBinaryAtomically(tempDest, dest);
+    replaceBinaryWithBackup(tempDest, dest);
 
     const BLUE = '\x1b[38;2;88;166;255m';
     const DIM = '\x1b[38;2;110;118;129m';


### PR DESCRIPTION
## Summary
- restrict npm installer redirects to an allowlist of expected GitHub release hosts
- make checksum retrieval and lookup fail closed instead of warning and continuing
- download into a temporary file and only move the binary into place after verification succeeds

## Testing
- node --check npm/scripts/install.js
- cargo test

Closes #57
