### PR TITLE
chore(release): bump version to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ name = "ccmux"
 # instead of starting at a single row and growing as the user typed
 # (#112). Overlay-open dimensions are visible behavior so this is a
 # minor bump, not a patch.
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- 0.12.0 → 0.13.0 に minor bump。
- 含まれる変更: `ccmux mcp install` で入る MCP に 5 つのペイン操作ツール (`list_panes` / `spawn_pane` / `close_pane` / `focus_pane` / `new_tab`) を追加し、さらに `spawn_pane` / `new_tab` の `command="claude"` を Alt+P と同じ peer 対応起動コマンドに自動アップグレードする機能を追加 (#114)。Claude Code ユーザーに見える tool surface が増えるため minor。

## Test plan
- [x] `cargo build` (Cargo.lock 更新済み)
- [ ] CI 4 プラットフォームビルドが通ること
- [ ] マージ後に `git tag v0.13.0 && git push origin v0.13.0` で release workflow を起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)