### PR TITLE
fix(deps): bump interprocess 2.4.0 → 2.4.2 to stop silent __fastfail on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,15 +956,15 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
  "libc",
  "recvmsg",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,13 @@ dirs = "5"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-interprocess = "2"
+# 2.4.2 removes the `CannotUnwind` guard from `exsync_op`. On 2.4.0 a
+# Win32 write failure during IPC — normal when a `ccmux events` client
+# disconnects ahead of the 30 s heartbeat — propagated via `?` before
+# the guard's `.end()` ran, so its `Drop` aborted the whole TUI via
+# `std::process::abort()` / `__fastfail`. Silent death, no panic. Pin
+# so a downgrade can't reintroduce it.
+interprocess = "2.4.2"
 oneshot = "0.1"
 subtle = "2"
 humantime = "2"


### PR DESCRIPTION
## Summary
- interprocess 2.4.0's \`exsync_op\` wraps Win32 async I/O in a \`CannotUnwind\` guard whose \`Drop\` calls \`std::process::abort()\`. When the pipe peer disconnects, \`?\` error-propagation races the guard's \`.end()\` call, Drop fires, and the whole TUI silent-__fastfails — no panic, no stderr, no hook.
- 2.4.2 removed the guard from \`exsync_op\`; bumping + pinning is enough to fix the regression.
- No code change in ccmux itself.

## Repro (pre-fix)
On Windows 11 (Windows Terminal + Git Bash), any flow that subscribes to \`ccmux events\` with a short timeout and then idles through the server's 30 s heartbeat kills ccmux silently. Windows Event Viewer records \`Application Error\` with exception code \`0xc0000409\` (\`__fastfail(FAST_FAIL_FATAL_APP_EXIT)\`). Faulting offset resolved (via debug PDB + llvm-objdump) to \`interprocess::os::windows::c_wrappers::exsync_op\`'s \`CannotUnwind\` Drop path.

Triggering sequence:
1. A client runs \`ccmux events --timeout 3s\`.
2. The client exits after 3 s and closes the pipe.
3. Server's \`stream_events_inner\` is sleeping on \`rx.recv_timeout(HEARTBEAT_INTERVAL)\` (30 s).
4. Heartbeat timer fires → \`sink.write_all(...)\`.
5. \`WriteFileEx\` returns 0 / \`ERROR_BROKEN_PIPE\` → \`?\` → \`CannotUnwind::drop\` → \`abort()\`.

ccmux's own \`sink.write_all(...).is_err()\` guard never got a chance to run.

## Why not #74
Initial suspicion was PR #74 (c13662b), but a clean pre-#74 build (5dd91fc) reproduced the same Event Viewer entry. The bug predates #74 and was latent since interprocess 2.4.0 was added.

## Test plan
- [x] \`cargo test\` — 222/222 green
- [x] Reproduce on Windows 11 / Windows Terminal / Git Bash with a workflow that spins up the events-subscribe → disconnect → heartbeat sequence — previously 100% death, now survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)