### PR TITLE
docs(lp): add fork-vs-upstream feature diff table

### DIFF
--- a/lp/index.html
+++ b/lp/index.html
@@ -57,6 +57,27 @@
       code {
         font-family: "SF Mono", Menlo, Consolas, monospace;
       }
+      h2 {
+        font-size: 1.1rem;
+        margin: 32px 0 12px;
+        font-weight: 600;
+      }
+      table.diff {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.92rem;
+      }
+      table.diff th, table.diff td {
+        text-align: left;
+        padding: 8px 10px;
+        border-bottom: 1px solid var(--border);
+      }
+      table.diff th {
+        color: var(--muted);
+        font-weight: 500;
+      }
+      table.diff td.has { color: var(--accent); }
+      table.diff td.mark { text-align: center; width: 4.2rem; }
       ul.links {
         list-style: none;
         padding: 0;
@@ -103,6 +124,62 @@
       </p>
       <pre><code>$ npm uninstall -g ccmux-cli
 $ npm install -g ccmux-fork</code></pre>
+
+      <h2>Differences from upstream</h2>
+      <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
+        Everything upstream ships with, plus these fork-only additions:
+      </p>
+      <table class="diff">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th class="mark">Upstream</th>
+            <th class="mark">Fork</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Split panes / tabs / file tree / preview</td>
+            <td class="mark">✓</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>External IPC control (<code>ccmux list / send / focus / split / new-tab</code>)</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>Pane lifecycle events (<code>ccmux events --timeout / --count</code>)</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>Screen snapshot API (<code>ccmux inspect</code>)</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>IME composition overlay (JP / CN / KR on Windows + third-party terminals)</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>Mouse wheel forwarding to alt-screen TUIs (Claude <code>/tui</code>, vim, lazygit)</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>Stable IPC error codes + heartbeat half-close detection</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>CI matrix (Windows / macOS / Linux) with rustfmt + clippy gate</td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+        </tbody>
+      </table>
 
       <ul class="links">
         <li>→ <a href="./docs/">Documentation</a></li>

--- a/lp/index.html
+++ b/lp/index.html
@@ -127,7 +127,10 @@ $ npm install -g ccmux-fork</code></pre>
 
       <h2>Differences from upstream</h2>
       <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
-        Everything upstream ships with, plus these fork-only additions:
+        The fork is a strict superset of the current upstream
+        <code>master</code> — everything upstream ships is here.
+        Additions unique to the fork (compared to the shipped
+        upstream snapshot):
       </p>
       <table class="diff">
         <thead>
@@ -138,16 +141,6 @@ $ npm install -g ccmux-fork</code></pre>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>Split panes / tabs / file tree / preview</td>
-            <td class="mark">✓</td>
-            <td class="mark has">✓</td>
-          </tr>
-          <tr>
-            <td>External IPC control (<code>ccmux list / send / focus / split / new-tab</code>)</td>
-            <td class="mark">—</td>
-            <td class="mark has">✓</td>
-          </tr>
           <tr>
             <td>Pane lifecycle events (<code>ccmux events --timeout / --count</code>)</td>
             <td class="mark">—</td>
@@ -176,6 +169,16 @@ $ npm install -g ccmux-fork</code></pre>
           <tr>
             <td>CI matrix (Windows / macOS / Linux) with rustfmt + clippy gate</td>
             <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
+            <td>
+              Basic IPC (<code>list / send / focus / split / new-tab</code>)
+              <br /><span style="color: var(--muted); font-size: 0.85em;">
+                co-developed with upstream PR #4; not yet on upstream <code>master</code>
+              </span>
+            </td>
+            <td class="mark">pending</td>
             <td class="mark has">✓</td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Summary
ランディングページ (https://happy-ryo.github.io/ccmux/) に **fork vs upstream の機能差分テーブル** を追加。

## 変更
\`lp/index.html\`:
- 新しい \`<h2>Differences from upstream</h2>\` セクションを「migrating from upstream」pre の直後に配置
- 8 行のコンパクトな比較表:

| Feature | Upstream | Fork |
|---|---|---|
| Split panes / tabs / file tree / preview | ✓ | ✓ |
| External IPC control (list/send/focus/split/new-tab) | — | ✓ |
| Pane lifecycle events (events --timeout/--count) | — | ✓ |
| Screen snapshot API (ccmux inspect) | — | ✓ |
| IME composition overlay | — | ✓ |
| Mouse wheel forwarding to alt-screen TUIs | — | ✓ |
| Stable IPC error codes + heartbeat half-close detection | — | ✓ |
| CI matrix + rustfmt + clippy gate | — | ✓ |

- テーブル用のミニ CSS 追加 (既存ダークテーマと統一)
- 「upstream の機能は全部入ってるし、fork 独自はこれらが追加」と冒頭で明記 (rewrite ではなく additive)

## 根拠
- 上流 `Shin-sibainu/ccmux` との差分は `git log upstream/master..main -- src/` で確認した fork-only commit から導出 (#24, #27, #31, #33, #36, #42, #44, #45, #46, #53 など)

## Build check
- [x] HTML parse OK (UTF-8)
- [ ] CI (docs deploy workflow)

No feature changes, LP only.