### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,12 @@ name = "ccmux"
 # and pre-filling the Alt+P launch line without pressing Enter so
 # the user reviews and commits. New keybindings are why this is a
 # minor bump rather than a patch.
-version = "0.11.0"
+# 0.12.0 opens the IME composition overlay at its configured maximum
+# height (`OVERLAY_MAX_INNER_HEIGHT` = 10 rows) on the first frame
+# instead of starting at a single row and growing as the user typed
+# (#112). Overlay-open dimensions are visible behavior so this is a
+# minor bump, not a patch.
+version = "0.12.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- 0.11.0 → 0.12.0 に minor bump。
- 含まれる変更: IME composition overlay を開いた瞬間から最大高さ (10 行) で表示するように変更 (#112)。overlay 展開時の見た目が変わる user-visible behavior change のため minor。

## Test plan
- [x] `cargo build` (Cargo.lock 更新済み)
- [ ] CI 4 プラットフォームビルドが通ること
- [ ] マージ後に `git tag v0.12.0 && git push origin v0.12.0` で release workflow を起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)