### PR TITLE
feat(ime): flip freeze + overlay catchup defaults to on (3000 ms)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -79,8 +79,8 @@ ccmux
 
 - `--min-pane-width <COLS>` — 分割後の各ペインが確保する最小幅 (デフォルト `20`)。これを下回る分割は拒否します。`0` を渡した場合は `1` に丸めて、幅 0 のペインが生まれないようにします。
 - `--min-pane-height <ROWS>` — 分割後の最小行数 (デフォルト `5`)。`--min-pane-width` と同じ丸め規則。
-- `--ime-freeze-panes[=BOOL]` — IME overlay を開いている間、背後のペインの再描画を止めます (デフォルト `false`)。日本語入力中に Claude の Thinking スピナーや裏で流れる出力がちらついて候補窓を邪魔するのを防ぎます。overlay を閉じた瞬間に最新の画面へ追いつきます。フラグだけ渡すと有効、`=false` を付けると config 側の `true` を打ち消せます。`config.toml` の `[ime] freeze_panes_on_overlay` でも指定できます。
-- `--ime-overlay-catchup-ms <MS>` — `--ime-freeze-panes` が有効なとき、指定ミリ秒ごとに 1 フレームだけ再描画を挟み込みます (デフォルト `0` = 無効、完全に凍結)。overlay を開いたまま Claude の出力が進む様子を確認できます。体感では `3000`〜`5000` がちょうど良く、ちらつきはほぼ気にならないまま、Claude の出力を追える程度の間隔で更新されます。`100` 未満は `100` に丸めます。`config.toml` の `[ime] overlay_catchup_ms` でも指定できます。
+- `--ime-freeze-panes[=BOOL]` — IME overlay を開いている間、背後のペインの再描画を止めます (デフォルト `true`)。日本語入力中に Claude の Thinking スピナーや裏で流れる出力がちらついて候補窓を邪魔するのを防ぎます。overlay を閉じた瞬間に最新の画面へ追いつきます。overlay を開かないユーザー (IME を使わない人) には影響しないので ON がデフォルト。入力中も生の再描画を見たい場合は `=false` で無効化できます。`config.toml` の `[ime] freeze_panes_on_overlay` でも指定できます。
+- `--ime-overlay-catchup-ms <MS>` — `--ime-freeze-panes` が有効なとき、指定ミリ秒ごとに 1 フレームだけ再描画を挟み込みます (デフォルト `3000` ms — README の sweet spot。ちらつきはほぼ気にならないまま、Claude の出力を追える程度の間隔で更新)。完全凍結したいなら `0` を渡してください。`100` 未満は `100` に丸めます。`config.toml` の `[ime] overlay_catchup_ms` でも指定できます。
 - `--lang <auto\|ja\|en>` — ステータスバーのヒントやプレビューのエラーメッセージの表示言語 (デフォルト `auto`)。`auto` は OS ロケールを見て、`ja` 系なら日本語、それ以外は英語にフォールバックします。`ja` / `en` はロケールに関わらず言語を固定します。大小文字は区別しません (`--lang JA` / `--lang En` も通ります)。`config.toml` の `[ui] lang` でも指定できます。
 
 ## 設定ファイル
@@ -111,20 +111,17 @@ CLI フラグ `--ime hotkey|off` は config を 1 回だけ上書きします。
 
 > 以前は `Claude` のペインにフォーカスするたびに overlay が自動で開く `always` モードもありましたが、実運用で不安定だったため削除しました。フォーカス直後から overlay を使いたい場合は `Ctrl+;` を 1 回押してください。
 
-### 日本語 (CJK) で使うときのおすすめ設定
+### 日本語 (CJK) IME での入力
 
-日本語などの IME 依存が強い言語で Claude にプロンプトを書くことが多いなら、次の 2 つを合わせて起動するのが楽です。
+**ちらつき防止 (freeze) + 3 秒ごとの catch-up は on がデフォルト**です (上の flag 表を参照)。追加の設定不要で、ペインにフォーカスして `Ctrl+;` を押せば overlay が開き、裏のペインは凍結されて 3 秒ごとに 1 フレームだけ更新されます。
 
-```bash
-ccmux --ime-freeze-panes --ime-overlay-catchup-ms 3000
-```
-
-毎回同じ設定で起動するなら `config.toml` に書き込んでおきます。
+overlay を開かないユーザー (IME を使わない人) には影響しないので ON をデフォルトにしています。どうしても入力中に生の再描画を見たい / 完全凍結にしたい場合は `config.toml` で上書きできます:
 
 ```toml
 [ime]
-freeze_panes_on_overlay = true
-overlay_catchup_ms = 3000
+freeze_panes_on_overlay = false    # 入力中も生の再描画
+# あるいは
+overlay_catchup_ms = 0             # 完全凍結 (catch-up 無効)
 ```
 
 あとはペインにフォーカスして `Ctrl+;` を押せば overlay が開き、凍結 + 周期再描画が自動で効きます。

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Launch from any directory. The file tree shows the current working directory.
 
 - `--min-pane-width <COLS>` — minimum child columns a split may produce (default `20`). Splits whose halved pane would be narrower are refused. `0` is clamped to `1` to avoid zero-width children.
 - `--min-pane-height <ROWS>` — minimum child rows a split may produce (default `5`). Same clamp rule as `--min-pane-width`.
-- `--ime-freeze-panes[=BOOL]` — freeze pane repaints while the IME composition overlay is open (default `false`). Suppresses flicker from Claude's thinking spinner and other background PTY output during JP composition; panes catch up instantly when the overlay closes. Pass the bare flag to enable, or `=false` to force-disable a config `true`. Also settable via `[ime] freeze_panes_on_overlay` in `config.toml`.
-- `--ime-overlay-catchup-ms <MS>` — when `--ime-freeze-panes` is active, force a single repaint every `<MS>` milliseconds so body-content progress stays visible through an open overlay (default `0` = disabled, pure freeze). `3000`–`5000` is the sweet spot: flicker stays barely noticeable while Claude's streaming output still advances at a readable pace. Non-zero values are clamped to at least `100`. Also settable via `[ime] overlay_catchup_ms` in `config.toml`.
+- `--ime-freeze-panes[=BOOL]` — freeze pane repaints while the IME composition overlay is open (default `true`). Suppresses flicker from Claude's thinking spinner and other background PTY output during JP composition; panes catch up instantly when the overlay closes. Only takes effect while the overlay is open, so users who never press `Ctrl+;` see no change — which is why it's on by default. Pass `=false` to force-disable and keep live repaints during composition. Also settable via `[ime] freeze_panes_on_overlay` in `config.toml`.
+- `--ime-overlay-catchup-ms <MS>` — when `--ime-freeze-panes` is active, force a single repaint every `<MS>` milliseconds so body-content progress stays visible through an open overlay (default `3000` ms — the sweet spot: flicker stays barely noticeable while Claude's streaming output still advances at a readable pace). Pass `0` for a pure freeze. Non-zero values are clamped to at least `100`. Also settable via `[ime] overlay_catchup_ms` in `config.toml`.
 - `--lang <auto\|ja\|en>` — UI language for status bar hints and preview error messages (default `auto`). `auto` detects from the OS locale: `ja*` tags use Japanese, everything else falls back to English. `ja` / `en` force a specific language regardless of locale. Values are case-insensitive (`--lang JA` / `--lang En` both work). Also settable via `[ui] lang` in `config.toml`.
 
 ## Configuration
@@ -112,23 +112,18 @@ The `--ime hotkey\|off` CLI flag overrides the config file for a single run. Pre
 
 > A third mode, `always`, used to auto-open the overlay on every Claude pane focus. It was removed because the auto-open never worked reliably in practice. Users who want the overlay ready on focus should just press `Ctrl+;` once.
 
-### Recommended setup for JP / CJK IME users
+### JP / CJK IME composition
 
-If you regularly compose Japanese (or any IME-heavy language) prompts for Claude, launch ccmux with this pair:
+Freeze-on-overlay and periodic catch-up are **on by default** (see the flag table above). No setup is needed — press `Ctrl+;` on a focused pane and the overlay opens with the pane frozen behind it, unfreezing for one frame every 3 s so Claude's streaming output stays visible.
 
-```bash
-ccmux --ime-freeze-panes --ime-overlay-catchup-ms 3000
-```
-
-Or set it once in `config.toml` so every session starts this way:
+The defaults are opt-out-friendly because the freeze only takes effect while the overlay is open; users who don't use IME never see a behavior change. If you specifically want live repaints during composition (or a pure freeze with no catch-up), override in `config.toml`:
 
 ```toml
 [ime]
-freeze_panes_on_overlay = true
-overlay_catchup_ms = 3000
+freeze_panes_on_overlay = false    # live repaints during composition
+# or
+overlay_catchup_ms = 0             # pure freeze, no periodic catch-up
 ```
-
-Press `Ctrl+;` on a focused pane to open the overlay — the freeze + catch-up behavior kicks in automatically while the overlay is open.
 
 ![Centered IME overlay with a Japanese conversion candidate window anchored right under the caret, Claude panes frozen behind it](ime-overlay.png)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,8 +35,9 @@ pub struct Cli {
     /// updating, so Claude's thinking spinner can't flicker the
     /// overlay. Panes catch up instantly when the overlay closes.
     /// Overrides `[ime] freeze_panes_on_overlay` in config.toml.
-    /// Pass `--ime-freeze-panes=false` to force-disable a config
-    /// value of `true`.
+    /// **On by default** — the freeze is inert for users who never
+    /// open the overlay. Pass `--ime-freeze-panes=false` to force-
+    /// disable and keep live repaints during composition.
     #[arg(
         long,
         value_name = "BOOL",
@@ -49,11 +50,13 @@ pub struct Cli {
     /// While `--ime-freeze-panes` is active, force a single repaint
     /// every `<MS>` milliseconds so body-content progress (Claude
     /// writing new lines, shell output scrolling) stays visible
-    /// through an open overlay. `0` (default) keeps the freeze
-    /// pure — the screen stops updating until the overlay closes.
-    /// Non-zero values are clamped to at least 100 ms. Has no
-    /// effect while freeze is disabled. Overrides `[ime]
-    /// overlay_catchup_ms` in config.toml.
+    /// through an open overlay. **Defaults to 3000 ms** (the
+    /// README-documented sweet spot: flicker stays barely noticeable
+    /// while Claude's output still advances at a readable pace).
+    /// Pass `0` for a pure freeze — the screen stops updating until
+    /// the overlay closes. Non-zero values are clamped to at least
+    /// 100 ms. Has no effect while freeze is disabled. Overrides
+    /// `[ime] overlay_catchup_ms` in config.toml.
     #[arg(long, value_name = "MS")]
     pub ime_overlay_catchup_ms: Option<u64>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,27 +38,50 @@ pub struct UiConfig {
 /// IME overlay settings. See Issue #39 for the full mode design;
 /// `always_on` lives behind Issue #40 and is explicitly not accepted
 /// here yet.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct ImeConfig {
     pub mode: ImeMode,
     /// When `true`, pane repaints driven by PTY output are suppressed
     /// while the IME composition overlay is open (Issue #37 / #82
     /// Phase 2). vt100 parsers keep advancing in the background, so
-    /// panes catch up instantly when the overlay closes. Off by
-    /// default because it's a user-visible behavior change (the
-    /// screen literally stops updating during composition) even
-    /// though it's the intended way to kill overlay flicker on hosts
-    /// where `overlay_poll_ms` throttling alone isn't enough.
+    /// panes catch up instantly when the overlay closes.
+    ///
+    /// **On by default** since the freeze only takes effect while the
+    /// overlay is open, and users who don't open the overlay (non-IME
+    /// users, `mode = "off"`) never see a behavior change. Users who
+    /// specifically want live repaints during composition can override
+    /// with `--ime-freeze-panes=false` or `freeze_panes_on_overlay =
+    /// false` in config.toml.
     pub freeze_panes_on_overlay: bool,
-    /// When [`ImeConfig::freeze_panes_on_overlay`] is true, optionally
-    /// force a single repaint every `overlay_catchup_ms` milliseconds
-    /// so the user sees body-content progress (Claude writing new
-    /// lines, shell output scrolling) periodically without the
-    /// continuous flicker of unthrottled repaints. `0` disables the
-    /// periodic catch-up and gives a pure freeze. Non-zero values are
-    /// clamped to [`MIN_OVERLAY_CATCHUP_MS`] at apply time.
+    /// When [`ImeConfig::freeze_panes_on_overlay`] is true, force a
+    /// single repaint every `overlay_catchup_ms` milliseconds so the
+    /// user sees body-content progress (Claude writing new lines,
+    /// shell output scrolling) periodically without the continuous
+    /// flicker of unthrottled repaints. `0` disables the periodic
+    /// catch-up and gives a pure freeze. Non-zero values are clamped
+    /// to [`MIN_OVERLAY_CATCHUP_MS`] at apply time.
+    ///
+    /// **Defaults to 3000 ms** (the sweet spot documented in the
+    /// README: flicker stays barely noticeable while Claude's
+    /// streaming output still advances at a readable pace).
     pub overlay_catchup_ms: u64,
+}
+
+impl Default for ImeConfig {
+    fn default() -> Self {
+        // Explicit Default impl rather than `#[derive(Default)]` so the
+        // booleans / numeric defaults don't silently collapse back to
+        // `false` / `0` if someone re-derives it. The `[ime]` section
+        // ships with freeze + periodic-catchup on because the behavior
+        // is inert for users who never open the overlay (see the
+        // struct docs above).
+        Self {
+            mode: ImeMode::default(),
+            freeze_panes_on_overlay: true,
+            overlay_catchup_ms: 3000,
+        }
+    }
 }
 
 /// Floor for `overlay_catchup_ms` when non-zero. Below this the
@@ -363,21 +386,27 @@ mod tests {
     }
 
     #[test]
-    fn freeze_panes_defaults_to_false() {
+    fn freeze_panes_defaults_to_true() {
+        // Flipped from the initial `false` default: the freeze is
+        // inert for users who never open the overlay, so turning it
+        // on by default helps IME users without affecting anyone else.
         let cfg = Config::default();
-        assert!(!cfg.ime.freeze_panes_on_overlay);
+        assert!(cfg.ime.freeze_panes_on_overlay);
     }
 
     #[test]
     fn parses_freeze_panes_from_toml() {
+        // Explicit `false` in the config must still round-trip through
+        // serde — pinning this so the new default-on can be overridden
+        // by users who prefer live repaints during composition.
         let cfg: Config = toml::from_str(
             r#"
             [ime]
-            freeze_panes_on_overlay = true
+            freeze_panes_on_overlay = false
             "#,
         )
         .unwrap();
-        assert!(cfg.ime.freeze_panes_on_overlay);
+        assert!(!cfg.ime.freeze_panes_on_overlay);
     }
 
     #[test]
@@ -398,9 +427,13 @@ mod tests {
     }
 
     #[test]
-    fn overlay_catchup_ms_defaults_to_zero() {
+    fn overlay_catchup_ms_defaults_to_3000() {
+        // Default catch-up interval: a single repaint every 3 s while
+        // the overlay is open, matching the value previously suggested
+        // as the "sweet spot" in README's JP IME setup section. `0`
+        // (pure freeze) is still available as an explicit override.
         let cfg = Config::default();
-        assert_eq!(cfg.ime.overlay_catchup_ms, 0);
+        assert_eq!(cfg.ime.overlay_catchup_ms, 3000);
     }
 
     #[test]
@@ -432,7 +465,9 @@ mod tests {
         cfg2.apply_cli_overrides(None, None, Some(10), None);
         assert_eq!(cfg2.ime.overlay_catchup_ms, MIN_OVERLAY_CATCHUP_MS);
 
-        // Zero must stay zero (means "disabled").
+        // Zero must stay zero (means "disabled") even when the default
+        // is a non-zero value — an explicit `--ime-overlay-catchup-ms 0`
+        // must still give a pure freeze.
         let mut cfg3 = Config::default();
         cfg3.apply_cli_overrides(None, None, Some(0), None);
         assert_eq!(cfg3.ime.overlay_catchup_ms, 0);


### PR DESCRIPTION
## Summary

Closes the loop on the session's original question: both `--ime-freeze-panes` and `--ime-overlay-catchup-ms` only have effect while the IME composition overlay is open (entered via `Ctrl+;` / `Alt+;` / `Alt+I`), and users who don't open the overlay never see any behavior change. Leaving them off-by-default meant JP IME users had to discover and opt into the fix every session — the flicker-suppression work that landed in PR #85 (freeze) was effectively gated behind a CLI flag.

This PR flips both defaults:

- `freeze_panes_on_overlay`: `false` → **`true`**
- `overlay_catchup_ms`: `0` → **`3000`** (the sweet spot previously documented as the recommended setting in the README)

## Backward compatibility

- **JP IME users**: net UX improvement. The overlay now freezes the pane behind it and unfreezes for one frame every 3 s without any CLI flag or config.toml entry.
- **Non-IME users**: **no change**. They never press `Ctrl+;`, so `self.overlay.is_none()` at all times, and both the freeze gate and the catch-up tick short-circuit (`src/app.rs:2435`, `src/app.rs:666-677`).
- **Users who want live repaints during composition**: can still opt out via `--ime-freeze-panes=false` or `[ime] freeze_panes_on_overlay = false` in `config.toml`.
- **Users who want pure freeze**: `--ime-overlay-catchup-ms 0` or `[ime] overlay_catchup_ms = 0` still gives the pre-PR-#85 behavior.

## Implementation

- `src/config.rs`: `ImeConfig` drops `#[derive(Default)]` for a manual `Default` impl so `false` / `0` can't silently creep back via a future refactor re-adding the derive.
- `src/config.rs` tests: existing assertions flipped to match the new defaults (`freeze_panes_defaults_to_false` → `freeze_panes_defaults_to_true`, etc.). `parses_freeze_panes_from_toml` now exercises `false` in the TOML to pin that the new default can be explicitly overridden.
- `src/cli.rs`: CLI `--help` text for both flags updated with the new defaults and opt-out paths.
- `README.md` / `README.ja.md`: flag table entries updated. The "Recommended setup for JP / CJK IME users" section is renamed to "JP / CJK IME composition" and now describes how to *opt out* of the defaults for the minority who want different behavior, rather than how to opt in.

`App::new` keeps `ime_freeze_panes_on_overlay: false` / `ime_overlay_catchup_ms: 0` as the pre-`apply_config` safety state. Production always calls `apply_config` immediately after `App::new` (see `src/main.rs`), so users see the new `Config::default()` values. Tests that exercise freeze-specific behavior already set these fields explicitly, so this distinction doesn't affect coverage.

## Test plan

- [x] `cargo fmt --check` ✅
- [x] `cargo clippy --all-targets -- -D warnings` ✅
- [x] `cargo test --release` → **306 passed; 0 failed** (same count as PR #100 — the existing default-value tests are updated, not deleted).
- [x] Config serde: `[ime] freeze_panes_on_overlay = false` / `overlay_catchup_ms = 0` in TOML still parses and overrides the new default.
- [x] CLI override: `--ime-freeze-panes=false` / `--ime-overlay-catchup-ms 0` still wins over a `true`/`3000` config (pre-existing precedence test updated to reflect new defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)