### PR TITLE
docs: architecture IPC layer (part 4/4 of #55)

### DIFF
--- a/docs/content/architecture.mdx
+++ b/docs/content/architecture.mdx
@@ -2,16 +2,27 @@
 
 ## 概要
 
-ccmux は約 2,800 行の Rust コードで、6 つのモジュールで構成されています：
+ccmux は約 11,000 行の Rust コードで、以下のモジュール構成:
 
 ```
 src/
-├── main.rs       # エントリーポイント、イベントループ、panic hook
-├── app.rs        # ワークスペース/タブ状態、レイアウトツリー、入力処理
-├── pane.rs       # PTY 管理、vt100 エミュレーション、シェル検出
-├── ui.rs         # ratatui 描画、テーマ、レイアウト
-├── filetree.rs   # ファイルツリー走査、ナビゲーション
-└── preview.rs    # シンタックスハイライト付きファイルプレビュー
+├── main.rs          # エントリーポイント、イベントループ、panic hook、raw mode setup
+├── app.rs           # ワークスペース/タブ状態、レイアウトツリー、入力処理、AppCommand dispatch
+├── pane.rs          # PTY 管理、vt100 エミュレーション、シェル検出、マウスホイール変換
+├── ui.rs            # ratatui 描画、テーマ、レイアウト、IME overlay、IME caret flicker 対策
+├── filetree.rs      # ファイルツリー走査、ナビゲーション
+├── preview.rs       # シンタックスハイライト付きファイルプレビュー
+├── cli.rs           # clap ベースのサブコマンド定義 (list/send/events/inspect 等)
+├── config.rs        # $XDG_CONFIG_HOME/ccmux/config.toml パーサ、[ime] 設定
+├── claude_monitor.rs# Claude Code の JSONL セッション監視 (プログレスバー等)
+├── layout_config.rs # ccmux-layouts/*.toml のマルチペインレイアウト
+├── version_check.rs # 起動時の新バージョンチェック (GitHub Releases)
+└── ipc/             # 外部クライアント向け IPC (下記セクション)
+    ├── mod.rs       # Request / Response / Event / CodedError / err_code 定数
+    ├── endpoint.rs  # Unix socket / Windows Named Pipe のエンドポイント解決
+    ├── events.rs    # EventBus (bounded channel + EventsDropped meta event)
+    ├── server.rs    # accept loop + worker threads + subscribe/half-close
+    └── client.rs    # CLI から IPC サーバーへ接続 + subscribe_events
 ```
 
 ## ターミナルエミュレーション
@@ -56,6 +67,43 @@ enum LayoutNode {
 3. **PTY リサイズ** — サイズが変わった時のみ更新（キャッシュ）
 4. **セル単位描画** — vt100 スクリーンバッファを読み、ゼロアロケーションで ratatui セルにマッピング
 5. **選択オーバーレイ** — 選択テキストに青いハイライトを適用
+
+## IPC レイヤー
+
+ccmux は起動時に Unix socket (`$XDG_RUNTIME_DIR/ccmux/<pid>.sock`) または Windows Named Pipe (`\\.\pipe\ccmux-<pid>`) をバインドし、同一ユーザーのプロセスから subcommand を受け付ける。詳細な使い方は [IPC](/docs/ipc) を、コード上の分担は以下を参照。
+
+### メッセージ型 (`src/ipc/mod.rs`)
+
+- **`Request`**: クライアント → サーバー。`Hello` / `List` / `Send` / `Focus` / `Split` / `NewTab` / `Inspect` / `Subscribe` の enum variant。
+- **`Response`**: サーバー → クライアント。`Ok { data }` / `Hello { server_pid, session_token }` / `Subscribed` / `Err { message, code }`。`code` は `err_code` モジュールで安定名 (shutting_down / pane_not_found / io_error 等) を公開。
+- **`Event`**: subscribe ストリームで流れる `pane_started` / `pane_exited` / `events_dropped` / `heartbeat`。
+- **`CodedError`**: App 層のエラーキャリア。`AppCommand` の reply 型が `Result<T, CodedError>` で、サーバーが `into_response()` で wire Response に変換。
+
+### スレッドモデル (`src/ipc/server.rs`)
+
+```
+accept thread ─────┐
+(listener loop)    │
+                   ↓ spawn per conn
+                worker thread
+                   │
+                   ├─ one-shot: dispatch_request ─→ App via mpsc
+                   │                                (App は毎フレーム drain)
+                   └─ subscribe: stream_events
+                      (EventBus::subscribe → loop with 30s heartbeat)
+```
+
+- accept thread は 1 本、プロセスライフタイムで blocked。shutdown は `self.stop` フラグ + self-connect で wake
+- 各接続は short-lived worker で捌かれ、slow client が accept をブロックしない
+- App への dispatch は `Sender<AppCommand>` + `oneshot::channel()` + `recv_timeout(5s)` で、UI スレッドが wedged でも worker が永遠にハングしない
+
+### EventBus (`src/ipc/events.rs`)
+
+bounded channel で subscriber を束ねる broker。slow subscriber には `EventsDropped { count, ts_ms }` meta event を合成して欠落数を通知。subscribe ストリームは 30 秒おきに `Heartbeat { ts_ms }` を wire write して、半クローズされた相手を早期検出する。
+
+### セキュリティモデル
+
+same-user local IPC。アクセス制御は **OS socket permission** に任せる (Unix は `XDG_RUNTIME_DIR` の 0700、Windows は Named Pipe のセッションスコープ)。`CCMUX_TOKEN` / `CCMUX_SOCKET` 環境変数はクライアントがエンドポイントを特定するための指標で、秘匿のための秘密鍵ではない。`CCMUX_TOKEN` は PID 再利用によって別 ccmux インスタンスへ誤接続することを防ぐための session token として機能する。
 
 ## パフォーマンス
 

--- a/docs/content/en/architecture.mdx
+++ b/docs/content/en/architecture.mdx
@@ -2,16 +2,27 @@
 
 ## Overview
 
-ccmux is ~2,800 lines of Rust, organized into 6 modules:
+ccmux is ~11,000 lines of Rust, organized as follows:
 
 ```
 src/
-├── main.rs       # Entry point, event loop, panic hook
-├── app.rs        # Workspace/tab state, layout tree, input handling
-├── pane.rs       # PTY management, vt100 emulation, shell detection
-├── ui.rs         # ratatui rendering, theme, layout
-├── filetree.rs   # File tree scanning, navigation
-└── preview.rs    # File preview with syntax highlighting
+├── main.rs           # Entry point, event loop, panic hook, raw-mode setup
+├── app.rs            # Workspace/tab state, layout tree, input handling, AppCommand dispatch
+├── pane.rs           # PTY management, vt100 emulation, shell detection, mouse-wheel translation
+├── ui.rs             # ratatui rendering, theme, layout, IME overlay, caret-flicker mitigation
+├── filetree.rs       # File tree scanning, navigation
+├── preview.rs        # Syntax-highlighted file preview
+├── cli.rs            # clap-based subcommand definitions (list/send/events/inspect/…)
+├── config.rs         # Parser for $XDG_CONFIG_HOME/ccmux/config.toml, [ime] settings
+├── claude_monitor.rs # Claude Code JSONL session monitor (progress bars, etc.)
+├── layout_config.rs  # Multi-pane layouts from ccmux-layouts/*.toml
+├── version_check.rs  # Startup new-version check against GitHub Releases
+└── ipc/              # External-client IPC (see section below)
+    ├── mod.rs        # Request / Response / Event / CodedError / err_code constants
+    ├── endpoint.rs   # Unix socket / Windows Named Pipe endpoint resolution
+    ├── events.rs     # EventBus (bounded channel + EventsDropped meta event)
+    ├── server.rs     # accept loop + worker threads + subscribe/half-close
+    └── client.rs     # CLI-side connect + subscribe_events
 ```
 
 ## Terminal Emulation
@@ -56,6 +67,43 @@ This naturally supports recursive splitting and makes layout calculation straigh
 3. **PTY resize** — Update PTY size only if it changed (cached)
 4. **Cell-by-cell rendering** — Read vt100 screen buffer, map to ratatui cells with zero heap allocation
 5. **Selection overlay** — Apply blue highlight on selected text
+
+## IPC Layer
+
+On startup ccmux binds a Unix socket (`$XDG_RUNTIME_DIR/ccmux/<pid>.sock`) or a Windows Named Pipe (`\\.\pipe\ccmux-<pid>`) and accepts subcommands from same-user processes. For user-facing details see the [IPC page](/docs/en/ipc); the code breakdown is below.
+
+### Message types (`src/ipc/mod.rs`)
+
+- **`Request`**: client → server. `Hello` / `List` / `Send` / `Focus` / `Split` / `NewTab` / `Inspect` / `Subscribe`.
+- **`Response`**: server → client. `Ok { data }` / `Hello { server_pid, session_token }` / `Subscribed` / `Err { message, code }`. The `code` is a stable identifier from the `err_code` module (shutting_down, pane_not_found, io_error, …).
+- **`Event`**: flows over the subscribe stream. `pane_started` / `pane_exited` / `events_dropped` / `heartbeat`.
+- **`CodedError`**: App-layer error carrier. `AppCommand` replies are `Result<T, CodedError>` and the server turns them into wire `Response`s via `into_response()`.
+
+### Thread model (`src/ipc/server.rs`)
+
+```
+accept thread ─────┐
+(listener loop)    │
+                   ↓ spawn per conn
+                worker thread
+                   │
+                   ├─ one-shot: dispatch_request → App via mpsc
+                   │                              (App drains every frame)
+                   └─ subscribe: stream_events
+                      (EventBus::subscribe → loop with 30 s heartbeat)
+```
+
+- A single accept thread lives for the process lifetime, blocked in `Listener::incoming()`. Shutdown flips `self.stop` and self-connects to unblock it.
+- Each connection runs on a short-lived worker so a slow client can't starve accept.
+- Dispatch to the App uses `Sender<AppCommand>` + `oneshot::channel()` + `recv_timeout(5s)`; even a wedged UI thread can't hang a worker forever.
+
+### EventBus (`src/ipc/events.rs`)
+
+A broker over a bounded channel. Slow subscribers are notified of drops via a synthetic `EventsDropped { count, ts_ms }` meta event; the subscribe stream emits a `Heartbeat { ts_ms }` every 30 seconds so half-closed peers are detected by the next failing write instead of lingering for hours on quiet workspaces.
+
+### Security model
+
+Same-user local IPC. Access control is delegated to **OS socket permissions** (Unix: `$XDG_RUNTIME_DIR` mode 0700; Windows: the Named Pipe's session scope). `CCMUX_TOKEN` / `CCMUX_SOCKET` environment variables are how clients *locate* the endpoint — not secrets, not an auth boundary. `CCMUX_TOKEN` specifically defends against PID reuse: a stale socket path inherited by a child shell pointing at a different ccmux PID would fail the token check and refuse to act.
 
 ## Performance
 


### PR DESCRIPTION
## Summary
Issue #55 最終サブタスク (part 4/4)。\`architecture.mdx\` の IPC レイヤー記述を追加。

## 変更
### \`docs/content/architecture.mdx\` / \`docs/content/en/architecture.mdx\`
- Overview ブロックを最新 src/ 構成に差し替え (~2,800 LOC / 6 modules → ~11,000 LOC、ipc/ サブディレクトリ含む 12 ファイル)
- **IPC Layer** セクション新設 (Performance の直前):
  - Message types: Request / Response / Event / CodedError + err_code への pointer
  - Thread model: accept thread + per-conn worker + App への Sender<AppCommand> + oneshot::channel(recv_timeout 5s)
  - EventBus: bounded channel + EventsDropped + 30s Heartbeat
  - Security model: OS socket permissions が信頼境界、CCMUX_TOKEN は PID-reuse guard
- ユーザー向け subcommand 解説 (/docs/ipc) への相互リンク

## Build check
- [x] \`docs/ && npx next build\` 成功
- [ ] CI

## Issue #55 完了に向けて
4 サブタスクすべて完了:
- part 1 (#56, merged): IPC reference ページ
- part 2 (#59, merged): IME overlay ページ
- part 3 (#60, merged): mouse wheel + keybindings
- part 4 (this): architecture IPC

マージ後、Issue #55 を閉じる。

Refs #55