### PR TITLE
feat(ime): opt-in pane freeze + periodic catch-up while overlay is open (#37, Phase 2 of #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Launch from any directory. The file tree shows the current working directory.
 - `--min-pane-width <COLS>` — minimum child columns a split may produce (default `20`). Splits whose halved pane would be narrower are refused. `0` is clamped to `1` to avoid zero-width children.
 - `--min-pane-height <ROWS>` — minimum child rows a split may produce (default `5`). Same clamp rule as `--min-pane-width`.
 - `--ime-freeze-panes[=BOOL]` — freeze pane repaints while the IME composition overlay is open (default `false`). Suppresses flicker from Claude's thinking spinner and other background PTY output during JP composition; panes catch up instantly when the overlay closes. Pass the bare flag to enable, or `=false` to force-disable a config `true`. Also settable via `[ime] freeze_panes_on_overlay` in `config.toml`.
-- `--ime-overlay-catchup-ms <MS>` — when `--ime-freeze-panes` is active, force a single repaint every `<MS>` milliseconds so body-content progress stays visible through an open overlay (default `0` = disabled, pure freeze). Non-zero values are clamped to at least `100`. Also settable via `[ime] overlay_catchup_ms` in `config.toml`.
+- `--ime-overlay-catchup-ms <MS>` — when `--ime-freeze-panes` is active, force a single repaint every `<MS>` milliseconds so body-content progress stays visible through an open overlay (default `0` = disabled, pure freeze). `3000`–`5000` is the sweet spot: flicker stays barely noticeable while Claude's streaming output still advances at a readable pace. Non-zero values are clamped to at least `100`. Also settable via `[ime] overlay_catchup_ms` in `config.toml`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Launch from any directory. The file tree shows the current working directory.
 - `--min-pane-width <COLS>` — minimum child columns a split may produce (default `20`). Splits whose halved pane would be narrower are refused. `0` is clamped to `1` to avoid zero-width children.
 - `--min-pane-height <ROWS>` — minimum child rows a split may produce (default `5`). Same clamp rule as `--min-pane-width`.
 - `--ime-freeze-panes[=BOOL]` — freeze pane repaints while the IME composition overlay is open (default `false`). Suppresses flicker from Claude's thinking spinner and other background PTY output during JP composition; panes catch up instantly when the overlay closes. Pass the bare flag to enable, or `=false` to force-disable a config `true`. Also settable via `[ime] freeze_panes_on_overlay` in `config.toml`.
+- `--ime-overlay-catchup-ms <MS>` — when `--ime-freeze-panes` is active, force a single repaint every `<MS>` milliseconds so body-content progress stays visible through an open overlay (default `0` = disabled, pure freeze). Non-zero values are clamped to at least `100`. Also settable via `[ime] overlay_catchup_ms` in `config.toml`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Launch from any directory. The file tree shows the current working directory.
 
 - `--min-pane-width <COLS>` — minimum child columns a split may produce (default `20`). Splits whose halved pane would be narrower are refused. `0` is clamped to `1` to avoid zero-width children.
 - `--min-pane-height <ROWS>` — minimum child rows a split may produce (default `5`). Same clamp rule as `--min-pane-width`.
+- `--ime-freeze-panes[=BOOL]` — freeze pane repaints while the IME composition overlay is open (default `false`). Suppresses flicker from Claude's thinking spinner and other background PTY output during JP composition; panes catch up instantly when the overlay closes. Pass the bare flag to enable, or `=false` to force-disable a config `true`. Also settable via `[ime] freeze_panes_on_overlay` in `config.toml`.
 
 ## Configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -538,6 +538,19 @@ pub struct App {
     /// cwd update) still repaint because those affect non-pane UI
     /// (tab labels, sidebar).
     pub ime_freeze_panes_on_overlay: bool,
+    /// When freeze is enabled, optionally force a single repaint every
+    /// `ime_overlay_catchup_ms` milliseconds so the user sees body-
+    /// content progress periodically without the flicker of live
+    /// repaints. `0` disables the periodic catch-up (pure freeze,
+    /// matches the original Phase 2 behavior). Clamped to
+    /// `MIN_OVERLAY_CATCHUP_MS` at apply time when non-zero to avoid
+    /// a tight repaint loop.
+    pub ime_overlay_catchup_ms: u64,
+    /// Instant of the last overlay-era repaint (open or catch-up
+    /// tick). Populated by [`App::maybe_tick_overlay_catchup`] and
+    /// cleared when the overlay closes. `None` outside an overlay
+    /// session.
+    last_overlay_repaint: Option<Instant>,
     /// In `Always` mode, the pane id where the user explicitly
     /// dismissed (Esc with empty buffer / Ctrl+C) the auto-opened
     /// overlay. Blocks re-open on the same focus. Cleared whenever
@@ -618,6 +631,8 @@ impl App {
             event_bus,
             ime_mode: crate::config::ImeMode::default(),
             ime_freeze_panes_on_overlay: false,
+            ime_overlay_catchup_ms: 0,
+            last_overlay_repaint: None,
             always_dismissed_pane: None,
             last_focused_pane: None,
             min_pane_width: 20,
@@ -632,6 +647,52 @@ impl App {
     pub fn apply_config(&mut self, cfg: &crate::config::Config) {
         self.ime_mode = cfg.ime.mode;
         self.ime_freeze_panes_on_overlay = cfg.ime.freeze_panes_on_overlay;
+        // 0 means "catch-up disabled"; any non-zero value is floored
+        // at MIN_OVERLAY_CATCHUP_MS so a fat-fingered `--…-catchup-ms 5`
+        // can't turn freeze into a ~200 fps repaint storm.
+        self.ime_overlay_catchup_ms = if cfg.ime.overlay_catchup_ms == 0 {
+            0
+        } else {
+            cfg.ime
+                .overlay_catchup_ms
+                .max(crate::config::MIN_OVERLAY_CATCHUP_MS)
+        };
+    }
+
+    /// Time-based catch-up for the freeze-panes-on-overlay path.
+    /// While the overlay is open AND freeze is on AND catch-up is
+    /// configured to a non-zero interval, force a single repaint
+    /// whenever the interval has elapsed. The user sees periodic
+    /// body-content progress (Claude writing new lines, shell output
+    /// scrolling) without the continuous flicker that plain
+    /// freeze=off produces. No-op otherwise.
+    pub fn maybe_tick_overlay_catchup(&mut self) {
+        if self.overlay.is_none() {
+            // Reset timer so the next open starts clean; otherwise a
+            // catch-up could fire 0 ms after a fresh open if the
+            // previous session left a stale Instant behind.
+            self.last_overlay_repaint = None;
+            return;
+        }
+        if !self.ime_freeze_panes_on_overlay || self.ime_overlay_catchup_ms == 0 {
+            return;
+        }
+        let interval = std::time::Duration::from_millis(self.ime_overlay_catchup_ms);
+        let now = Instant::now();
+        match self.last_overlay_repaint {
+            None => {
+                // First tick of this overlay session — anchor the
+                // timer at "now" without repainting, so the first
+                // catch-up fires `interval` after open, not
+                // immediately.
+                self.last_overlay_repaint = Some(now);
+            }
+            Some(prev) if now.duration_since(prev) >= interval => {
+                self.dirty = true;
+                self.last_overlay_repaint = Some(now);
+            }
+            _ => {}
+        }
     }
 
     /// Override the minimum per-child split dimensions. Values of `0`
@@ -3213,6 +3274,100 @@ mod tests {
             app.dirty,
             "PtyOutput should dirty the app when freeze is disabled"
         );
+    }
+
+    #[test]
+    fn overlay_catchup_noop_when_no_overlay() {
+        // No overlay open → catch-up must never dirty or set the
+        // anchor timer, regardless of config values.
+        let mut app = App::new(40, 80).expect("App::new");
+        app.ime_freeze_panes_on_overlay = true;
+        app.ime_overlay_catchup_ms = 1000;
+        app.overlay = None;
+        app.dirty = false;
+
+        app.maybe_tick_overlay_catchup();
+
+        assert!(!app.dirty);
+        assert!(app.last_overlay_repaint.is_none());
+    }
+
+    #[test]
+    fn overlay_catchup_noop_when_disabled() {
+        // Catch-up interval of 0 = disabled. Even with freeze on and
+        // overlay open, no repaint should be forced.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.ime_overlay_catchup_ms = 0;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        app.maybe_tick_overlay_catchup();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        app.maybe_tick_overlay_catchup();
+
+        assert!(!app.dirty);
+    }
+
+    #[test]
+    fn overlay_catchup_first_call_anchors_without_repaint() {
+        // First tick of a freshly-opened overlay should seed the
+        // timer at "now" without firing a repaint — the first real
+        // catch-up lands `interval` later, not immediately on open.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.ime_overlay_catchup_ms = 500;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        app.maybe_tick_overlay_catchup();
+
+        assert!(!app.dirty, "first tick must not repaint");
+        assert!(
+            app.last_overlay_repaint.is_some(),
+            "first tick must anchor the timer"
+        );
+    }
+
+    #[test]
+    fn overlay_catchup_fires_after_interval() {
+        // Simulate an elapsed interval by backdating last_overlay_repaint.
+        // `maybe_tick_overlay_catchup` should then mark dirty and
+        // re-anchor the timer.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.ime_overlay_catchup_ms = 100;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+        app.last_overlay_repaint = Some(Instant::now() - std::time::Duration::from_millis(150));
+
+        app.maybe_tick_overlay_catchup();
+
+        assert!(app.dirty, "elapsed interval must force a repaint");
+        let anchor = app.last_overlay_repaint.expect("timer stays set");
+        assert!(
+            Instant::now().duration_since(anchor) < std::time::Duration::from_millis(50),
+            "timer must be re-anchored to ~now"
+        );
+    }
+
+    #[test]
+    fn overlay_catchup_clears_timer_when_overlay_closes() {
+        // If the overlay closes between ticks, the timer must reset
+        // so the next session doesn't inherit a stale anchor that
+        // could fire a catch-up 0 ms after open.
+        let mut app = App::new(40, 80).expect("App::new");
+        app.ime_freeze_panes_on_overlay = true;
+        app.ime_overlay_catchup_ms = 500;
+        app.overlay = None;
+        app.last_overlay_repaint = Some(Instant::now());
+
+        app.maybe_tick_overlay_catchup();
+
+        assert!(app.last_overlay_repaint.is_none());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3254,6 +3254,141 @@ mod tests {
     }
 
     #[test]
+    fn freeze_panes_still_repaints_on_pty_eof() {
+        // State-changing events must punch through the freeze: PtyEof
+        // flips `pane.exited` and emits PaneExited, which in turn
+        // changes the pane chrome (title dim-out, etc.), so the user
+        // needs to see it even mid-composition.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        app.event_tx
+            .send(AppEvent::PtyEof(pane_a))
+            .expect("send PtyEof");
+        app.drain_pty_events();
+
+        assert!(
+            app.dirty,
+            "PtyEof must dirty the app even under freeze — pane chrome changes"
+        );
+    }
+
+    #[test]
+    fn freeze_panes_still_repaints_on_cwd_changed() {
+        // CwdChanged rewrites the workspace name and rebuilds the
+        // file-tree sidebar; a frozen overlay must not starve those
+        // UI-chrome updates.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        // temp_dir() is canonicalizable and is_dir() on every tier-1
+        // platform, so the CwdChanged handler will take the full
+        // "update" branch instead of the early `continue`.
+        let tmp = std::env::temp_dir();
+        app.event_tx
+            .send(AppEvent::CwdChanged(pane_a, tmp))
+            .expect("send CwdChanged");
+        app.drain_pty_events();
+
+        assert!(
+            app.dirty,
+            "CwdChanged must dirty the app even under freeze — sidebar/tab label depend on it"
+        );
+    }
+
+    #[test]
+    fn freeze_panes_mixed_batch_repaints_when_any_state_change_present() {
+        // A single drain pass may pick up both a spinner PtyOutput
+        // and a concurrent PtyEof; the state change must win so the
+        // user isn't left with a stale pane title while the overlay
+        // is open.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        app.event_tx
+            .send(AppEvent::PtyOutput(pane_a))
+            .expect("send PtyOutput");
+        app.event_tx
+            .send(AppEvent::PtyEof(pane_a))
+            .expect("send PtyEof");
+        app.drain_pty_events();
+
+        assert!(
+            app.dirty,
+            "mixed batch with any state-changing event must repaint"
+        );
+    }
+
+    #[test]
+    fn overlay_catchup_noop_when_freeze_disabled() {
+        // Catch-up is gated on freeze being on — otherwise the main
+        // loop is already repainting at the overlay poll rate, and
+        // an extra forced repaint would be redundant. Verify the
+        // freeze-off short-circuit holds even with an elapsed timer.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = false;
+        app.ime_overlay_catchup_ms = 100;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+        app.last_overlay_repaint = Some(Instant::now() - std::time::Duration::from_millis(500));
+
+        app.maybe_tick_overlay_catchup();
+
+        assert!(
+            !app.dirty,
+            "catch-up must not fire when freeze is disabled, even if interval elapsed"
+        );
+    }
+
+    #[test]
+    fn overlay_catchup_timer_reanchors_on_reopen_cycle() {
+        // Close then re-open: the timer state from the previous
+        // session must not carry over, or the first tick after
+        // re-open could fire a catch-up with 0 ms elapsed.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.ime_overlay_catchup_ms = 500;
+
+        // Simulate a prior session that advanced the timer.
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.maybe_tick_overlay_catchup();
+        assert!(app.last_overlay_repaint.is_some());
+
+        // Close the overlay; next tick should clear the timer.
+        app.overlay = None;
+        app.maybe_tick_overlay_catchup();
+        assert!(
+            app.last_overlay_repaint.is_none(),
+            "closing the overlay must clear the catch-up anchor"
+        );
+
+        // Re-open and tick: first tick of the new session should
+        // anchor WITHOUT painting, even though wall-time elapsed.
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+        app.maybe_tick_overlay_catchup();
+        assert!(
+            !app.dirty,
+            "first tick of a fresh re-open must not force a repaint"
+        );
+        assert!(
+            app.last_overlay_repaint.is_some(),
+            "first tick of a fresh re-open must re-anchor"
+        );
+    }
+
+    #[test]
     fn freeze_panes_off_still_repaints_on_pty_output() {
         // Sanity: with freeze disabled the legacy behavior is
         // preserved — PtyOutput dirties the app even while the

--- a/src/app.rs
+++ b/src/app.rs
@@ -531,6 +531,13 @@ pub struct App {
     /// IME overlay mode resolved from config + CLI. `Off` disables
     /// the Ctrl+; hotkey so the keystroke reaches the PTY untouched.
     pub ime_mode: crate::config::ImeMode,
+    /// When `true`, PTY-output-driven repaints are suppressed while
+    /// the IME composition overlay is open (Issue #37 / #82 Phase 2).
+    /// Populated from config + CLI via [`App::apply_config`]; consumed
+    /// by [`App::drain_pty_events`]. State-changing events (pane exit,
+    /// cwd update) still repaint because those affect non-pane UI
+    /// (tab labels, sidebar).
+    pub ime_freeze_panes_on_overlay: bool,
     /// In `Always` mode, the pane id where the user explicitly
     /// dismissed (Esc with empty buffer / Ctrl+C) the auto-opened
     /// overlay. Blocks re-open on the same focus. Cleared whenever
@@ -610,6 +617,7 @@ impl App {
             clipboard: None,
             event_bus,
             ime_mode: crate::config::ImeMode::default(),
+            ime_freeze_panes_on_overlay: false,
             always_dismissed_pane: None,
             last_focused_pane: None,
             min_pane_width: 20,
@@ -623,6 +631,7 @@ impl App {
     /// collapsed into a single resolved value.
     pub fn apply_config(&mut self, cfg: &crate::config::Config) {
         self.ime_mode = cfg.ime.mode;
+        self.ime_freeze_panes_on_overlay = cfg.ime.freeze_panes_on_overlay;
     }
 
     /// Override the minimum per-child split dimensions. Values of `0`
@@ -2361,10 +2370,18 @@ impl App {
 
     pub fn drain_pty_events(&mut self) -> bool {
         let mut had_events = false;
+        // Track state-changing events (pane exit, cwd update) separately
+        // from raw PTY output. When `ime_freeze_panes_on_overlay` is on
+        // and the overlay is open we suppress repaints caused by pure
+        // PTY output so Claude's thinking spinner can't flicker the
+        // overlay, but state-changing events still need to repaint
+        // because they affect non-pane UI (tab labels, sidebar cwd).
+        let mut had_state_change = false;
         while let Ok(event) = self.event_rx.try_recv() {
             had_events = true;
             match event {
                 AppEvent::PtyEof(pane_id) => {
+                    had_state_change = true;
                     let mut exit_meta: Option<(Option<String>, Option<String>)> = None;
                     for ws in &mut self.workspaces {
                         if let Some(pane) = ws.panes.get_mut(&pane_id) {
@@ -2386,6 +2403,7 @@ impl App {
                     }
                 }
                 AppEvent::CwdChanged(pane_id, new_cwd) => {
+                    had_state_change = true;
                     // Security: resolve symlinks and relative components.
                     // Reject paths that don't resolve to a real directory
                     // (prevents OSC 7 escape sequence path injection).
@@ -2419,7 +2437,10 @@ impl App {
             }
         }
         if had_events {
-            self.dirty = true;
+            let freeze_output = self.ime_freeze_panes_on_overlay && self.overlay.is_some();
+            if had_state_change || !freeze_output {
+                self.dirty = true;
+            }
         }
         had_events
     }
@@ -3143,6 +3164,74 @@ mod tests {
         // `ime_mode != Always` without observing or clearing state.
         assert_eq!(app.always_dismissed_pane, Some(pane_a));
         assert!(app.overlay.is_none());
+    }
+
+    #[test]
+    fn freeze_panes_suppresses_pty_output_repaint_when_overlay_open() {
+        // With freeze enabled and the overlay open, a burst of
+        // PtyOutput events must NOT mark the app dirty, so the screen
+        // stays frozen while the user composes JP text. vt100 parser
+        // work happens on reader threads and is unaffected by this
+        // gate, so panes catch up instantly when the overlay closes.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        // Push a PtyOutput directly through the event channel —
+        // drain_pty_events treats it as the pure-output no-op case.
+        app.event_tx
+            .send(AppEvent::PtyOutput(pane_a))
+            .expect("send PtyOutput");
+        app.drain_pty_events();
+
+        assert!(
+            !app.dirty,
+            "PtyOutput must not dirty the app while overlay is open and freeze is on"
+        );
+    }
+
+    #[test]
+    fn freeze_panes_off_still_repaints_on_pty_output() {
+        // Sanity: with freeze disabled the legacy behavior is
+        // preserved — PtyOutput dirties the app even while the
+        // overlay is open. This is the pre-#37 baseline and how the
+        // flag's default (false) has to behave.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = false;
+        app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+        app.dirty = false;
+
+        app.event_tx
+            .send(AppEvent::PtyOutput(pane_a))
+            .expect("send PtyOutput");
+        app.drain_pty_events();
+
+        assert!(
+            app.dirty,
+            "PtyOutput should dirty the app when freeze is disabled"
+        );
+    }
+
+    #[test]
+    fn freeze_panes_does_not_suppress_without_overlay() {
+        // Freeze is gated on overlay being open. With the overlay
+        // closed the flag must have no effect, so normal editing
+        // stays responsive.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_a = app.ws().focused_pane_id;
+        app.ime_freeze_panes_on_overlay = true;
+        app.overlay = None;
+        app.dirty = false;
+
+        app.event_tx
+            .send(AppEvent::PtyOutput(pane_a))
+            .expect("send PtyOutput");
+        app.drain_pty_events();
+
+        assert!(app.dirty, "PtyOutput must dirty when overlay is closed");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,17 @@ pub struct Cli {
     )]
     pub ime_freeze_panes: Option<bool>,
 
+    /// While `--ime-freeze-panes` is active, force a single repaint
+    /// every `<MS>` milliseconds so body-content progress (Claude
+    /// writing new lines, shell output scrolling) stays visible
+    /// through an open overlay. `0` (default) keeps the freeze
+    /// pure — the screen stops updating until the overlay closes.
+    /// Non-zero values are clamped to at least 100 ms. Has no
+    /// effect while freeze is disabled. Overrides `[ime]
+    /// overlay_catchup_ms` in config.toml.
+    #[arg(long, value_name = "MS")]
+    pub ime_overlay_catchup_ms: Option<u64>,
+
     /// Minimum columns each child pane must retain after a vertical
     /// split. Splits that would produce a narrower child are refused.
     /// A value of `0` is clamped to `1` at runtime to avoid degenerate
@@ -761,6 +772,18 @@ mod tests {
     fn ime_freeze_panes_explicit_false_overrides_config() {
         let cli = Cli::try_parse_from(["ccmux", "--ime-freeze-panes=false"]).unwrap();
         assert_eq!(cli.ime_freeze_panes, Some(false));
+    }
+
+    #[test]
+    fn ime_overlay_catchup_ms_defaults_to_none() {
+        let cli = Cli::try_parse_from(["ccmux"]).unwrap();
+        assert_eq!(cli.ime_overlay_catchup_ms, None);
+    }
+
+    #[test]
+    fn parses_ime_overlay_catchup_ms_override() {
+        let cli = Cli::try_parse_from(["ccmux", "--ime-overlay-catchup-ms", "3000"]).unwrap();
+        assert_eq!(cli.ime_overlay_catchup_ms, Some(3000));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,23 @@ pub struct Cli {
     #[arg(long, value_name = "MODE", value_enum)]
     pub ime: Option<crate::config::ImeMode>,
 
+    /// Suppress pane repaints while the IME composition overlay is
+    /// open (Issue #37 / #82 Phase 2). PTY output keeps flowing into
+    /// the vt100 parser in the background; the screen just stops
+    /// updating, so Claude's thinking spinner can't flicker the
+    /// overlay. Panes catch up instantly when the overlay closes.
+    /// Overrides `[ime] freeze_panes_on_overlay` in config.toml.
+    /// Pass `--ime-freeze-panes=false` to force-disable a config
+    /// value of `true`.
+    #[arg(
+        long,
+        value_name = "BOOL",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+    )]
+    pub ime_freeze_panes: Option<bool>,
+
     /// Minimum columns each child pane must retain after a vertical
     /// split. Splits that would produce a narrower child are refused.
     /// A value of `0` is clamped to `1` at runtime to avoid degenerate
@@ -726,6 +743,24 @@ mod tests {
     fn ime_flag_is_optional() {
         let cli = Cli::try_parse_from(["ccmux"]).unwrap();
         assert_eq!(cli.ime, None);
+    }
+
+    #[test]
+    fn ime_freeze_panes_defaults_to_none() {
+        let cli = Cli::try_parse_from(["ccmux"]).unwrap();
+        assert_eq!(cli.ime_freeze_panes, None);
+    }
+
+    #[test]
+    fn ime_freeze_panes_bare_flag_means_true() {
+        let cli = Cli::try_parse_from(["ccmux", "--ime-freeze-panes"]).unwrap();
+        assert_eq!(cli.ime_freeze_panes, Some(true));
+    }
+
+    #[test]
+    fn ime_freeze_panes_explicit_false_overrides_config() {
+        let cli = Cli::try_parse_from(["ccmux", "--ime-freeze-panes=false"]).unwrap();
+        assert_eq!(cli.ime_freeze_panes, Some(false));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,20 @@ pub struct ImeConfig {
     /// though it's the intended way to kill overlay flicker on hosts
     /// where `overlay_poll_ms` throttling alone isn't enough.
     pub freeze_panes_on_overlay: bool,
+    /// When [`ImeConfig::freeze_panes_on_overlay`] is true, optionally
+    /// force a single repaint every `overlay_catchup_ms` milliseconds
+    /// so the user sees body-content progress (Claude writing new
+    /// lines, shell output scrolling) periodically without the
+    /// continuous flicker of unthrottled repaints. `0` disables the
+    /// periodic catch-up and gives a pure freeze. Non-zero values are
+    /// clamped to [`MIN_OVERLAY_CATCHUP_MS`] at apply time.
+    pub overlay_catchup_ms: u64,
 }
+
+/// Floor for `overlay_catchup_ms` when non-zero. Below this the
+/// periodic repaint becomes a near-continuous storm that defeats the
+/// point of freezing in the first place.
+pub const MIN_OVERLAY_CATCHUP_MS: u64 = 100;
 
 /// How Ctrl+; behaves in a focused pane.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, clap::ValueEnum)]
@@ -152,12 +165,22 @@ impl Config {
         &mut self,
         ime_mode: Option<ImeMode>,
         freeze_panes_on_overlay: Option<bool>,
+        overlay_catchup_ms: Option<u64>,
     ) {
         if let Some(mode) = ime_mode {
             self.ime.mode = mode;
         }
         if let Some(freeze) = freeze_panes_on_overlay {
             self.ime.freeze_panes_on_overlay = freeze;
+        }
+        if let Some(ms) = overlay_catchup_ms {
+            self.ime.overlay_catchup_ms = ms;
+        }
+        // Clamp any non-zero value regardless of origin so the main
+        // loop never sees a sub-floor interval.
+        if self.ime.overlay_catchup_ms != 0 && self.ime.overlay_catchup_ms < MIN_OVERLAY_CATCHUP_MS
+        {
+            self.ime.overlay_catchup_ms = MIN_OVERLAY_CATCHUP_MS;
         }
     }
 }
@@ -259,7 +282,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(Some(ImeMode::Off), None);
+        cfg.apply_cli_overrides(Some(ImeMode::Off), None, None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -272,7 +295,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, None);
+        cfg.apply_cli_overrides(None, None, None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -341,12 +364,53 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, Some(false));
+        cfg.apply_cli_overrides(None, Some(false), None);
         assert!(!cfg.ime.freeze_panes_on_overlay);
 
         let mut cfg2 = Config::default();
-        cfg2.apply_cli_overrides(None, Some(true));
+        cfg2.apply_cli_overrides(None, Some(true), None);
         assert!(cfg2.ime.freeze_panes_on_overlay);
+    }
+
+    #[test]
+    fn overlay_catchup_ms_defaults_to_zero() {
+        let cfg = Config::default();
+        assert_eq!(cfg.ime.overlay_catchup_ms, 0);
+    }
+
+    #[test]
+    fn parses_overlay_catchup_ms_from_toml() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            overlay_catchup_ms = 2500
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.ime.overlay_catchup_ms, 2500);
+    }
+
+    #[test]
+    fn cli_overlay_catchup_ms_beats_file_and_clamps_below_floor() {
+        let mut cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            overlay_catchup_ms = 500
+            "#,
+        )
+        .unwrap();
+        cfg.apply_cli_overrides(None, None, Some(3000));
+        assert_eq!(cfg.ime.overlay_catchup_ms, 3000);
+
+        let mut cfg2 = Config::default();
+        // Non-zero sub-floor value must be clamped up.
+        cfg2.apply_cli_overrides(None, None, Some(10));
+        assert_eq!(cfg2.ime.overlay_catchup_ms, MIN_OVERLAY_CATCHUP_MS);
+
+        // Zero must stay zero (means "disabled").
+        let mut cfg3 = Config::default();
+        cfg3.apply_cli_overrides(None, None, Some(0));
+        assert_eq!(cfg3.ime.overlay_catchup_ms, 0);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,15 @@ pub struct Config {
 #[serde(default)]
 pub struct ImeConfig {
     pub mode: ImeMode,
+    /// When `true`, pane repaints driven by PTY output are suppressed
+    /// while the IME composition overlay is open (Issue #37 / #82
+    /// Phase 2). vt100 parsers keep advancing in the background, so
+    /// panes catch up instantly when the overlay closes. Off by
+    /// default because it's a user-visible behavior change (the
+    /// screen literally stops updating during composition) even
+    /// though it's the intended way to kill overlay flicker on hosts
+    /// where `overlay_poll_ms` throttling alone isn't enough.
+    pub freeze_panes_on_overlay: bool,
 }
 
 /// How Ctrl+; behaves in a focused pane.
@@ -139,9 +148,16 @@ impl Config {
     /// Apply an optional CLI override on top of the loaded config.
     /// `None` leaves the field untouched, mirroring the precedence
     /// "CLI > file > default".
-    pub fn apply_cli_overrides(&mut self, ime_mode: Option<ImeMode>) {
+    pub fn apply_cli_overrides(
+        &mut self,
+        ime_mode: Option<ImeMode>,
+        freeze_panes_on_overlay: Option<bool>,
+    ) {
         if let Some(mode) = ime_mode {
             self.ime.mode = mode;
+        }
+        if let Some(freeze) = freeze_panes_on_overlay {
+            self.ime.freeze_panes_on_overlay = freeze;
         }
     }
 }
@@ -243,7 +259,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(Some(ImeMode::Off));
+        cfg.apply_cli_overrides(Some(ImeMode::Off), None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -256,7 +272,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None);
+        cfg.apply_cli_overrides(None, None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -296,6 +312,41 @@ mod tests {
         let cfg = Config::load_from(&tmp);
         std::fs::remove_file(&tmp).ok();
         assert_eq!(cfg.ime.mode, ImeMode::Hotkey);
+    }
+
+    #[test]
+    fn freeze_panes_defaults_to_false() {
+        let cfg = Config::default();
+        assert!(!cfg.ime.freeze_panes_on_overlay);
+    }
+
+    #[test]
+    fn parses_freeze_panes_from_toml() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            freeze_panes_on_overlay = true
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.ime.freeze_panes_on_overlay);
+    }
+
+    #[test]
+    fn cli_freeze_panes_beats_file() {
+        let mut cfg: Config = toml::from_str(
+            r#"
+            [ime]
+            freeze_panes_on_overlay = true
+            "#,
+        )
+        .unwrap();
+        cfg.apply_cli_overrides(None, Some(false));
+        assert!(!cfg.ime.freeze_panes_on_overlay);
+
+        let mut cfg2 = Config::default();
+        cfg2.apply_cli_overrides(None, Some(true));
+        assert!(cfg2.ime.freeze_panes_on_overlay);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> Result<()> {
 
     // Load user config + apply CLI override (CLI > file > default).
     let mut user_config = config::Config::load();
-    user_config.apply_cli_overrides(cli.ime, cli.ime_freeze_panes);
+    user_config.apply_cli_overrides(cli.ime, cli.ime_freeze_panes, cli.ime_overlay_catchup_ms);
 
     // Create app (spawns the initial pane, which captures the env above).
     let mut app = app::App::new(size.height, size.width)?;
@@ -353,6 +353,11 @@ fn run_event_loop(
         // so the host terminal's IME has an anchor from the start.
         // Idempotent and cheap.
         app.maybe_auto_open_always_overlay();
+
+        // Phase 2 (#37) catch-up: when freeze+catch-up is enabled,
+        // periodically force a single repaint so body content stays
+        // visible through an open overlay. No-op otherwise.
+        app.maybe_tick_overlay_catchup();
 
         // Only render when something changed (and no cooldown is active)
         if app.dirty && app.paste_cooldown == 0 && app.resize_cooldown == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> Result<()> {
 
     // Load user config + apply CLI override (CLI > file > default).
     let mut user_config = config::Config::load();
-    user_config.apply_cli_overrides(cli.ime);
+    user_config.apply_cli_overrides(cli.ime, cli.ime_freeze_panes);
 
     // Create app (spawns the initial pane, which captures the env above).
     let mut app = app::App::new(size.height, size.width)?;


### PR DESCRIPTION
## Summary

Phase 2 of the IME overlay epic (#82). Addresses Issue #37 with a **lighter dirty-gate variant** rather than the vt100 snapshot originally sketched — see design notes below.

Two opt-in flags that stack:

- **`--ime-freeze-panes[=BOOL]`** — while the IME composition overlay is open, pane repaints driven by pure \`PtyOutput\` are suppressed. Claude's thinking spinner and other idle PTY chatter can no longer flicker the overlay. vt100 parsers keep advancing in background reader threads, so panes catch up instantly when the overlay closes. State-changing events (\`PtyEof\`, \`CwdChanged\`) still repaint because tab labels / sidebar cwd depend on them. Default: **off**.
- **`--ime-overlay-catchup-ms <MS>`** — when freeze is on, force a single repaint every \`<MS>\` ms so body-content progress stays visible without continuous flicker. \`0\` (default) keeps the pure freeze. Non-zero values are clamped to ≥ 100 ms. **\`3000\`–\`5000\` is the tested sweet spot** and now recommended in the README.

Both also settable via \`[ime]\` in \`config.toml\`:

\`\`\`toml
[ime]
freeze_panes_on_overlay = true
overlay_catchup_ms = 3000
\`\`\`

## Why dirty-gate instead of vt100 snapshot

Issue #37 originally proposed cloning each pane's \`vt100::Screen\` on overlay open and rendering from the snapshot. This PR takes a lighter path with equivalent user-visible semantics:

| | Snapshot approach | This PR (dirty-gate) |
|---|---|---|
| Memory overhead | 10–60 MB transient per open (epic's pessimistic estimate) | 0 |
| Code surface | ui.rs + Overlay + render plumbing | one branch in \`drain_pty_events\` + config |
| vt100::Cell implementation risk | must audit before shipping | N/A |
| User-visible semantics | screen stops updating during overlay | screen stops updating during overlay |

The catch-up timer (option B from the epic discussion thread) is content-agnostic, so it keeps working through Claude UI changes — unlike a scrollback-diff heuristic that can silently hide short body updates.

## Stacking with #84 (Phase 1 poll_ms throttle)

Both PRs touch \`apply_cli_overrides\`, the \`App\` \`ime_*\` fields, and \`main.rs\`. Whichever merges first will leave the other with conflicts in the config signature — easy to resolve (just add the extra argument).

This PR does **not** include the \`--ime-overlay-poll-ms\` flag from #84; the two features are orthogonal and can land in either order. With freeze enabled, #84's poll throttle has less work to do because the spinner stops triggering repaints anyway.

## Test plan

- [x] \`cargo check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` — 256 pass, 0 fail (+19 new tests across config parse / CLI parse / freeze gating / catch-up timer behavior)
- [x] \`cargo fmt --all -- --check\`
- [x] Manual smoke: \`cargo run --release -- --ime-freeze-panes --ime-overlay-catchup-ms 3000\`, split + run \`claude\`, fire a long prompt, open overlay, confirm pane freezes and catches up every 3 s

## TODO (post-merge)

- [ ] Close Issue #37 as "resolved via dirty-gate; snapshot approach shelved"
- [ ] Update Issue #82 TODO list to reflect Phase 2 landing with case B (catch-up) built in

Refs: #82, #37