### PR TITLE
chore: bump version to 0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.7-fork.3"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccmux"
-version = "0.5.7-fork.3"
+version = "0.5.8"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.7-fork.3",
+  "version": "0.5.8",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary

First plain-semver release since #70 dropped the \`-fork.N\` prerelease suffix convention.

## What's in 0.5.8

- **#75** — \`fix(deps): bump interprocess 2.4.0 → 2.4.2 to stop silent __fastfail\`  
  On Windows, \`interprocess 2.4.0\`'s \`exsync_op\` wrapped Win32 async I/O in a \`CannotUnwind\` guard whose \`Drop\` aborts the process. \`?\` error-propagation on a broken pipe raced the \`.end()\` call, \`__fastfail\` fired, the TUI vanished silently (exit code \`0xc0000409\`). 2.4.2 removed the guard; pinning here so a downgrade can't reintroduce it.

- **#76** — \`fix(ipc): emit PaneStarted after name/role attach on split\`  
  \`split_focused_pane\` and \`new_tab\` emitted \`PaneStarted\` before their IPC callers attached \`name\` / \`role\`, so subscribers always received \`name: None, role: None\` and documented \`ccmux events | jq 'select(.type == "pane_started" and .name == "<id>")'\` patterns silently missed every spawn. Refactored both helpers to return the new pane id (plus \`Option\` for refused splits) and emit in the callers after attach. Added 4 regression tests covering both helpers and the refused path.

## Release process

After merge, tag \`v0.5.8\` and push — \`release.yml\` handles the rest (cross-platform build, GitHub Release, npm publish via Trusted Publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)