### PR TITLE
fix(ipc): use real OS uid for Unix socket dir, fail-closed on chmod (closes #58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "dirs",
  "humantime",
  "interprocess",
+ "libc",
  "oneshot",
  "portable-pty",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ interprocess = "2"
 oneshot = "0.1"
 subtle = "2"
 humantime = "2"
+
+[target.'cfg(unix)'.dependencies]
+# getuid() for the IPC endpoint directory name. Used only on Unix;
+# on Windows the endpoint is a Named Pipe that doesn't need a uid.
+libc = "0.2"

--- a/src/ipc/endpoint.rs
+++ b/src/ipc/endpoint.rs
@@ -148,6 +148,15 @@ pub fn endpoint_from_env() -> Result<EndpointName> {
 mod tests {
     use super::*;
 
+    // Tests in this module mutate process-global environment variables
+    // (`UID`, `XDG_RUNTIME_DIR`, `TMPDIR`, `CCMUX_SOCKET`). `cargo test`
+    // runs test functions on multiple threads inside a single process,
+    // which makes concurrent env reads/writes racy. Guard every env-
+    // touching test with this Mutex so they serialize among themselves
+    // and — implicitly via the lock — against each other's restore
+    // paths. Tests that don't touch env vars don't need the lock.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn endpoint_for_pid_includes_pid() {
         let ep = endpoint_for_pid(12345).unwrap();
@@ -176,6 +185,7 @@ mod tests {
         // If a hostile / unusual shell exports UID=1337, the socket
         // directory must still be named after the *OS* uid — that's
         // the whole point of #58.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let before = unix_real_uid();
         let prev = std::env::var("UID").ok();
         std::env::set_var("UID", "1337");
@@ -193,6 +203,7 @@ mod tests {
         // Force the /tmp fallback by clearing both XDG_RUNTIME_DIR
         // and TMPDIR, then confirm the resulting path contains the
         // OS uid even if $UID is lying.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
         let prev_tmp = std::env::var("TMPDIR").ok();
         let prev_uid = std::env::var("UID").ok();
@@ -229,7 +240,13 @@ mod tests {
 
     #[test]
     fn endpoint_from_env_fails_without_var() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var(ENV_SOCKET).ok();
         std::env::remove_var(ENV_SOCKET);
-        assert!(endpoint_from_env().is_err());
+        let result = endpoint_from_env();
+        if let Some(v) = prev {
+            std::env::set_var(ENV_SOCKET, v);
+        }
+        assert!(result.is_err());
     }
 }

--- a/src/ipc/endpoint.rs
+++ b/src/ipc/endpoint.rs
@@ -19,7 +19,13 @@ pub const ENV_TOKEN: &str = "CCMUX_TOKEN";
 ///
 /// On Windows this is a Named Pipe path (`\\.\pipe\ccmux-<pid>`).
 /// On Unix this is a filesystem path under `$XDG_RUNTIME_DIR/ccmux/`,
-/// falling back to `$TMPDIR` and then `/tmp/ccmux-$UID/`.
+/// falling back to `$TMPDIR/ccmux-<uid>/` and then `/tmp/ccmux-<uid>/`.
+/// The uid is the **real** OS uid of the current process (via
+/// `libc::getuid`), never the `$UID` environment variable. `$UID` is a
+/// bash-internal shell variable that may not be exported in minimal
+/// init systems or non-bash login shells; if we trusted it we'd
+/// happily collide with another user's directory or fall back to a
+/// hardcoded `1000`.
 pub fn endpoint_for_pid(pid: u32) -> Result<EndpointName> {
     #[cfg(windows)]
     {
@@ -30,13 +36,16 @@ pub fn endpoint_for_pid(pid: u32) -> Result<EndpointName> {
         let dir = unix_socket_dir()?;
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("failed to create {}", dir.display()))?;
-        // Restrict directory to owner-only; ignore failure on platforms
-        // where chmod isn't expressible (shouldn't happen on unix).
-        #[cfg(unix)]
+        // Restrict directory to 0o700. Owner-only is the *only* access
+        // control that protects the endpoint from other local users;
+        // if we can't establish it the trust model is broken, so fail
+        // closed rather than continue with potentially world-reachable
+        // permissions.
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o700);
-            let _ = std::fs::set_permissions(&dir, perms);
+            std::fs::set_permissions(&dir, perms)
+                .with_context(|| format!("failed to restrict {} to owner-only", dir.display()))?;
         }
         let path = dir.join(format!("ccmux-{pid}.sock"));
         Ok(EndpointName::socket(path))
@@ -45,29 +54,36 @@ pub fn endpoint_for_pid(pid: u32) -> Result<EndpointName> {
 
 #[cfg(unix)]
 fn unix_socket_dir() -> Result<PathBuf> {
+    // XDG_RUNTIME_DIR (set by systemd-logind and many others) is the
+    // canonical location. The OS already guarantees it's owner-only
+    // and cleaned up on logout, so we just nest `ccmux/` under it.
     if let Ok(d) = std::env::var("XDG_RUNTIME_DIR") {
         if !d.is_empty() {
             return Ok(PathBuf::from(d).join("ccmux"));
         }
     }
+    // Fall back to $TMPDIR / /tmp, in which case we have to include
+    // the uid so separate users don't collide.
+    let uid = unix_real_uid();
     if let Ok(d) = std::env::var("TMPDIR") {
         if !d.is_empty() {
-            return Ok(PathBuf::from(d).join(format!("ccmux-{}", uid())));
+            return Ok(PathBuf::from(d).join(format!("ccmux-{uid}")));
         }
     }
-    Ok(PathBuf::from("/tmp").join(format!("ccmux-{}", uid())))
+    Ok(PathBuf::from("/tmp").join(format!("ccmux-{uid}")))
 }
 
+/// Real OS uid of the current process.
+///
+/// Uses `libc::getuid` directly. This is a plain syscall with no
+/// arguments, no failure mode, and no memory safety concerns, so the
+/// `unsafe` block is purely ceremony — wrapping it in `nix` or
+/// `rustix` would add a dependency for no practical gain.
 #[cfg(unix)]
-fn uid() -> u32 {
-    // Avoid pulling in `nix` just for getuid; libc is already a transitive
-    // dependency of basically everything on Unix. Until we add it
-    // explicitly, fall back to env(USER) if libc isn't available — the
-    // value only needs to be stable per-user.
-    std::env::var("UID")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1000)
+fn unix_real_uid() -> u32 {
+    // SAFETY: `getuid` is defined on every supported Unix, takes no
+    // arguments, has no error path, and returns a simple uid_t.
+    unsafe { libc::getuid() as u32 }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -152,6 +168,63 @@ mod tests {
         let ep = endpoint_for_pid(1).unwrap();
         assert!(ep.as_str().ends_with(".sock"), "{}", ep.as_str());
         assert_eq!(ep.kind(), EndpointKind::Socket);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_real_uid_is_independent_of_env() {
+        // If a hostile / unusual shell exports UID=1337, the socket
+        // directory must still be named after the *OS* uid — that's
+        // the whole point of #58.
+        let before = unix_real_uid();
+        let prev = std::env::var("UID").ok();
+        std::env::set_var("UID", "1337");
+        let after = unix_real_uid();
+        match prev {
+            Some(v) => std::env::set_var("UID", v),
+            None => std::env::remove_var("UID"),
+        }
+        assert_eq!(before, after, "getuid() must not read $UID");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_socket_dir_fallback_uses_real_uid_not_env() {
+        // Force the /tmp fallback by clearing both XDG_RUNTIME_DIR
+        // and TMPDIR, then confirm the resulting path contains the
+        // OS uid even if $UID is lying.
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        let prev_tmp = std::env::var("TMPDIR").ok();
+        let prev_uid = std::env::var("UID").ok();
+        std::env::remove_var("XDG_RUNTIME_DIR");
+        std::env::remove_var("TMPDIR");
+        std::env::set_var("UID", "9999");
+
+        let dir = unix_socket_dir().unwrap();
+        let real = unix_real_uid();
+
+        // restore before asserting so a failure doesn't poison the
+        // test harness.
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+        match prev_tmp {
+            Some(v) => std::env::set_var("TMPDIR", v),
+            None => std::env::remove_var("TMPDIR"),
+        }
+        match prev_uid {
+            Some(v) => std::env::set_var("UID", v),
+            None => std::env::remove_var("UID"),
+        }
+
+        let expected_suffix = format!("ccmux-{real}");
+        assert!(
+            dir.display().to_string().ends_with(&expected_suffix),
+            "{} should end with {}",
+            dir.display(),
+            expected_suffix
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,21 @@ fn main() -> Result<()> {
     // inherit env from this process (via portable-pty's CommandBuilder),
     // and we publish `CCMUX` as a "you're inside ccmux" flag here too.
     let our_pid = std::process::id();
-    let ipc_endpoint = ipc::endpoint::endpoint_for_pid(our_pid)?;
-    std::env::set_var(ipc::endpoint::ENV_SOCKET, ipc_endpoint.as_str());
+    // Endpoint resolution can fail on Unix if we can't create the
+    // owner-only socket directory (read-only FS, permission-constrained
+    // mount, …). IPC is non-essential — fall through without it so the
+    // TUI still works as a plain multiplexer, mirroring the IpcServer
+    // soft-fail path below.
+    let ipc_endpoint = match ipc::endpoint::endpoint_for_pid(our_pid) {
+        Ok(ep) => Some(ep),
+        Err(e) => {
+            eprintln!("ccmux: IPC endpoint unavailable ({e}); external commands disabled.");
+            None
+        }
+    };
+    if let Some(ep) = &ipc_endpoint {
+        std::env::set_var(ipc::endpoint::ENV_SOCKET, ep.as_str());
+    }
     std::env::set_var("CCMUX", "1");
 
     // Session token derived from the process's start nanoseconds so a
@@ -117,20 +130,23 @@ fn main() -> Result<()> {
 
     // Keep the server handle alive for the process lifetime; its Drop
     // impl cleans up the Unix socket file on exit.
-    let _ipc_server = match ipc::server::IpcServer::spawn(
-        ipc_endpoint.clone(),
-        app.command_tx.clone(),
-        session_token.clone(),
-        app.event_bus.clone(),
-    ) {
-        Ok(server) => Some(server),
-        Err(e) => {
-            // IPC is non-essential for the TUI itself — fail soft so users
-            // without the required socket permissions can still use ccmux
-            // as a plain multiplexer.
-            eprintln!("ccmux: IPC server failed to start ({e}); external commands disabled.");
-            None
-        }
+    let _ipc_server = match ipc_endpoint.clone() {
+        Some(endpoint) => match ipc::server::IpcServer::spawn(
+            endpoint,
+            app.command_tx.clone(),
+            session_token.clone(),
+            app.event_bus.clone(),
+        ) {
+            Ok(server) => Some(server),
+            Err(e) => {
+                // IPC is non-essential for the TUI itself — fail soft so users
+                // without the required socket permissions can still use ccmux
+                // as a plain multiplexer.
+                eprintln!("ccmux: IPC server failed to start ({e}); external commands disabled.");
+                None
+            }
+        },
+        None => None,
     };
 
     // Phase 1 (--exec): queue the requested command on the initial focused


### PR DESCRIPTION
## Summary
Issue #58 対応。Unix IPC エンドポイントの UID 解決と permission 処理の強化。

### Problem
- \`src/ipc/endpoint.rs::uid()\` が \`\$UID\` env var に依存、未設定時に \`1000\` 固定フォールバック
  - bash 内部変数で非 bash / 非 login shell では未 export → 別ユーザーと衝突
  - \`/tmp/ccmux-1000/\` を複数ユーザーが共有する事態
- ディレクトリの \`0o700\` chmod が silently 無視されていた → owner-only 前提が保証されない

### Fix
- **libc を Unix 限定で追加**: \`Cargo.toml\` に \`[target.'cfg(unix)'.dependencies] libc = "0.2"\` 追加
- **Real uid via libc::getuid()**: \`unsafe { libc::getuid() as u32 }\` で OS 由来の実 UID を取得。\`\$UID\` / \`1000\` fallback 廃止
- **Fail-closed on chmod**: \`set_permissions(0o700)\` 失敗を \`?\` で propagate。\`create_dir_all\` + chmod が成功しない限り IPC 起動しない
- **Unix 限定 regression tests** (2 本追加):
  - \`unix_real_uid_is_independent_of_env\`: \`\$UID=1337\` に変更しても real uid が変わらない
  - \`unix_socket_dir_fallback_uses_real_uid_not_env\`: \`\$TMPDIR\` / \`\$XDG_RUNTIME_DIR\` を消して \`\$UID=9999\` にしても \`/tmp/ccmux-<real_uid>\` のパスになる

### Platform impact
- Unix: 実 UID ベースで衝突しないディレクトリ、chmod 失敗時は早期エラー
- Windows: 無変更 (Named Pipe は UID スコープ不要)

## Test plan
- [x] cargo build (Windows local): success
- [x] cargo test (Windows local): 211 passed (Unix 限定テストは CI Linux/macOS で実行)
- [x] cargo clippy --all-targets -- -D warnings: clean
- [x] cargo fmt: applied
- [ ] CI 3 プラットフォーム