### PR TITLE
feat(app): make MIN_PANE_WIDTH/HEIGHT configurable via CLI flags (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ ccmux
 
 Launch from any directory. The file tree shows the current working directory.
 
+### Flags
+
+- `--min-pane-width <COLS>` — minimum child columns a split may produce (default `20`). Splits whose halved pane would be narrower are refused. `0` is clamped to `1` to avoid zero-width children.
+- `--min-pane-height <ROWS>` — minimum child rows a split may produce (default `5`). Same clamp rule as `--min-pane-width`.
+
 ## Configuration
 
 Optional. Place a TOML file at:

--- a/src/app.rs
+++ b/src/app.rs
@@ -619,10 +619,12 @@ pub struct App {
     /// Minimum width (cols) each child must retain after a vertical
     /// split. Populated from `--min-pane-width`; `0` is clamped to `1`
     /// in `set_min_pane_size` to avoid degenerate halving math.
-    pub min_pane_width: u16,
+    /// Private — the setter is the only supported entry point so the
+    /// clamp invariant cannot be bypassed.
+    min_pane_width: u16,
     /// Minimum height (rows) each child must retain after a horizontal
-    /// split. See [`App::min_pane_width`] for the clamp rule.
-    pub min_pane_height: u16,
+    /// split. See [`App::set_min_pane_size`] for the clamp rule.
+    min_pane_height: u16,
 }
 
 impl App {
@@ -4039,8 +4041,10 @@ mod tests {
         // the attached name. Exercises the runtime wiring that CLI
         // parse tests cannot cover.
         let mut app = App::new(40, 80).expect("App::new");
-        app.set_min_pane_size(10, 3);
 
+        // First split runs under defaults (20 / 5) so the cached rect
+        // geometry feeding the second split is identical to the
+        // refusal test's setup — only the threshold itself differs.
         app.handle_split(
             &ipc::PaneRef::Focused,
             ipc::Direction::Vertical,
@@ -4049,6 +4053,11 @@ mod tests {
             None,
         )
         .expect("first split should succeed");
+
+        // Lower the threshold just before the split that would
+        // otherwise refuse, so the causal contrast with the sibling
+        // refusal test is explicit in the test body.
+        app.set_min_pane_size(10, 3);
 
         let (_sub_id, rx) = app.event_bus.subscribe();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -616,6 +616,13 @@ pub struct App {
     /// by `maybe_auto_open_always_overlay` to detect focus changes
     /// and clear `always_dismissed_pane`.
     last_focused_pane: Option<usize>,
+    /// Minimum width (cols) each child must retain after a vertical
+    /// split. Populated from `--min-pane-width`; `0` is clamped to `1`
+    /// in `set_min_pane_size` to avoid degenerate halving math.
+    pub min_pane_width: u16,
+    /// Minimum height (rows) each child must retain after a horizontal
+    /// split. See [`App::min_pane_width`] for the clamp rule.
+    pub min_pane_height: u16,
 }
 
 impl App {
@@ -678,6 +685,8 @@ impl App {
             ime_mode: crate::config::ImeMode::default(),
             always_dismissed_pane: None,
             last_focused_pane: None,
+            min_pane_width: 20,
+            min_pane_height: 5,
         })
     }
 
@@ -687,6 +696,15 @@ impl App {
     /// collapsed into a single resolved value.
     pub fn apply_config(&mut self, cfg: &crate::config::Config) {
         self.ime_mode = cfg.ime.mode;
+    }
+
+    /// Override the minimum per-child split dimensions. Values of `0`
+    /// are clamped to `1` so `rect.width / 2 < min` stays meaningful
+    /// (`0` would let splits succeed on a 1-column pane and produce
+    /// zero-width children).
+    pub fn set_min_pane_size(&mut self, width: u16, height: u16) {
+        self.min_pane_width = width.max(1);
+        self.min_pane_height = height.max(1);
     }
 
     /// In `Always` mode, make sure the IME overlay is open whenever
@@ -1581,8 +1599,6 @@ impl App {
     }
 
     const MAX_PANES: usize = 16;
-    const MIN_PANE_WIDTH: u16 = 20;
-    const MIN_PANE_HEIGHT: u16 = 5;
 
     /// Create a new pane by splitting the focused one. Returns the new
     /// pane id on success, or `None` when the split was refused because
@@ -1606,12 +1622,12 @@ impl App {
         {
             match direction {
                 SplitDirection::Vertical => {
-                    if rect.width / 2 < Self::MIN_PANE_WIDTH {
+                    if rect.width / 2 < self.min_pane_width {
                         return Ok(None);
                     }
                 }
                 SplitDirection::Horizontal => {
-                    if rect.height / 2 < Self::MIN_PANE_HEIGHT {
+                    if rect.height / 2 < self.min_pane_height {
                         return Ok(None);
                     }
                 }
@@ -3959,7 +3975,8 @@ mod tests {
     #[test]
     fn split_refused_keeps_focus_and_emits_no_pane_started() {
         // Drive handle_split into its refused arm (pane too small
-        // after halving, below MIN_PANE_WIDTH) and confirm:
+        // after halving, below `min_pane_width` — default 20) and
+        // confirm:
         //   * SPLIT_REFUSED bubbles up,
         //   * focus stays where it was,
         //   * the requested name is NOT registered,
@@ -3981,7 +3998,8 @@ mod tests {
         let (_sub_id, rx) = app.event_bus.subscribe();
 
         // Second vertical split on the now-focused ~30-col pane would
-        // produce ~15-col children, below MIN_PANE_WIDTH (20) → refuse.
+        // produce ~15-col children, below `min_pane_width` (default
+        // 20) → refuse.
         let err = app
             .handle_split(
                 &ipc::PaneRef::Focused,
@@ -4008,6 +4026,74 @@ mod tests {
             .any(|ev| matches!(ev, ipc::Event::PaneStarted { .. }));
         assert!(!any_started, "refused split must not emit PaneStarted");
 
+        app.shutdown();
+    }
+
+    #[test]
+    fn set_min_pane_size_lets_split_succeed_below_default_threshold() {
+        // With defaults (20 / 5), a second vertical split on a
+        // ~30-col pane refuses (same geometry as
+        // `split_refused_keeps_focus_and_emits_no_pane_started`).
+        // Lowering the threshold via `set_min_pane_size` must let the
+        // same split succeed and emit exactly one PaneStarted with
+        // the attached name. Exercises the runtime wiring that CLI
+        // parse tests cannot cover.
+        let mut app = App::new(40, 80).expect("App::new");
+        app.set_min_pane_size(10, 3);
+
+        app.handle_split(
+            &ipc::PaneRef::Focused,
+            ipc::Direction::Vertical,
+            None,
+            Some("first".into()),
+            None,
+        )
+        .expect("first split should succeed");
+
+        let (_sub_id, rx) = app.event_bus.subscribe();
+
+        let new_id = app
+            .handle_split(
+                &ipc::PaneRef::Focused,
+                ipc::Direction::Vertical,
+                None,
+                Some("narrow".into()),
+                None,
+            )
+            .expect("split should succeed once min_pane_width is lowered");
+
+        assert_eq!(app.ws().focused_pane_id, new_id, "focus moves to new pane");
+        assert_eq!(
+            app.ws().pane_names.get("narrow").copied(),
+            Some(new_id),
+            "requested name registers on success"
+        );
+
+        let started_ids: Vec<usize> = rx
+            .try_iter()
+            .filter_map(|ev| match ev {
+                ipc::Event::PaneStarted { id, .. } => Some(id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            started_ids,
+            vec![new_id],
+            "exactly one PaneStarted for the freshly-created pane"
+        );
+
+        app.shutdown();
+    }
+
+    #[test]
+    fn set_min_pane_size_clamps_zero_to_one() {
+        // `--min-pane-width 0` would make `rect.width / 2 < 0` always
+        // false and let splits succeed on 1-col panes. The setter
+        // must floor the value at 1.
+        let mut app = App::new(40, 80).expect("App::new");
+        app.set_min_pane_size(0, 0);
+        assert_eq!(app.min_pane_width, 1);
+        assert_eq!(app.min_pane_height, 1);
         app.shutdown();
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -740,9 +740,8 @@ mod tests {
         // Non-zero override is stored verbatim; the runtime clamp of
         // `0 → 1` lives in `App::set_min_pane_size`, not in clap, so
         // this parses without error.
-        let cli =
-            Cli::try_parse_from(["ccmux", "--min-pane-width", "0", "--min-pane-height", "3"])
-                .unwrap();
+        let cli = Cli::try_parse_from(["ccmux", "--min-pane-width", "0", "--min-pane-height", "3"])
+            .unwrap();
         assert_eq!(cli.min_pane_width, 0);
         assert_eq!(cli.min_pane_height, 3);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,19 @@ pub struct Cli {
     ///   never opened.
     #[arg(long, value_name = "MODE", value_enum)]
     pub ime: Option<crate::config::ImeMode>,
+
+    /// Minimum columns each child pane must retain after a vertical
+    /// split. Splits that would produce a narrower child are refused.
+    /// A value of `0` is clamped to `1` at runtime to avoid degenerate
+    /// halving math. Default: 20.
+    #[arg(long, value_name = "COLS", default_value_t = 20)]
+    pub min_pane_width: u16,
+
+    /// Minimum rows each child pane must retain after a horizontal
+    /// split. Splits that would produce a shorter child are refused.
+    /// A value of `0` is clamped to `1` at runtime. Default: 5.
+    #[arg(long, value_name = "ROWS", default_value_t = 5)]
+    pub min_pane_height: u16,
 }
 
 /// Subcommands dispatched to a running ccmux instance via its IPC
@@ -713,6 +726,31 @@ mod tests {
     fn ime_flag_is_optional() {
         let cli = Cli::try_parse_from(["ccmux"]).unwrap();
         assert_eq!(cli.ime, None);
+    }
+
+    #[test]
+    fn min_pane_size_defaults_to_20_and_5() {
+        let cli = Cli::try_parse_from(["ccmux"]).unwrap();
+        assert_eq!(cli.min_pane_width, 20);
+        assert_eq!(cli.min_pane_height, 5);
+    }
+
+    #[test]
+    fn min_pane_size_accepts_override_and_zero() {
+        // Non-zero override is stored verbatim; the runtime clamp of
+        // `0 → 1` lives in `App::set_min_pane_size`, not in clap, so
+        // this parses without error.
+        let cli =
+            Cli::try_parse_from(["ccmux", "--min-pane-width", "0", "--min-pane-height", "3"])
+                .unwrap();
+        assert_eq!(cli.min_pane_width, 0);
+        assert_eq!(cli.min_pane_height, 3);
+
+        let cli2 =
+            Cli::try_parse_from(["ccmux", "--min-pane-width", "12", "--min-pane-height", "4"])
+                .unwrap();
+        assert_eq!(cli2.min_pane_width, 12);
+        assert_eq!(cli2.min_pane_height, 4);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,7 @@ fn main() -> Result<()> {
     // Create app (spawns the initial pane, which captures the env above).
     let mut app = app::App::new(size.height, size.width)?;
     app.apply_config(&user_config);
+    app.set_min_pane_size(cli.min_pane_width, cli.min_pane_height);
 
     // Keep the server handle alive for the process lifetime; its Drop
     // impl cleans up the Unix socket file on exit.


### PR DESCRIPTION
## Summary
- `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` をハードコードの const から `App` の private フィールド + `set_min_pane_size` setter に格上げ
- clap に `--min-pane-width <COLS>` / `--min-pane-height <ROWS>`（default 20 / 5、`u16`）を追加
- `main.rs` で `apply_config` 直後に setter を呼び、CLI 値で config を上書き
- `0` が渡された場合は setter 内で `1` にクランプ（ゼロ除算防止）。挙動は README / clap doc comment で明示

Closes #78

## Scope notes（本 PR の対象外）
- 環境変数 `CCMUX_MIN_PANE_*` サポート
- `config.toml` への追加
- Issue #78 の Additional ideas（`--target-largest` / rect JSON 出力）

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`（warning なし）
- [x] `cargo test` 全 230 passed（新規 4 本含む: `min_pane_size_defaults_to_20_and_5` / `min_pane_size_accepts_override_and_zero` / `set_min_pane_size_lets_split_succeed_below_default_threshold` / `set_min_pane_size_clamps_zero_to_one`）
- [x] 既存テスト `split_refused_keeps_focus_and_emits_no_pane_started` も従来どおり pass（既定値 20/5 で挙動不変）
- [x] 後方互換: `App::new` のシグネチャ・既定挙動とも不変（既存 14 箇所の呼び出しは無変更で動作）

## Review history
- Plan 設計レビュー（Codex）: App レベルテスト追加、0→1 クランプの README 明示を追補
- 実装レビュー（Codex）: nit 2 件（テストの因果コントラストを鋭くする / フィールド private 化）を追補コミット `cba8400` で反映

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>