### PR TITLE
chore: add opt-in pre-commit hook running cargo fmt --check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Git hooks must keep LF line endings even on Windows checkouts —
+# sh + Git Bash chokes on a `#!/usr/bin/env sh\r\n` shebang because
+# the `\r` ends up as part of the interpreter path.
+.githooks/*        text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+# ccmux pre-commit hook: refuse the commit if `cargo fmt` would change
+# anything. CI (`.github/workflows/ci.yml`) runs the same check, so this
+# exists to surface the failure locally ~8 seconds earlier than the
+# remote runner does — the v0.7.2 i18n PR tripped on exactly this and
+# needed a follow-up fix commit just for whitespace.
+#
+# Opt-in: run `git config core.hooksPath .githooks` once per clone to
+# enable. Not auto-installed because that would rewrite a contributor's
+# existing `.git/hooks` without consent.
+#
+# Scope: format check only. Clippy/test live in CI — running them on
+# every commit would add ~30 s of latency and make fixup commits
+# painful. Contributors who want the full CI check locally can extend
+# this hook or wire a pre-push hook with `cargo clippy && cargo test`.
+
+set -eu
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "pre-commit: cargo not found in PATH — skipping fmt check" >&2
+    exit 0
+fi
+
+if ! cargo fmt --all -- --check; then
+    echo >&2
+    echo "pre-commit: rustfmt would modify staged files. Run \`cargo fmt --all\` and re-stage." >&2
+    exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,4 @@ cargo run            # Run the app
 
 ## Workflow Rules
 - **Every implementation must be reviewed by the evaluator agent** before reporting done. This is a Rust TUI app, so Playwright MCP is not available — the evaluator should perform static review (diff analysis, edge cases, logic correctness, key conflict checks, layout math consistency).
+- **Run `cargo fmt --all` before committing.** CI's `rustfmt` job fails fast on unformatted code, so an unformatted commit costs an extra push-and-wait cycle. The repo ships a `.githooks/pre-commit` that enforces this; enable it with `git config core.hooksPath .githooks` once after cloning.

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,14 @@ cargo build --release
 
 [Rust](https://rustup.rs/) のツールチェインが必要です。
 
+PR を送る予定があるなら、クローン後に一度だけ git hooks を有効化しておいてください:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+pre-commit hook が `cargo fmt --all -- --check` を走らせるので、整形漏れが CI ではなく手元で落ちます。既存の `.git/hooks` を勝手に書き換えないよう opt-in にしています。
+
 ## 使い方
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ cargo build --release
 
 Requires [Rust](https://rustup.rs/) toolchain.
 
+If you plan to send PRs, enable the repo's git hooks once after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This wires up a pre-commit hook that runs `cargo fmt --all -- --check` so a formatting miss fails locally instead of on CI. Opt-in so the setting never rewrites your existing `.git/hooks` without consent.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- #98 landed with a rustfmt failure on first push because `cargo fmt` wasn't run locally. That cost a fixup commit + re-push + full CI cycle. Adding a local pre-commit hook catches it in ~1 s on the commit itself instead of ~15 s into CI.
- The hook is **opt-in** via `git config core.hooksPath .githooks` — not auto-installed, so a contributor's existing `.git/hooks` aren't rewritten without consent.

## What's included

- `.githooks/pre-commit` — sh script that runs `cargo fmt --all -- --check` and exits non-zero if rustfmt would modify anything. Skipped (warning only) if `cargo` isn't on PATH, so the hook doesn't break commits in a stripped-down environment.
- `.gitattributes` (new) — forces LF on `.githooks/*`. Needed because Windows clones with `core.autocrlf=true` would otherwise get `\r\n` on the shebang line, which breaks `#!/usr/bin/env sh`.
- `README.md` / `README.ja.md` — one-liner setup instructions under "From source".
- `CLAUDE.md` — reminder for agents to run fmt before commit + a pointer to the hook setup under "Workflow Rules".

## Scope

**Format only.** Clippy and tests stay in CI. Running them on every commit would add ~30 s of latency and make fixup commits painful. Contributors who want the full CI check locally can extend this hook or layer a pre-push hook with `cargo clippy && cargo test` themselves.

## Test plan

- [x] Local smoke test: `./.githooks/pre-commit` exits 0 on the current tree ✅
- [x] File mode: `git ls-files --stage .githooks/pre-commit` → `100755` (marked executable in the index so Unix clones work without a follow-up `chmod`) ✅
- [x] Line endings: `cat -A .githooks/pre-commit` shows `$` (LF) on every line, no `^M` ✅
- [x] Opt-in behavior: without `git config core.hooksPath .githooks`, the hook doesn't run — default `.git/hooks` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)