### PR TITLE
feat(ime): throttle event::poll while overlay is open (#38, Phase 1 of #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Launch from any directory. The file tree shows the current working directory.
 
 - `--min-pane-width <COLS>` — minimum child columns a split may produce (default `20`). Splits whose halved pane would be narrower are refused. `0` is clamped to `1` to avoid zero-width children.
 - `--min-pane-height <ROWS>` — minimum child rows a split may produce (default `5`). Same clamp rule as `--min-pane-width`.
+- `--ime-overlay-poll-ms <MS>` — idle `event::poll` timeout (ms) while the IME composition overlay is open (default `166`, preliminary per Issue #82). Larger values throttle flicker during JP composition without affecting key/paste/mouse responsiveness. Values below `10` are clamped up. Also settable via `[ime] overlay_poll_ms` in `config.toml`.
 
 ## Configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -606,6 +606,11 @@ pub struct App {
     /// IME overlay mode resolved from config + CLI. `Off` disables
     /// the Ctrl+; hotkey so the keystroke reaches the PTY untouched.
     pub ime_mode: crate::config::ImeMode,
+    /// Resolved main-loop `event::poll` timeout (ms) to use while the
+    /// IME composition overlay is open. Populated from config + CLI
+    /// by [`App::apply_config`] and consumed by the main loop in
+    /// `src/main.rs`. See Issue #38.
+    pub ime_overlay_poll_ms: u64,
     /// In `Always` mode, the pane id where the user explicitly
     /// dismissed (Esc with empty buffer / Ctrl+C) the auto-opened
     /// overlay. Blocks re-open on the same focus. Cleared whenever
@@ -685,6 +690,7 @@ impl App {
             clipboard: None,
             event_bus,
             ime_mode: crate::config::ImeMode::default(),
+            ime_overlay_poll_ms: crate::config::DEFAULT_OVERLAY_POLL_MS,
             always_dismissed_pane: None,
             last_focused_pane: None,
             min_pane_width: 20,
@@ -698,6 +704,14 @@ impl App {
     /// collapsed into a single resolved value.
     pub fn apply_config(&mut self, cfg: &crate::config::Config) {
         self.ime_mode = cfg.ime.mode;
+        // Config::apply_cli_overrides already clamped this to
+        // MIN_OVERLAY_POLL_MS, but re-apply the floor here so direct
+        // tests that mutate cfg.ime.overlay_poll_ms without going
+        // through the setter still get a safe value.
+        self.ime_overlay_poll_ms = cfg
+            .ime
+            .overlay_poll_ms
+            .max(crate::config::MIN_OVERLAY_POLL_MS);
     }
 
     /// Override the minimum per-child split dimensions. Values of `0`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,15 @@ pub struct Cli {
     #[arg(long, value_name = "MODE", value_enum)]
     pub ime: Option<crate::config::ImeMode>,
 
+    /// Main-loop `event::poll` timeout (ms) while the IME composition
+    /// overlay is open (Issue #38). Throttles idle redraws during JP
+    /// IME composition; key / paste / mouse / resize events still
+    /// interrupt the poll immediately so responsiveness is preserved.
+    /// Values below 10 are clamped up to 10. Overrides `[ime]
+    /// overlay_poll_ms` in config.toml. Default: 166 (preliminary).
+    #[arg(long, value_name = "MS")]
+    pub ime_overlay_poll_ms: Option<u64>,
+
     /// Minimum columns each child pane must retain after a vertical
     /// split. Splits that would produce a narrower child are refused.
     /// A value of `0` is clamped to `1` at runtime to avoid degenerate
@@ -726,6 +735,18 @@ mod tests {
     fn ime_flag_is_optional() {
         let cli = Cli::try_parse_from(["ccmux"]).unwrap();
         assert_eq!(cli.ime, None);
+    }
+
+    #[test]
+    fn ime_overlay_poll_ms_defaults_to_none() {
+        let cli = Cli::try_parse_from(["ccmux"]).unwrap();
+        assert_eq!(cli.ime_overlay_poll_ms, None);
+    }
+
+    #[test]
+    fn parses_ime_overlay_poll_ms_override() {
+        let cli = Cli::try_parse_from(["ccmux", "--ime-overlay-poll-ms", "250"]).unwrap();
+        assert_eq!(cli.ime_overlay_poll_ms, Some(250));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,10 +22,37 @@ pub struct Config {
 /// IME overlay settings. See Issue #39 for the full mode design;
 /// `always_on` lives behind Issue #40 and is explicitly not accepted
 /// here yet.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct ImeConfig {
     pub mode: ImeMode,
+    /// Main-loop `event::poll` timeout (ms) while the IME composition
+    /// overlay is open (Issue #38). Higher values throttle redraws
+    /// during composition at the cost of a slightly less responsive
+    /// cancel/commit path on very slow typists. Input events (key /
+    /// paste / mouse / resize) still interrupt the poll immediately,
+    /// so only the idle redraw rate is affected. Clamped to
+    /// `MIN_OVERLAY_POLL_MS` at apply time to avoid degenerate near-0
+    /// timeouts. Default is 166 ms — preliminary, to be finalized by
+    /// the PoC benchmark described in Issue #82.
+    pub overlay_poll_ms: u64,
+}
+
+/// Preliminary default overlay `event::poll` timeout. See
+/// [`ImeConfig::overlay_poll_ms`].
+pub const DEFAULT_OVERLAY_POLL_MS: u64 = 166;
+
+/// Floor for `overlay_poll_ms`. Values below this (including 0) are
+/// clamped up so the main loop never spins on a 0-ms poll.
+pub const MIN_OVERLAY_POLL_MS: u64 = 10;
+
+impl Default for ImeConfig {
+    fn default() -> Self {
+        Self {
+            mode: ImeMode::default(),
+            overlay_poll_ms: DEFAULT_OVERLAY_POLL_MS,
+        }
+    }
 }
 
 /// How Ctrl+; behaves in a focused pane.
@@ -136,12 +163,20 @@ impl Config {
         }
     }
 
-    /// Apply an optional CLI override on top of the loaded config.
+    /// Apply optional CLI overrides on top of the loaded config.
     /// `None` leaves the field untouched, mirroring the precedence
-    /// "CLI > file > default".
-    pub fn apply_cli_overrides(&mut self, ime_mode: Option<ImeMode>) {
+    /// "CLI > file > default". `overlay_poll_ms` is clamped to
+    /// [`MIN_OVERLAY_POLL_MS`] whether it arrived via CLI, file, or
+    /// default, so the main loop never sees a sub-floor value.
+    pub fn apply_cli_overrides(&mut self, ime_mode: Option<ImeMode>, overlay_poll_ms: Option<u64>) {
         if let Some(mode) = ime_mode {
             self.ime.mode = mode;
+        }
+        if let Some(ms) = overlay_poll_ms {
+            self.ime.overlay_poll_ms = ms;
+        }
+        if self.ime.overlay_poll_ms < MIN_OVERLAY_POLL_MS {
+            self.ime.overlay_poll_ms = MIN_OVERLAY_POLL_MS;
         }
     }
 }
@@ -243,7 +278,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(Some(ImeMode::Off));
+        cfg.apply_cli_overrides(Some(ImeMode::Off), None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -256,7 +291,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None);
+        cfg.apply_cli_overrides(None, None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -296,6 +331,59 @@ mod tests {
         let cfg = Config::load_from(&tmp);
         std::fs::remove_file(&tmp).ok();
         assert_eq!(cfg.ime.mode, ImeMode::Hotkey);
+    }
+
+    #[test]
+    fn default_overlay_poll_ms_is_preliminary_166() {
+        let cfg = Config::default();
+        assert_eq!(cfg.ime.overlay_poll_ms, DEFAULT_OVERLAY_POLL_MS);
+        assert_eq!(DEFAULT_OVERLAY_POLL_MS, 166);
+    }
+
+    #[test]
+    fn parses_overlay_poll_ms_from_toml() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            mode = "hotkey"
+            overlay_poll_ms = 200
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.ime.overlay_poll_ms, 200);
+    }
+
+    #[test]
+    fn cli_overlay_poll_ms_beats_file() {
+        let mut cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            overlay_poll_ms = 200
+            "#,
+        )
+        .unwrap();
+        cfg.apply_cli_overrides(None, Some(333));
+        assert_eq!(cfg.ime.overlay_poll_ms, 333);
+    }
+
+    #[test]
+    fn overlay_poll_ms_clamps_below_floor() {
+        // Sub-floor values from config must be clamped up, even when no
+        // CLI override is provided, so the main loop never sees a 0 ms
+        // poll.
+        let mut cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            overlay_poll_ms = 0
+            "#,
+        )
+        .unwrap();
+        cfg.apply_cli_overrides(None, None);
+        assert_eq!(cfg.ime.overlay_poll_ms, MIN_OVERLAY_POLL_MS);
+
+        let mut cfg2 = Config::default();
+        cfg2.apply_cli_overrides(None, Some(1));
+        assert_eq!(cfg2.ime.overlay_poll_ms, MIN_OVERLAY_POLL_MS);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> Result<()> {
 
     // Load user config + apply CLI override (CLI > file > default).
     let mut user_config = config::Config::load();
-    user_config.apply_cli_overrides(cli.ime);
+    user_config.apply_cli_overrides(cli.ime, cli.ime_overlay_poll_ms);
 
     // Create app (spawns the initial pane, which captures the env above).
     let mut app = app::App::new(size.height, size.width)?;
@@ -382,8 +382,18 @@ fn run_event_loop(
             break;
         }
 
-        // Poll for crossterm events with a short timeout (~30fps)
-        if event::poll(Duration::from_millis(33))? {
+        // Poll for crossterm events. Normal rate is ~30 fps (33 ms);
+        // while the IME composition overlay is open we stretch the
+        // timeout (Issue #38) so Claude's thinking spinner doesn't
+        // force a repaint every frame during JP composition. Any real
+        // input (key / paste / mouse / resize) interrupts the poll
+        // immediately, so perceived latency is unaffected.
+        let poll_timeout = if app.overlay.is_some() {
+            Duration::from_millis(app.ime_overlay_poll_ms)
+        } else {
+            Duration::from_millis(33)
+        };
+        if event::poll(poll_timeout)? {
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     let consumed = app.handle_key_event(key)?;


### PR DESCRIPTION
## Summary

Phase 1 of the IME overlay epic (#82). While the IME composition overlay is open, the main loop now polls crossterm events with a configurable timeout (default **166 ms**, preliminary) instead of the baseline 33 ms. Claude's thinking spinner and other idle PTY activity can no longer force a repaint every frame during JP composition, but real input (key / paste / mouse / resize) still interrupts the poll immediately so commit / cancel stays responsive.

- New `--ime-overlay-poll-ms <MS>` CLI flag
- New `[ime] overlay_poll_ms` config field
- Precedence mirrors the existing `--ime` flag: **CLI > config file > default**
- Values below 10 ms are clamped up to 10 ms so the main loop can never spin on a 0 ms poll
- `App::ime_overlay_poll_ms` carries the resolved value; `apply_config` re-applies the floor defensively
- README gains a one-liner under the Flags section

## Why 166 ms as the default

Issue #82 explicitly names 166 ms as the 暫定 default to ship with the CLI flag, so the 6-condition benchmark (33 / 100 / 166 / 200 / 300 / 500 ms × 2 terminals) described in the epic can be run against real terminals. The final value will be locked in by that benchmark in a follow-up; this PR's purpose is to make the comparison feasible.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 243 pass, 0 fail (+6 new tests covering CLI parse, TOML parse, CLI > file precedence, sub-floor clamp)
- [x] `cargo fmt --all -- --check`
- [ ] Manual bench per epic: Windows Terminal + wezterm (or VS Code terminal), 6 poll values × 30 s, Claude Thinking running in a split pane, overlay opened in the other — record FPS / CPU / subjective flicker
- [ ] Pick final default, update README + DEFAULT_OVERLAY_POLL_MS in a follow-up

## Dependencies / Stacking

Does **not** depend on #83 (Phase 0 refactor); this PR touches `src/app.rs` / `src/main.rs` / `src/cli.rs` / `src/config.rs` / `README.md` only. The two PRs can merge in either order.

Refs: #82, #38