### PR TITLE
docs: drop the -fork.N prerelease suffix; use plain semver next

### DIFF
--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -74,9 +74,10 @@ gh pr create --repo Shin-sibainu/ccmux --base master
 
 ## リリース・npm パッケージ
 
-- Git tag: フォーク識別子付き prerelease (`vX.Y.Z-fork.N` 等) を利用
-- npm パッケージ名: 上流と衝突しないフォーク専用の名前を使用
-- 具体的な移行作業は関連 Issue を参照
+- **Git tag**: 普通の semver (`vX.Y.Z`)。v0.5.7-fork.1 〜 v0.5.7-fork.3 では `-fork.N` 接尾辞で prerelease 扱いしていたが、フォークは npm パッケージ名 (`ccmux-fork`) と GitHub リポジトリ名で既にアイデンティティが確保されており、suffix は誤った "pre" 信号をユーザーに送るだけだった (v0.5.7-fork.3 リリース後に見直し)。今後は通常の semver で切る。
+- **Prerelease が必要な場合** (大規模変更の先行公開など): `vX.Y.Z-rc.N` / `-beta.N` 等を使う。`contains(github.ref_name, '-')` で workflow が自動的に prerelease 扱い + npm dist-tag `next` に振り分ける (`.github/workflows/release.yml`)
+- **npm パッケージ名**: 上流と衝突しないよう `ccmux-fork` を使用
+- 上流 (`Shin-sibainu/ccmux`) は `0.5.x` 系を別途リリースしているが、こちらの fork はそれとは独立に semver を進める。バージョン番号の同期は取らない
 
 ## ブランチ保護
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,19 @@ cargo run            # Run the app
 
 ## Release Process
 1. `Cargo.toml` と `npm/package.json` のバージョンを同じ値に揃えて上げる
-2. コミット & `git push origin main`
+2. PR で `main` に merge (main は PR 必須)
 3. `git tag vX.Y.Z && git push origin vX.Y.Z`
 4. CI (`.github/workflows/release.yml`) が自動で実行:
    - 4プラットフォーム (Windows x64, macOS x64/arm64, Linux x64) のリリースビルド
    - GitHub Release 作成 + checksums.txt 生成
    - npm publish (Trusted Publishing)
+
+### タグ命名
+- 通常は **`vX.Y.Z` (plain semver)** を使う。これで GitHub Release が stable、npm dist-tag が `latest` になる。
+- 先行公開したい場合だけ `vX.Y.Z-rc.N` / `-beta.N` / `-alpha.N` 等を使う。workflow が `ref_name` に `-` を含むかで自動的に prerelease + npm `next` に振り分ける。
+- 過去に `vX.Y.Z-fork.N` suffix で全リリースを prerelease 扱いしていたが、フォーク識別子はパッケージ名 (`ccmux-fork`) とリポジトリ名で既に確保されており、実運用中のバージョンを "pre" として出す意味がなかったため v0.5.7-fork.3 以降廃止。
+
+### やってはいけない
 - **手動で `npm publish` や `gh release create` しないこと** — バージョン衝突の原因になる
 
 ## Fork & Branching


### PR DESCRIPTION
## Summary
リリースタグの \`vX.Y.Z-fork.N\` 接尾辞運用を **廃止**、以降は plain semver (\`vX.Y.Z\`) を使う。

## Motivation
- \`-fork.N\` があると semver が prerelease と見なし、\`.github/workflows/release.yml\` が自動で:
  - GitHub Release に赤い "Pre-release" バッジ
  - npm dist-tag を \`next\` に振る (\`latest\` は 0.5.4 のまま据え置き)
- その結果 \`npm i -g ccmux-fork\` で古い 0.5.4 が入り、ユーザーは \`@next\` を明示しないと新機能に到達できない状態
- 元々の意図 (上流との衝突防止 / フォーク識別) は npm パッケージ名 (\`ccmux-fork\`) と GitHub リポジトリ名で確保されているので suffix は冗長

## Changes
- **CLAUDE.md Release Process**: 通常は plain semver、prerelease は \`-rc.N\` / \`-beta.N\` 等、`-fork.N` 廃止の経緯を追記
- **BRANCHING.md**: リリース節を書き直して同じ方針を記述、上流とバージョン同期を取らない旨も明記

## Scope
Docs only. Workflow 側 (\`.github/workflows/release.yml\`) は \`contains(github.ref_name, '-')\` で分岐するので、プレリリース機構自体は残る。次回以降の release タグで plain semver を使い始めるだけ。

## Next release
この PR merge 後、次のパッチは **v0.5.8** (plain) から。過去の v0.5.7-fork.3 は履歴として残すが修正しない。

Refs: CLAUDE.md Release Process + BRANCHING.md 「リリース・npm パッケージ」