### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "ccmux"
 # users can tell fork and upstream apart at a glance, and reflects the
 # breaking change in `mode = "always"` removal (#90) plus the shipped
 # IME overlay rework (#85 / #86) and image-preview sync (#91).
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
Patch release consolidating the post-v0.7.0 fixes and the small filetree feature that piggybacked on them.

After this PR merges:

\`\`\`
git checkout main && git pull
git tag v0.7.1 && git push origin v0.7.1
\`\`\`

CI builds all four platform binaries, creates the GitHub Release with checksums, and \`npm publish\`es \`ccmux-fork\` via Trusted Publishing.

---

## Release notes draft (paste into the GitHub Release body after CI creates it)

### 🐛 Fixes

- **IME overlay reachable on WSL + Windows Terminal** (#94). \`Ctrl+;\` is dropped by conpty on WSL because ASCII has no encoding for Ctrl+punctuation. Accept \`Alt+;\` and \`Alt+I\` as portable fallbacks — both arrive as ESC-prefixed sequences that every tier-1 terminal forwards reliably. The VS Code terminal on Linux and a few tmux configs had the same issue and are now reachable too.

### ✨ New

- **Ranger/vifm-style re-root on the file tree** (#95).
  - \`h\` moves the tree root up one level (no-op at the filesystem root).
  - \`l\` descends into the selected directory (no-op on files).
  - \`Enter\` still expands/collapses directories inline, so the tree view and the swap-root view co-exist.
  - Pane-side \`cd\` tracking still wins — a pane's \`CwdChanged\` resets the sidebar to that pane's cwd, overriding any user-driven re-root.

### 🛠 Changed

- **Status-bar hints caught up with the keymap** (part of #95). The bottom status bar now surfaces \`h/l 親/下へ\` in file-tree mode and \`^;/A-; IME入力\` in pane mode. Both shortcuts already existed but weren't hinted.

### Install

\`\`\`
npm install -g ccmux-fork
\`\`\`

Or grab a binary from [Releases](https://github.com/happy-ryo/ccmux/releases/tag/v0.7.1).