### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,23 @@ name = "ccmux"
 # claude` auto-launches Claude Code with the channel flag. The new
 # keybinding and the user-visible `ccmux mcp` subcommand tree are why
 # this is a minor bump.
-version = "0.9.0"
+# 0.10.0 centers on macOS Alt-key ergonomics:
+# - #107 documents the per-terminal Option=Meta setup (WezTerm /
+#   iTerm2 / Alacritty / Ghostty / Kitty / Terminal.app) in the
+#   README and cross-links it from the IME overlay Alt+Enter note.
+# - #108 adds a first-launch banner on macOS that surfaces the same
+#   setup hint at runtime and links to the README anchor, dismissed
+#   by any key or a 20 s timeout and persisted via a zero-byte
+#   marker at `~/.config/ccmux/.macos_tip_dismissed`. Two new
+#   override flags (`--no-macos-tip` / `--show-macos-tip`) and the
+#   `CCMUX_NO_MACOS_TIP` env var are the user-visible surface. The
+#   landing page (`lp/index.html` / `lp/ja.html`) also grows a
+#   dedicated "macOS setup: Option as Meta" section so visitors can
+#   read the configuration before installing.
+# Minor bump (not patch) because the banner is a first-launch
+# behavior change on macOS and the CLI surface grows — patch is
+# reserved for bug-only fixes per the release policy.
+version = "0.10.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary

Rolls up since v0.9.0 — focused on macOS Alt-key ergonomics:

- **docs(readme): per-terminal Option=Meta setup for macOS (#107)** — WezTerm / iTerm2 / Alacritty / Ghostty / Kitty / Terminal.app の設定表、IME overlay Alt+Enter 行からのクロスリンク
- **feat(ui): first-launch macOS Option-as-Meta banner (#108)** — ステータスバー直上に 2 行バナーで README アンカーへ誘導、任意キー / 20 秒で dismiss + `~/.config/ccmux/.macos_tip_dismissed` でオプトアウト永続化、`--no-macos-tip` / `--show-macos-tip` / `CCMUX_NO_MACOS_TIP` 上書き、LP (EN/JP) に「macOS setup: Option as Meta」セクション追加

## Why minor (not patch)

- 初回起動時バナーは macOS の挙動変更 (visible behavior change)
- CLI surface が拡張 (新フラグ 2 つ + env var 1 つ)
- 非 macOS ユーザーには影響なし

## Release process after merge

1. `main` にマージ
2. `git tag v0.10.0 && git push origin v0.10.0`
3. `.github/workflows/release.yml` が自動実行 → 4 プラットフォームのリリースビルド + GitHub Release + npm publish (Trusted Publishing)

## Test plan

- [x] `cargo build` クリーン (Cargo.lock 更新済み)
- [x] 前段の #108 で `cargo fmt` / `clippy --all-targets -D warnings` / `test --release` は 329 passed 確認済み
- [ ] このバージョン bump PR に対する CI (rustfmt / clippy / test x 3 OS) が全 green
- [ ] マージ後 `v0.10.0` タグ push で release workflow が成功 (4 platforms + npm publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)