### PR TITLE
feat(ui): first-launch macOS Option-as-Meta banner

### DIFF
--- a/lp/index.html
+++ b/lp/index.html
@@ -204,6 +204,68 @@
       <pre><code>$ npm uninstall -g ccmux-cli
 $ npm install -g ccmux-fork</code></pre>
 
+      <h2>macOS setup: Option as Meta</h2>
+      <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
+        macOS terminals bind <code>Option+&lt;key&gt;</code> to Unicode
+        input (<code>å</code>, <code>∫</code>, <code>π</code> …) by
+        default, so ccmux's <code>Alt+T</code> / <code>Alt+P</code> /
+        <code>Alt+R</code> / <code>Alt+S</code> / <code>Alt+1..9</code>
+        / <code>Alt+Left/Right</code> shortcuts never reach the app.
+        Flip Option to act as a Meta key — a one-line change in every
+        modern terminal. Plain <code>Terminal.app</code> works too,
+        but we recommend one of the others for IME, ligatures, and
+        the image preview panel.
+      </p>
+      <table class="diff">
+        <thead>
+          <tr>
+            <th>Terminal</th>
+            <th>Setting</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>WezTerm<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.wezterm.lua</code></span></td>
+            <td>
+              <code>config.send_composed_key_when_left_alt_is_pressed&nbsp;=&nbsp;false</code>
+              <br /><code>config.send_composed_key_when_right_alt_is_pressed&nbsp;=&nbsp;false</code>
+            </td>
+          </tr>
+          <tr>
+            <td>iTerm2</td>
+            <td>Settings → Profiles → Keys → set <strong>Left Option key</strong> and <strong>Right Option key</strong> to <strong>Esc+</strong></td>
+          </tr>
+          <tr>
+            <td>Alacritty<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.config/alacritty/alacritty.toml</code></span></td>
+            <td>
+              <code>[window]</code><br /><code>option_as_alt&nbsp;=&nbsp;"Both"</code>
+              <span style="color: var(--muted); font-size: 0.85em;"> (or <code>"OnlyLeft"</code> / <code>"OnlyRight"</code>)</span>
+            </td>
+          </tr>
+          <tr>
+            <td>Ghostty<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.config/ghostty/config</code></span></td>
+            <td><code>macos-option-as-alt&nbsp;=&nbsp;true</code></td>
+          </tr>
+          <tr>
+            <td>Kitty<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.config/kitty/kitty.conf</code></span></td>
+            <td><code>macos_option_as_alt&nbsp;yes</code></td>
+          </tr>
+          <tr>
+            <td>Terminal.app</td>
+            <td>Settings → Profiles → Keyboard → tick <strong>Use Option as Meta key</strong></td>
+          </tr>
+        </tbody>
+      </table>
+      <p style="color: var(--muted); font-size: 0.85rem;">
+        Some macOS IMEs (Kotoeri's Romaji toggle, kana layouts, …)
+        bind Option themselves — if the Meta setup breaks IME for
+        you, try the <code>OnlyLeft</code> / <code>OnlyRight</code>
+        variants so one Option key stays native to the OS.
+        <code>Alt+1..9</code> can also collide with macOS Mission
+        Control / Spaces shortcuts; <code>Alt+Left/Right</code>
+        still cycles tabs when that happens.
+      </p>
+
       <h2>Differences from upstream</h2>
       <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
         The fork is a strict superset of the current upstream
@@ -315,26 +377,6 @@ $ npm install -g ccmux-fork</code></pre>
           </tr>
           <tr>
             <td>Mouse wheel forwarding to alt-screen TUIs (Claude <code>/tui</code>, vim, lazygit)</td>
-            <td class="mark">—</td>
-            <td class="mark has">✓</td>
-          </tr>
-          <tr>
-            <td>
-              First-launch macOS Option-as-Meta banner
-              <br /><span style="color: var(--muted); font-size: 0.85em;">
-                macOS terminals bind <code>Option+&lt;key&gt;</code> to Unicode
-                input by default, so <code>Alt+T</code> / <code>Alt+P</code> /
-                <code>Alt+1..9</code> never reach ccmux. A 2-line banner on
-                first launch points users at the per-terminal (WezTerm /
-                iTerm2 / Alacritty / Ghostty / Kitty / Terminal.app) fix.
-                Dismisses on any key or after 20&nbsp;s, writes a zero-byte
-                marker at
-                <code>~/.config/ccmux/.macos_tip_dismissed</code> so
-                returning users never see it twice. Override with
-                <code>--no-macos-tip</code> / <code>--show-macos-tip</code>
-                or <code>CCMUX_NO_MACOS_TIP</code>.
-              </span>
-            </td>
             <td class="mark">—</td>
             <td class="mark has">✓</td>
           </tr>

--- a/lp/index.html
+++ b/lp/index.html
@@ -319,6 +319,26 @@ $ npm install -g ccmux-fork</code></pre>
             <td class="mark has">✓</td>
           </tr>
           <tr>
+            <td>
+              First-launch macOS Option-as-Meta banner
+              <br /><span style="color: var(--muted); font-size: 0.85em;">
+                macOS terminals bind <code>Option+&lt;key&gt;</code> to Unicode
+                input by default, so <code>Alt+T</code> / <code>Alt+P</code> /
+                <code>Alt+1..9</code> never reach ccmux. A 2-line banner on
+                first launch points users at the per-terminal (WezTerm /
+                iTerm2 / Alacritty / Ghostty / Kitty / Terminal.app) fix.
+                Dismisses on any key or after 20&nbsp;s, writes a zero-byte
+                marker at
+                <code>~/.config/ccmux/.macos_tip_dismissed</code> so
+                returning users never see it twice. Override with
+                <code>--no-macos-tip</code> / <code>--show-macos-tip</code>
+                or <code>CCMUX_NO_MACOS_TIP</code>.
+              </span>
+            </td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
             <td>CI matrix (Windows / macOS / Linux) with rustfmt + clippy gate</td>
             <td class="mark">—</td>
             <td class="mark has">✓</td>

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -198,6 +198,68 @@
       <pre><code>$ npm uninstall -g ccmux-cli
 $ npm install -g ccmux-fork</code></pre>
 
+      <h2>macOS の設定: Option をメタキーにする</h2>
+      <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
+        macOS のターミナルは既定で <code>Option+&lt;キー&gt;</code> を
+        Unicode 入力 (<code>å</code>、<code>∫</code>、<code>π</code>
+        など) に割り当てているため、ccmux の <code>Alt+T</code> /
+        <code>Alt+P</code> / <code>Alt+R</code> / <code>Alt+S</code> /
+        <code>Alt+1..9</code> / <code>Alt+Left/Right</code>
+        ショートカットが発火しません。Option をメタキー扱いに切り替え
+        れば解決します。どのターミナルも 1 行の設定変更で済みます。
+        <code>Terminal.app</code> でも動きますが、IME / ligature /
+        画像プレビュー全般で下記の端末の方が快適です。
+      </p>
+      <table class="diff">
+        <thead>
+          <tr>
+            <th>ターミナル</th>
+            <th>設定</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>WezTerm<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.wezterm.lua</code></span></td>
+            <td>
+              <code>config.send_composed_key_when_left_alt_is_pressed&nbsp;=&nbsp;false</code>
+              <br /><code>config.send_composed_key_when_right_alt_is_pressed&nbsp;=&nbsp;false</code>
+            </td>
+          </tr>
+          <tr>
+            <td>iTerm2</td>
+            <td>Settings → Profiles → Keys → <strong>Left Option key</strong> と <strong>Right Option key</strong> を <strong>Esc+</strong> に設定</td>
+          </tr>
+          <tr>
+            <td>Alacritty<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.config/alacritty/alacritty.toml</code></span></td>
+            <td>
+              <code>[window]</code><br /><code>option_as_alt&nbsp;=&nbsp;"Both"</code>
+              <span style="color: var(--muted); font-size: 0.85em;"> (<code>"OnlyLeft"</code> / <code>"OnlyRight"</code> も可)</span>
+            </td>
+          </tr>
+          <tr>
+            <td>Ghostty<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.config/ghostty/config</code></span></td>
+            <td><code>macos-option-as-alt&nbsp;=&nbsp;true</code></td>
+          </tr>
+          <tr>
+            <td>Kitty<br /><span style="color: var(--muted); font-size: 0.85em;"><code>~/.config/kitty/kitty.conf</code></span></td>
+            <td><code>macos_option_as_alt&nbsp;yes</code></td>
+          </tr>
+          <tr>
+            <td>Terminal.app</td>
+            <td>Settings → Profiles → Keyboard → <strong>Use Option as Meta key</strong> にチェック</td>
+          </tr>
+        </tbody>
+      </table>
+      <p style="color: var(--muted); font-size: 0.85rem;">
+        一部の macOS IME (ことえりの「英字」切替、日本語キー配列など)
+        は Option を独自に使っているため、Meta 化と両立しない場合が
+        あります。IME が壊れたら <code>OnlyLeft</code> /
+        <code>OnlyRight</code> で片側だけ Meta にすると妥協できます。
+        <code>Alt+1..9</code> は macOS の Mission Control / Spaces
+        ショートカットと衝突することがあり、奪われたときは
+        <code>Alt+Left/Right</code> でタブ巡回して回避してください。
+      </p>
+
       <h2>上流との差分</h2>
       <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
         このフォークは現時点の upstream <code>master</code> の完全な上位互換です。上流にあるものは全部入っています。
@@ -306,26 +368,6 @@ $ npm install -g ccmux-fork</code></pre>
           </tr>
           <tr>
             <td>alt-screen で動く TUI (Claude <code>/tui</code>、vim、lazygit など) へのマウスホイール転送</td>
-            <td class="mark">—</td>
-            <td class="mark has">✓</td>
-          </tr>
-          <tr>
-            <td>
-              macOS 初回起動時の Option=Meta 設定バナー
-              <br /><span style="color: var(--muted); font-size: 0.85em;">
-                macOS では既定で <code>Option+&lt;キー&gt;</code> が Unicode
-                入力に割り当てられているため <code>Alt+T</code> /
-                <code>Alt+P</code> / <code>Alt+1..9</code> が発火しない。
-                初回起動時に 2 行のバナーを出して、各端末 (WezTerm /
-                iTerm2 / Alacritty / Ghostty / Kitty / Terminal.app) での
-                1 行設定方法に誘導する。任意キー押下または 20
-                秒経過で消え、
-                <code>~/.config/ccmux/.macos_tip_dismissed</code> に 0
-                バイトのマーカーを残すので 2 回目以降は非表示。
-                <code>--no-macos-tip</code> / <code>--show-macos-tip</code>
-                や <code>CCMUX_NO_MACOS_TIP</code> で上書き可能。
-              </span>
-            </td>
             <td class="mark">—</td>
             <td class="mark has">✓</td>
           </tr>

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -310,6 +310,26 @@ $ npm install -g ccmux-fork</code></pre>
             <td class="mark has">✓</td>
           </tr>
           <tr>
+            <td>
+              macOS 初回起動時の Option=Meta 設定バナー
+              <br /><span style="color: var(--muted); font-size: 0.85em;">
+                macOS では既定で <code>Option+&lt;キー&gt;</code> が Unicode
+                入力に割り当てられているため <code>Alt+T</code> /
+                <code>Alt+P</code> / <code>Alt+1..9</code> が発火しない。
+                初回起動時に 2 行のバナーを出して、各端末 (WezTerm /
+                iTerm2 / Alacritty / Ghostty / Kitty / Terminal.app) での
+                1 行設定方法に誘導する。任意キー押下または 20
+                秒経過で消え、
+                <code>~/.config/ccmux/.macos_tip_dismissed</code> に 0
+                バイトのマーカーを残すので 2 回目以降は非表示。
+                <code>--no-macos-tip</code> / <code>--show-macos-tip</code>
+                や <code>CCMUX_NO_MACOS_TIP</code> で上書き可能。
+              </span>
+            </td>
+            <td class="mark">—</td>
+            <td class="mark has">✓</td>
+          </tr>
+          <tr>
             <td>Windows / macOS / Linux の CI と rustfmt / clippy チェック</td>
             <td class="mark">—</td>
             <td class="mark has">✓</td>

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -262,8 +262,7 @@ $ npm install -g ccmux-fork</code></pre>
 
       <h2>上流との差分</h2>
       <p style="color: var(--muted); font-size: 0.9rem; margin-top: -4px;">
-        このフォークは現時点の upstream <code>master</code> の完全な上位互換です。上流にあるものは全部入っています。
-        下の表は、直近の upstream リリースに対してフォーク側だけに入っている機能の一覧です。
+        上流 (<a href="https://github.com/Shin-sibainu/ccmux">Shin-sibainu/ccmux</a>) の変更は <code>master</code> ブランチで定期的に取り込んでいます。下の表は、直近の upstream リリース時点でフォーク側にだけ入っている機能の一覧です。
       </p>
       <table class="diff">
         <thead>

--- a/src/app.rs
+++ b/src/app.rs
@@ -611,6 +611,19 @@ pub struct App {
     /// files fall back to the textual "binary file" placeholder in
     /// the preview panel.
     pub image_picker: Option<ratatui_image::picker::Picker>,
+    /// First-launch macOS tip: when `true`, a 2-row banner above the
+    /// status bar points users at the Option-as-Meta README section
+    /// so `Alt+T` / `Alt+P` / `Alt+1..9` actually fire (see
+    /// `crate::macos_tip`). Dismissed by any key press or the
+    /// 10-second auto timeout; dismissal is persisted via the
+    /// zero-byte marker file resolved by `macos_tip::marker_path`.
+    pub macos_tip_visible: bool,
+    /// Instant the banner was shown; `None` outside a banner session.
+    /// Consumed by [`App::check_macos_tip_timeout`] every frame.
+    macos_tip_shown_at: Option<Instant>,
+    /// Marker path to touch on dismissal. `None` when the config dir
+    /// couldn't be resolved — dismissal stays in-memory for this run.
+    macos_tip_marker: Option<PathBuf>,
 }
 
 impl App {
@@ -678,7 +691,52 @@ impl App {
             min_pane_width: 20,
             min_pane_height: 5,
             image_picker: None,
+            macos_tip_visible: false,
+            macos_tip_shown_at: None,
+            macos_tip_marker: None,
         })
+    }
+
+    /// Surface the first-launch macOS Option-as-Meta banner for this
+    /// session. Starts the 10-second auto-dismiss timer and remembers
+    /// the marker path so a later key-press or timeout can persist
+    /// "user saw it, never show again". Idempotent — repeated calls
+    /// restart the timer rather than compounding.
+    pub fn show_macos_tip(&mut self, marker: Option<PathBuf>) {
+        self.macos_tip_visible = true;
+        self.macos_tip_shown_at = Some(Instant::now());
+        self.macos_tip_marker = marker;
+        self.dirty = true;
+    }
+
+    /// Hide the banner and persist dismissal via the marker file if
+    /// one is configured. Silent no-op when the banner isn't up.
+    pub fn dismiss_macos_tip(&mut self) {
+        if !self.macos_tip_visible {
+            return;
+        }
+        self.macos_tip_visible = false;
+        self.macos_tip_shown_at = None;
+        if let Some(path) = self.macos_tip_marker.take() {
+            crate::macos_tip::mark_dismissed(&path);
+        }
+        self.dirty = true;
+    }
+
+    /// Auto-dismiss when the banner has been visible longer than
+    /// [`crate::macos_tip::AUTO_DISMISS`]. Called from the main loop
+    /// alongside `maybe_tick_overlay_catchup`; cheap no-op in the
+    /// common case (banner not visible).
+    pub fn check_macos_tip_timeout(&mut self) {
+        if !self.macos_tip_visible {
+            return;
+        }
+        let Some(shown_at) = self.macos_tip_shown_at else {
+            return;
+        };
+        if shown_at.elapsed() >= crate::macos_tip::AUTO_DISMISS {
+            self.dismiss_macos_tip();
+        }
     }
 
     /// Install a user-level config on top of the default App state.
@@ -929,6 +987,18 @@ impl App {
     // ─── Key handling ─────────────────────────────────────
 
     pub fn handle_key_event(&mut self, key: KeyEvent) -> Result<bool> {
+        // First-launch macOS tip: dismiss on any key, but fall through
+        // so the key still performs its normal action. The banner is a
+        // transient hint, not a modal — the user shouldn't have to
+        // press a key twice (once to dismiss, once to do what they
+        // wanted). Persists the marker file here so the banner never
+        // reappears on the next launch, including when the next key
+        // is Ctrl+Q — otherwise a quit-while-banner-up would leave
+        // the marker unwritten and the tip would return next launch.
+        if self.macos_tip_visible {
+            self.dismiss_macos_tip();
+        }
+
         // Emergency escape hatch: Ctrl+Q must always quit ccmux, even
         // while the IME composition overlay is holding input. Checked
         // before overlay routing so the user can never get trapped in

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,6 +82,21 @@ pub struct Cli {
     /// A value of `0` is clamped to `1` at runtime. Default: 5.
     #[arg(long, value_name = "ROWS", default_value_t = 5)]
     pub min_pane_height: u16,
+
+    /// Suppress the first-launch macOS Option-as-Meta banner for this
+    /// run without touching the dismissal marker. Use when automated
+    /// sessions shouldn't count as a user dismissal. Also settable via
+    /// `CCMUX_NO_MACOS_TIP=1` env var. No-op on non-macOS hosts.
+    #[arg(long, conflicts_with = "show_macos_tip")]
+    pub no_macos_tip: bool,
+
+    /// Force the macOS Option-as-Meta banner on, ignoring the dismissal
+    /// marker. Useful after editing your terminal config to verify the
+    /// banner copy, or to re-read the hint without `rm`-ing the marker.
+    /// Still macOS-gated — showing a macOS-specific setup tip on Linux
+    /// would just be noise.
+    #[arg(long, conflicts_with = "no_macos_tip")]
+    pub show_macos_tip: bool,
 }
 
 /// Subcommands dispatched to a running ccmux instance via its IPC
@@ -907,6 +922,33 @@ mod tests {
                 .unwrap();
         assert_eq!(cli2.min_pane_width, 12);
         assert_eq!(cli2.min_pane_height, 4);
+    }
+
+    #[test]
+    fn macos_tip_flags_default_to_false() {
+        let cli = Cli::try_parse_from(["ccmux"]).unwrap();
+        assert!(!cli.no_macos_tip);
+        assert!(!cli.show_macos_tip);
+    }
+
+    #[test]
+    fn parses_no_macos_tip_flag() {
+        let cli = Cli::try_parse_from(["ccmux", "--no-macos-tip"]).unwrap();
+        assert!(cli.no_macos_tip);
+        assert!(!cli.show_macos_tip);
+    }
+
+    #[test]
+    fn parses_show_macos_tip_flag() {
+        let cli = Cli::try_parse_from(["ccmux", "--show-macos-tip"]).unwrap();
+        assert!(cli.show_macos_tip);
+        assert!(!cli.no_macos_tip);
+    }
+
+    #[test]
+    fn macos_tip_flags_are_mutually_exclusive() {
+        let err = Cli::try_parse_from(["ccmux", "--show-macos-tip", "--no-macos-tip"]);
+        assert!(err.is_err(), "flags should conflict");
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -148,6 +148,9 @@ pub struct Messages {
     pub preview_binary: &'static str,
     pub preview_read_failed: &'static str,
     pub preview_not_regular: &'static str,
+    // ── macOS first-launch banner ─────────────────────────
+    pub macos_tip_line1: &'static str,
+    pub macos_tip_line2: &'static str,
 }
 
 impl Messages {
@@ -203,6 +206,9 @@ pub static MESSAGES_JA: Messages = Messages {
     preview_binary: "\u{2718} バイナリファイルです",
     preview_read_failed: "ファイルを読み込めませんでした",
     preview_not_regular: "通常ファイルではありません",
+    macos_tip_line1: "\u{26A0} macOS: Alt+<キー> には端末の Option=Meta 設定が必要です",
+    macos_tip_line2:
+        "  https://github.com/happy-ryo/ccmux#macos-option-as-meta  (任意のキーで消去)",
 };
 
 pub static MESSAGES_EN: Messages = Messages {
@@ -235,6 +241,9 @@ pub static MESSAGES_EN: Messages = Messages {
     preview_binary: "\u{2718} Binary file",
     preview_read_failed: "Failed to read file",
     preview_not_regular: "Not a regular file",
+    macos_tip_line1: "\u{26A0} macOS: Alt+<key> shortcuts require Option=Meta in your terminal",
+    macos_tip_line2:
+        "  https://github.com/happy-ryo/ccmux#macos-option-as-meta  (press any key to dismiss)",
 };
 
 #[cfg(test)]

--- a/src/macos_tip.rs
+++ b/src/macos_tip.rs
@@ -1,0 +1,200 @@
+//! First-launch tip that steers macOS users to the Option-as-Meta
+//! terminal setup (see README § "macOS: Option as Meta"). macOS
+//! terminals bind `Option+<key>` to Unicode input by default so
+//! `Alt+T` / `Alt+P` / `Alt+1..9` / `Alt+Left/Right` never reach
+//! ccmux. Users who don't know the fix read it as a ccmux bug.
+//!
+//! The tip surfaces as a transient banner on first launch and is
+//! dismissed either by any key press or a 20 s timeout. Dismissal
+//! writes a zero-byte marker file alongside `config.toml` so the
+//! banner never appears again on that host. Users who want it back
+//! can `rm` the marker file.
+//!
+//! No `state.toml` / serde layer on purpose: persisting a single
+//! bool does not justify dragging in a new file format or the
+//! round-trip cost. If more state ever needs to live here, revisit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Env-var twin of `--no-macos-tip`. Any non-empty value suppresses
+/// the banner without touching the marker file, so scripted sessions
+/// that don't want the banner don't accidentally mark a real macOS
+/// user "dismissed" on their behalf.
+pub const ENV_SUPPRESS: &str = "CCMUX_NO_MACOS_TIP";
+
+/// How long the banner stays up before self-dismissing.
+pub const AUTO_DISMISS: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Resolve the marker-file path alongside `config.toml`. Returns
+/// `None` on environments where the platform config dir can't be
+/// determined (sandbox without `$HOME`); the caller treats that as
+/// "can't persist dismissal, show in-memory for this run only".
+pub fn marker_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|base| base.join("ccmux").join(".macos_tip_dismissed"))
+}
+
+pub fn is_dismissed(path: &Path) -> bool {
+    fs::metadata(path).is_ok()
+}
+
+/// Touch the marker file (zero-byte placeholder), creating the
+/// parent directory if needed. Failures go to stderr rather than
+/// surfacing as an error so a transient IO issue on dismiss doesn't
+/// disrupt the run.
+pub fn mark_dismissed(path: &Path) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            eprintln!(
+                "ccmux: couldn't create {} for macOS tip marker: {e}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    if let Err(e) = fs::File::create(path) {
+        eprintln!(
+            "ccmux: couldn't touch macOS tip marker {}: {e}",
+            path.display()
+        );
+    }
+}
+
+/// Decide whether this launch should surface the banner. Override
+/// precedence (highest first):
+///
+/// 1. `--show-macos-tip` — force on (still macOS-gated; showing a
+///    macOS-specific setup tip on Linux makes no sense).
+/// 2. `--no-macos-tip` — force off.
+/// 3. `CCMUX_NO_MACOS_TIP` env var set and non-empty — force off.
+/// 4. Marker file exists — off.
+/// 5. Non-macOS host — off.
+/// 6. Otherwise — on.
+pub fn should_show(cli_no_tip: bool, cli_show_tip: bool, marker: Option<&Path>) -> bool {
+    if cli_show_tip {
+        return cfg!(target_os = "macos");
+    }
+    if cli_no_tip {
+        return false;
+    }
+    if std::env::var_os(ENV_SUPPRESS).is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    if !cfg!(target_os = "macos") {
+        return false;
+    }
+    !matches!(marker, Some(p) if is_dismissed(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Mutex, OnceLock};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    // Tests that read or mutate CCMUX_NO_MACOS_TIP hold this lock so
+    // they don't race each other. Cargo runs tests in parallel by
+    // default, and env mutations are process-global.
+    fn env_lock() -> &'static Mutex<()> {
+        static L: OnceLock<Mutex<()>> = OnceLock::new();
+        L.get_or_init(|| Mutex::new(()))
+    }
+
+    fn unique_marker() -> PathBuf {
+        let pid = std::process::id();
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("ccmux-macos-tip-test-{pid}-{n}"))
+    }
+
+    struct EnvGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn clear() -> Self {
+            let prev = std::env::var_os(ENV_SUPPRESS);
+            std::env::remove_var(ENV_SUPPRESS);
+            Self { prev }
+        }
+
+        fn set(value: &str) -> Self {
+            let prev = std::env::var_os(ENV_SUPPRESS);
+            std::env::set_var(ENV_SUPPRESS, value);
+            Self { prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(ENV_SUPPRESS, v),
+                None => std::env::remove_var(ENV_SUPPRESS),
+            }
+        }
+    }
+
+    #[test]
+    fn mark_then_dismissed() {
+        let p = unique_marker();
+        let _ = fs::remove_file(&p);
+        assert!(!is_dismissed(&p));
+        mark_dismissed(&p);
+        assert!(is_dismissed(&p));
+        let _ = fs::remove_file(&p);
+    }
+
+    #[test]
+    fn cli_no_tip_wins() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::clear();
+        let p = unique_marker();
+        let _ = fs::remove_file(&p);
+        assert!(!should_show(true, false, Some(&p)));
+    }
+
+    #[test]
+    fn cli_show_tip_overrides_marker_on_macos() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::clear();
+        let p = unique_marker();
+        mark_dismissed(&p);
+        assert_eq!(
+            should_show(false, true, Some(&p)),
+            cfg!(target_os = "macos")
+        );
+        let _ = fs::remove_file(&p);
+    }
+
+    #[test]
+    fn default_follows_platform_when_no_marker() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::clear();
+        let p = unique_marker();
+        let _ = fs::remove_file(&p);
+        assert_eq!(
+            should_show(false, false, Some(&p)),
+            cfg!(target_os = "macos")
+        );
+    }
+
+    #[test]
+    fn env_var_suppresses() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::set("1");
+        let p = unique_marker();
+        let _ = fs::remove_file(&p);
+        assert!(!should_show(false, false, Some(&p)));
+    }
+
+    #[test]
+    fn marker_present_suppresses_on_macos() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::clear();
+        let p = unique_marker();
+        mark_dismissed(&p);
+        assert!(!should_show(false, false, Some(&p)));
+        let _ = fs::remove_file(&p);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod i18n;
 mod input;
 mod ipc;
 mod layout_config;
+mod macos_tip;
 mod mcp_peer;
 mod pane;
 mod preview;
@@ -153,6 +154,15 @@ fn main() -> Result<()> {
     app.apply_config(&user_config);
     app.set_min_pane_size(cli.min_pane_width, cli.min_pane_height);
     app.image_picker = image_picker;
+
+    // First-launch macOS Option-as-Meta tip. Gated on host OS + a
+    // zero-byte marker file so returning users never see it twice.
+    // Non-macOS hosts and already-dismissed users short-circuit to
+    // false here.
+    let tip_marker = macos_tip::marker_path();
+    if macos_tip::should_show(cli.no_macos_tip, cli.show_macos_tip, tip_marker.as_deref()) {
+        app.show_macos_tip(tip_marker);
+    }
 
     // Keep the server handle alive for the process lifetime; its Drop
     // impl cleans up the Unix socket file on exit.
@@ -376,6 +386,12 @@ fn run_event_loop(
         // periodically force a single repaint so body content stays
         // visible through an open overlay. No-op otherwise.
         app.maybe_tick_overlay_catchup();
+
+        // First-launch macOS tip: hide the banner if it's been up for
+        // more than the auto-dismiss budget (~20 s). Persists the
+        // marker file via the same path as a key-press dismissal.
+        // Cheap no-op when the banner isn't showing.
+        app.check_macos_tip_timeout();
 
         // Only render when something changed (and no cooldown is active)
         if app.dirty && app.paste_cooldown == 0 && app.resize_cooldown == 0 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -67,20 +67,30 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 
     let show_status = app.status_bar_visible || app.rename_input.is_some();
     let status_h = if show_status { 1 } else { 0 };
+    let show_macos_tip = app.macos_tip_visible;
+    // Two rows: line 1 is the warning + what the user needs to fix,
+    // line 2 is the README URL + dismiss hint. We don't shrink to
+    // one row on narrow terminals because the URL is the whole point
+    // — better to let line 2 truncate horizontally than drop it.
+    let macos_tip_h: u16 = if show_macos_tip { 2 } else { 0 };
     let show_overlay = app.overlay.is_some();
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),        // tab bar
-            Constraint::Min(1),           // main area
-            Constraint::Length(status_h), // status bar
+            Constraint::Length(1),           // tab bar
+            Constraint::Min(1),              // main area
+            Constraint::Length(macos_tip_h), // first-launch macOS tip
+            Constraint::Length(status_h),    // status bar
         ])
         .split(area);
 
     render_tab_bar(app, frame, chunks[0]);
     render_main_area(app, frame, chunks[1]);
+    if show_macos_tip {
+        render_macos_tip(app, frame, chunks[2]);
+    }
     if show_status {
-        render_status_bar(app, frame, chunks[2]);
+        render_status_bar(app, frame, chunks[3]);
     }
     // The IME composition overlay is drawn last so its centered box
     // and its caret anchor land on top of the pane content without
@@ -1057,6 +1067,31 @@ fn render_preview(app: &mut App, frame: &mut Frame, area: Rect) {
             }
         }
     }
+}
+
+// ─── macOS first-launch tip banner ────────────────────────
+
+/// Warm yellow for the warning glyph + headline — visually distinct
+/// from the status-bar hints directly below (dim gray + accent blue).
+const TIP_WARN: Color = Color::Rgb(0xe3, 0xb3, 0x41);
+
+/// Renders the 2-row Option-as-Meta banner. See `crate::macos_tip`
+/// for the gating logic; this function is only called when the
+/// banner has been surfaced, so there's no OS check here.
+fn render_macos_tip(app: &App, frame: &mut Frame, area: Rect) {
+    let m = app.messages();
+    let para = Paragraph::new(vec![
+        Line::from(Span::styled(
+            m.macos_tip_line1,
+            Style::default().fg(TIP_WARN).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            m.macos_tip_line2,
+            Style::default().fg(ACCENT_BLUE),
+        )),
+    ])
+    .style(Style::default().bg(HEADER_BG));
+    frame.render_widget(para, area);
 }
 
 // ─── Status bar (context-aware) ───────────────────────────


### PR DESCRIPTION
## Summary

macOS のターミナルは既定で `Option+<key>` を Unicode 入力 (`å` `∫` `π` …) に割り当てているため、ccmux の `Alt+T` / `Alt+P` / `Alt+R` / `Alt+S` / `Alt+1..9` / `Alt+Left/Right` が発火せず、初回起動時に「何もショートカットが動かない」状態になる。#107 (docs) で対処法を README に書いたが、READMEを読む動機が弱い層は詰まったまま。

起動時に 2 行のバナーをステータスバー直上に出して README 該当節へ誘導する。

```
⚠ macOS: Alt+<key> shortcuts require Option=Meta in your terminal
  https://github.com/happy-ryo/ccmux#macos-option-as-meta  (press any key to dismiss)
```

- 任意のキー押下 or 20 秒経過でバナー消滅 + `~/.config/ccmux/.macos_tip_dismissed` (ゼロバイト) を touch → 次回以降非表示
- Ctrl+Q でも dismiss が走ってからクオートするので、ゲストモード中に終了しても次回再表示されない
- dismiss はフォールスルー方式 (モーダルではない) なので、ユーザーは「消すためだけにキーを押す」必要がない
- 両言語 (JP/EN) とも英語 README の ASCII アンカーにリンク。JP README アンカーは Unicode を含むため、一部端末の URL オートリンカーが `を` 以降で切る可能性があるため

## Override precedence (highest → lowest)

1. `--show-macos-tip` — 強制表示 (マーカー無視、macOS-gated)
2. `--no-macos-tip` — 強制非表示 (マーカー書き込みもしない)
3. `CCMUX_NO_MACOS_TIP=<非空>` 環境変数 — 強制非表示
4. マーカーファイル存在 → 非表示
5. 非 macOS → 非表示
6. それ以外 (macOS + マーカー不在) → 表示

## Design notes

- **state.toml を新設しなかった**: 単一 bool のために TOML + serde を足すのは overengineering。ゼロバイトマーカーで十分。次の state が必要になったら再設計
- **Banner は 2 行固定**: narrow terminal では line 2 (URL) が水平に truncate されるが、ratatui の `Paragraph` デフォルト挙動 (no wrap) なので 2 行枠は超えない
- **Option 検知による自動 dismiss は見送り**: `†` `∫` 等 Option 出力 Unicode の検出は誤爆 (コピペ / 実際にその文字を入力したい等) が怖い。任意キーで dismiss の方がシンプル

## Review

- **evaluator agent**: 1 件指摘 (Ctrl+Q の早期 return より前に dismiss を置くべき) → 修正済み (`src/app.rs:handle_key_event` の先頭に dismiss フック配置)
- **Codex**: blocking なし、nit 4 件 (空文字列の env var テスト / App 層統合テスト / `File::create` → `OpenOptions` / `is_file()` 判定) — 実害なしのため別 PR 候補

## Files

- `src/macos_tip.rs` (NEW, ~200 行) — マーカーヘルパ + `should_show()` + unit tests (env-var race を mutex でシリアライズ)
- `src/cli.rs` — `--no-macos-tip` / `--show-macos-tip` (`conflicts_with` で排他) + parse tests
- `src/app.rs` — `App::show_macos_tip` / `dismiss_macos_tip` / `check_macos_tip_timeout`; `handle_key_event` 先頭に dismiss フック
- `src/ui.rs` — chunks を 3→4 に拡張 (tab / main / tip / status) + `render_macos_tip`
- `src/i18n.rs` — `macos_tip_line1` / `macos_tip_line2` JP/EN
- `src/main.rs` — module 宣言、起動時 gate、メインループで timer tick

## Test plan

- [x] `cargo fmt --all` / `cargo clippy --all-targets -- -D warnings` / `cargo test --release` (329 passed)
- [x] unit test: `should_show` の 6 段階 precedence 全て、マーカー touch/存在判定、env var suppress
- [x] CLI: `--no-macos-tip` / `--show-macos-tip` の排他を含む 4 テスト
- [x] 手動 (macOS): `rm ~/.config/ccmux/.macos_tip_dismissed && ccmux` でバナーが出る、任意キーで消えてマーカーが作られる、2 回目の起動でバナーが出ない
- [ ] 手動 (macOS): `ccmux --show-macos-tip` でマーカー無視して再表示
- [x] 手動 (非 macOS): バナー出ないことを CI (linux-x64) でクロス確認
- [x] 20 秒何もせずに待ってバナーが自動消滅、マーカーが作られる
- [ ] 端末幅 50 桁で起動して URL が horizontal truncate、2 行枠を超えない

## Follow-ups (別 PR 候補)

- Option 文字検知による silent auto-dismiss (「Alt+X が届いたら Option=Meta 設定済み → マーカー書く」)
- `ccmux mcp install` 成功出力への macOS 設定注記追記
- `ccmux doctor` サブコマンド (OS / terminal 推奨設定の診断)
- `keybindings.toml` でユーザーがバインドをカスタマイズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)