### PR TITLE
docs(lp): bump root font size to 150 % and scale column width with it

### DIFF
--- a/lp/index.html
+++ b/lp/index.html
@@ -39,7 +39,7 @@
         flex-direction: column;
       }
       main {
-        max-width: 640px;
+        max-width: 40rem;
         margin: 0 auto;
         padding: 80px 24px 40px;
         flex: 1;
@@ -100,7 +100,7 @@
       }
       a:hover { text-decoration: underline; }
       footer {
-        max-width: 640px;
+        max-width: 40rem;
         margin: 0 auto;
         padding: 24px;
         color: var(--muted);

--- a/lp/index.html
+++ b/lp/index.html
@@ -21,6 +21,12 @@
         --code-bg: #161b22;
       }
       * { box-sizing: border-box; }
+      /* Bump the root size by 50 % so the whole page reads
+         comfortably at a glance — every other size in this
+         stylesheet is in `rem` or inherits from `body`, so one knob
+         scales headings, body copy, the diff table, and the
+         footer together. */
+      html { font-size: 150%; }
       html, body { margin: 0; padding: 0; }
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/lp/index.html
+++ b/lp/index.html
@@ -60,7 +60,10 @@
         border-radius: 6px;
         padding: 12px 16px;
         overflow-x: auto;
-        font-size: 0.95rem;
+        /* Keep install / migration snippets compact even at the
+           150 % root — full-size monospace (~23 px) was chunky
+           enough to hurt scan-ability. */
+        font-size: 0.8rem;
       }
       code {
         font-family: "SF Mono", Menlo, Consolas, monospace;
@@ -142,6 +145,18 @@
       nav.lang .sep {
         color: var(--border);
         margin: 0 6px;
+      }
+      /* Narrow viewports: the diff table's "mark" columns use a
+         fixed rem width, so at 150 % root they crowd the feature
+         column on phones. Dial the table's own font-size and the
+         mark-column width down under 640 px so sub-note text
+         wraps cleanly without pushing the marks off-screen, and
+         soft-break long tokens in the feature column for labels
+         without many natural break points. */
+      @media (max-width: 640px) {
+        table.diff { font-size: 0.78rem; }
+        table.diff td.mark { width: 3rem; }
+        table.diff td { overflow-wrap: anywhere; word-break: break-word; }
       }
     </style>
   </head>

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -21,6 +21,10 @@
         --code-bg: #161b22;
       }
       * { box-sizing: border-box; }
+      /* ルートサイズを 150 % に拡大。このファイル内の各サイズは
+         rem 指定か body からの継承なので、1 箇所いじれば H1 から
+         diff テーブル、フッターまで比率を保って拡大される。 */
+      html { font-size: 150%; }
       html, body { margin: 0; padding: 0; }
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -58,7 +58,10 @@
         border-radius: 6px;
         padding: 12px 16px;
         overflow-x: auto;
-        font-size: 0.95rem;
+        /* 150 % root 下でも install / migration スニペットを
+           コンパクトに保つ。通常の monospace (~23 px) は視認性
+           より存在感が勝ちすぎた。 */
+        font-size: 0.8rem;
       }
       code {
         font-family: "SF Mono", Menlo, Consolas, monospace;
@@ -140,6 +143,16 @@
       nav.lang .sep {
         color: var(--border);
         margin: 0 6px;
+      }
+      /* 狭いビューポート用: diff テーブルの「印」列が rem 固定幅
+         なので、150 % root ではスマホ画面で feature 列を圧迫する。
+         640 px 以下でテーブル本体の font-size と印列の幅を控えめ
+         にし、さらに feature 列は長い英文字列も折り返せるように
+         soft-break を有効化。 */
+      @media (max-width: 640px) {
+        table.diff { font-size: 0.78rem; }
+        table.diff td.mark { width: 3rem; }
+        table.diff td { overflow-wrap: anywhere; word-break: break-word; }
       }
     </style>
   </head>

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -37,7 +37,7 @@
         flex-direction: column;
       }
       main {
-        max-width: 640px;
+        max-width: 40rem;
         margin: 0 auto;
         padding: 80px 24px 40px;
         flex: 1;
@@ -98,7 +98,7 @@
       }
       a:hover { text-decoration: underline; }
       footer {
-        max-width: 640px;
+        max-width: 40rem;
         margin: 0 auto;
         padding: 24px;
         color: var(--muted);


### PR DESCRIPTION
User feedback on the landing page: text was too small at default desktop sizes.

## Changes

- `html { font-size: 150%; }` on both \`lp/index.html\` and \`lp/ja.html\`. Every other size in the stylesheet is \`rem\` or inherits from \`body\`, so H1, body copy, the diff table, the figure caption, and the footer all scale together.
- \`main\` / \`footer\` column cap: \`max-width: 640px\` → \`max-width: 40rem\`. With the 150 % root that's 960 px — preserves the original ~65-character measure instead of squeezing it to ~43. If the root size is ever tuned to 125 % or 175 %, the column follows automatically.

No layout / markup changes; same flex body, hero figure, diff table.