### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,13 @@ name = "ccmux"
 # Minor bump (not patch) because the banner is a first-launch
 # behavior change on macOS and the CLI surface grows — patch is
 # reserved for bug-only fixes per the release policy.
-version = "0.10.0"
+# 0.11.0 adds FILES-sidebar Claude launcher keys (#110): `c`
+# splits the focused pane left/right and `v` splits it top/bottom,
+# each opening the new pane in the directory selected in the tree
+# and pre-filling the Alt+P launch line without pressing Enter so
+# the user reviews and commits. New keybindings are why this is a
+# minor bump rather than a patch.
+version = "0.11.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- 0.10.0 → 0.11.0 に minor bump。
- 含まれる変更: FILES サイドバーから Claude を分割起動するキー (`c` = 左右分割 / `v` = 上下分割) を追加 (#110)。新しいキーバインドの追加分として minor。

## Test plan
- [x] `cargo build` (Cargo.lock 更新済み)
- [ ] CI 4 プラットフォームビルドが通ること
- [ ] マージ後に `git tag v0.11.0 && git push origin v0.11.0` でリリースワークフローを起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)