### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,11 @@ name = "ccmux"
 # users can tell fork and upstream apart at a glance, and reflects the
 # breaking change in `mode = "always"` removal (#90) plus the shipped
 # IME overlay rework (#85 / #86) and image-preview sync (#91).
-version = "0.7.1"
+# 0.8.0 rolls up the i18n auto-locale (#98), click-event forwarding
+# (#100), and IME freeze-on-overlay defaults flipped ON (#101); the
+# last is a user-visible behavior change for anyone who opens the
+# IME overlay, hence the minor bump rather than a patch.
+version = "0.8.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary

Version bump PR for v0.8.0. Rolls up 4 merged PRs since v0.7.1:

- [#98](https://github.com/happy-ryo/ccmux/pull/98) feat(i18n): auto-detect OS locale for UI language (JP / EN)
- [#99](https://github.com/happy-ryo/ccmux/pull/99) chore: add opt-in pre-commit hook running cargo fmt --check
- [#100](https://github.com/happy-ryo/ccmux/pull/100) fix: forward mouse click / drag / release to PTY in alt-screen panes
- [#101](https://github.com/happy-ryo/ccmux/pull/101) feat(ime): flip freeze + overlay catchup defaults to on (3000 ms)

## Why minor, not patch

- #98 adds a new `[ui] lang` config section + `--lang` CLI flag (additive, but user-visible surface).
- #100 is a user-visible bug fix: mouse-report-subscribing TUIs (Claude Code `/tui fullscreen`, vim, lazygit, less) now actually receive clicks.
- #101 flips two defaults (`freeze_panes_on_overlay` → `true`, `overlay_catchup_ms` → `3000`). Anyone who opens the IME overlay sees the new behavior on first launch without having to opt in. Non-IME users see no change (both flags are inert while the overlay is closed).

## What this PR does

- `Cargo.toml` / `Cargo.lock` / `npm/package.json` → `0.8.0`
- Cargo.toml comment extended with the v0.8.0 rollup context.

Post-merge: I'll `git tag v0.8.0` + `git push origin v0.8.0` so `.github/workflows/release.yml` fires the 4-platform release build + GitHub Release + npm publish via Trusted Publishing.

## Test plan

- [x] `cargo build` ✅ (Cargo.lock picks up the new version)
- [x] All of #98 / #100 / #101's test suites are merged to main already and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)