### PR TITLE
chore: bump version to 0.5.7-fork.3 (security patch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.7-fork.2"
+version = "0.5.7-fork.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccmux"
-version = "0.5.7-fork.2"
+version = "0.5.7-fork.3"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.7-fork.2",
+  "version": "0.5.7-fork.3",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
**Security patch release**。v0.5.7-fork.2 以降の 2 つの fail-closed 強化 (PR #61 + PR #65) を束ねる。

### Highlights
- **npm installer hardening** (#57, PR #61):
  - Redirect 先を GitHub Release hosts の allow-list に制限
  - Checksum 取得 / lookup が失敗したら warn+continue ではなく install 失敗
  - \`.tmp\` にダウンロード → verify → rename。install 毎にユニーク名 \`.bak\` で旧バイナリ保全。Windows AV ロック対策の EBUSY/EPERM retry あり
- **Unix IPC real uid** (#58, PR #65):
  - \`libc::getuid()\` で実 UID 取得。\`\$UID\` env + 1000 固定 fallback 廃止 → 非 bash / 非 login shell でも正しく動作、クロスユーザー衝突なし
  - \`set_permissions(0o700)\` 失敗を silent ignore ではなく \`?\` で伝播
  - \`main.rs\` で endpoint 取得失敗時は IPC 無効化して TUI 継続 (plain multiplexer として利用可能)

### 非破壊
Protocol / API / CLI 無変更。v0.5.7-fork.2 からのドロップイン。

## Release process
マージ後:
1. \`git tag v0.5.7-fork.3 && git push origin v0.5.7-fork.3\`
2. CI で 4 プラットフォーム release build + GitHub Release + npm publish (next)

## Test plan
- [x] Cargo.toml / npm/package.json / Cargo.lock 同期
- [x] cargo build --release (Windows local): success
- [x] cargo test: 211 passed
- [ ] CI 3 プラットフォーム