### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,13 @@ name = "ccmux"
 # (#100), and IME freeze-on-overlay defaults flipped ON (#101); the
 # last is a user-visible behavior change for anyone who opens the
 # IME overlay, hence the minor bump rather than a patch.
-version = "0.8.0"
+# 0.9.0 ships per-tab peer messaging between Claude Code panes (#97 /
+# #104): `ccmux mcp install` registers a stdio MCP server, `Alt+P`
+# inserts the peer-enabled launch command, and `ccmux split --role
+# claude` auto-launches Claude Code with the channel flag. The new
+# keybinding and the user-visible `ccmux mcp` subcommand tree are why
+# this is a minor bump.
+version = "0.9.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary

Release PR for v0.9.0. Headline feature: **per-tab peer messaging between Claude Code panes** (#97 / #104). After this merges:

```
git checkout main && git pull
git tag v0.9.0 && git push origin v0.9.0
```

CI builds all four platform binaries, creates the GitHub Release with checksums, and `npm publish`es `ccmux-fork` via Trusted Publishing.

---

## Release notes draft (paste into the GitHub Release body after CI creates it)

### ✨ New

- **Peer messaging between Claude Code panes in the same ccmux tab** (#97, #104). A baked-in MCP server lets same-tab Claude Code instances discover each other via `list_peers` and exchange messages via `send_message`. Peer messages arrive as `<channel source="ccmux-peers">` tags in the receiver's context, cleanly distinct from user input.
  - `ccmux mcp install` registers the stdio MCP server in Claude Code's user-scope config (delegates to `claude mcp add-json` so ccmux stays out of Claude Code's on-disk schema). Companion commands: `ccmux mcp uninstall` / `ccmux mcp status`.
  - `Alt+P` inserts `claude --dangerously-load-development-channels server:ccmux-peers` into the focused pane (trailing space, no Enter). Works across bash / zsh / fish / pwsh / cmd.exe because the keystroke is a pre-PTY write.
  - `ccmux split --role claude` and `ccmux new-tab --role claude` auto-launch Claude Code with the peer-channel flag applied.
  - Scope boundary is the ccmux tab itself: cross-tab sends are silent no-ops so callers cannot enumerate panes in other tabs.

### 🛠 Changed

- Status bar hint (pane mode) now surfaces `A-P Claude Code起動 / claude code` alongside the existing shortcuts.
- Every spawned pane now inherits `CCMUX_PANE_ID` in addition to the existing `CCMUX` / `CCMUX_SOCKET` / `CCMUX_TOKEN` env vars.

### Documentation

- README (EN + JP) — new "Peer messaging" section covering setup, launch paths, the two-pane workflow, and troubleshooting.
- Nextra docs ship a dedicated `peer-messaging.mdx` page (EN + JP) with the scope-authority rationale and delivery semantics.
- Landing page (`lp/index.html` + `lp/ja.html`) gets a top-row callout in the "vs upstream" diff table.

### Follow-ups

- #105 tracks an observation that ccmux peer conversations tend to run ~3 turns where `claude-peers-mcp` converges in ~1. Backlog only — no implementation planned.

### Install

```
npm install -g ccmux-fork
```

Or grab a binary from [Releases](https://github.com/happy-ryo/ccmux/releases/tag/v0.9.0).
