### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.5.8"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "ccmux"
-# Fork keeps its own version line; intentionally stays below the
-# upstream `0.6.0` bump. Next release will jump past it when we ship
-# the image-preview sync + our own accumulated changes.
-version = "0.5.8"
+# Fork keeps its own version line. 0.7.0 jumps past upstream 0.6.0 so
+# users can tell fork and upstream apart at a glance, and reflects the
+# breaking change in `mode = "always"` removal (#90) plus the shipped
+# IME overlay rework (#85 / #86) and image-preview sync (#91).
+version = "0.7.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.5.8",
+  "version": "0.7.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
Version bump from **0.5.8 → 0.7.0**, consolidating the 18-commit stretch since the last release. Jumping past upstream's `0.6.0` so fork users can tell the two lines apart at a glance on `npm info`.

After this PR merges, tag and let CI do the rest:

```
git checkout main && git pull
git tag v0.7.0 && git push origin v0.7.0
```

CI will build all four platform binaries, create the GitHub Release with checksums, and run `npm publish` via Trusted Publishing.

---

## Release notes draft (paste into the GitHub Release body after CI creates it)

### ✨ New

- **Centered multi-line IME composition overlay** (#86).
  - `Ctrl+;` opens a floating box at the middle of the terminal.
  - `Alt+Enter` (macOS `Option+Return`) sends, `Ctrl+Enter` works on Windows Terminal / wezterm / VS Code / most Linux terminals.
  - `Enter` inserts a newline; `Ctrl+Home` / `Ctrl+End` navigate the whole buffer. Host-terminal IME candidate windows anchor to the caret inside the box.
- **Opt-in pane freeze + periodic catch-up during IME composition** (#85).
  - `--ime-freeze-panes` suppresses background PTY-driven repaints.
  - `--ime-overlay-catchup-ms 3000` (recommended) lets a single frame through every N ms so Claude's streaming output stays readable without flicker. Sweet spot is `3000`–`5000`.
- **Image preview in the file-tree preview panel** (#91, upstream sync of [Shin-sibainu/ccmux#7](https://github.com/Shin-sibainu/ccmux/pull/7)).
  - PNG / JPEG / GIF / BMP / WebP via `ratatui-image` with automatic protocol pick (Sixel / Kitty / iTerm2 / halfblocks).
- **Configurable minimum pane size** (#79).
  - `--min-pane-width <COLS>` / `--min-pane-height <ROWS>` override the 20 × 5 default so tighter layouts no longer need a source patch.
- **`ccmux list` now includes each pane's screen rect** (#80 / #81) so external tools can match by on-screen position.

### 🛠 Changed

- `OverlayState` and the modal key handler extracted to `src/input/overlay.rs` (#83) as the first slice of #66. No behavior change; sets up the snapshot field the freeze/catch-up work builds on.
- Landing page (`lp/index.html` + `lp/ja.html`) gets an IME overlay hero screenshot, an expanded fork-vs-upstream diff table, and more natural Japanese prose (#87, #88, #89, #92).
- `README.ja.md` added and kept in sync with the EN source.

### ⚠️ BREAKING

- **`[ime] mode = "always"` / `--ime always` removed** (#90). The auto-open variant was never stable enough to recommend — it popped in and out as Claude rewrote its own title, and the state machine around it was carrying its own bugs. Existing configs pinning `mode = "always"` now fail parsing with a clear error; ccmux still starts on defaults (`hotkey`) and prints a warning.
  - **Migration**: drop `mode = "always"` from `config.toml`, keep `mode = "hotkey"` (the default), and press `Ctrl+;` when you want the overlay.

### 🧑‍💻 For JP / CJK IME users

Recommended launch:

```
ccmux --ime-freeze-panes --ime-overlay-catchup-ms 3000
```

Or in `config.toml`:

```toml
[ime]
freeze_panes_on_overlay = true
overlay_catchup_ms = 3000
```

Full keymap and screenshots in [README](./README.md) / [README.ja](./README.ja.md).

### Install

```
npm install -g ccmux-fork
```

Or download a binary from [Releases](https://github.com/happy-ryo/ccmux/releases/tag/v0.7.0).