### PR TITLE
feat(mcp): add inspect_pane tool for pane screen snapshots

### DIFF
--- a/src/mcp_peer/mod.rs
+++ b/src/mcp_peer/mod.rs
@@ -212,7 +212,11 @@ assigns a stable name, or attaches a role label.\n\
 - close_pane: Close a pane by id or name. Refuses when it's the last pane of the last tab.\n\
 - focus_pane: Move keyboard focus to another pane in the same tab.\n\
 - new_tab: Open a brand-new tab with a fresh pane and switch focus to it. Unlike the other \
-pane-control tools, this reaches outside the current tab.\n\n\
+pane-control tools, this reaches outside the current tab.\n\
+- inspect_pane: Snapshot the visible screen of a pane so you can detect interactive \
+prompts, banners, or mode indicators in another pane without asking it. Returns plain \
+text by default; pass format=\"grid\" for row-addressable JSON or lines=N to trim to \
+the last N rows.\n\n\
 Launching Claude Code: when spawn_pane or new_tab is asked to start Claude Code, pass \
 command=\"claude\" (plus any normal claude arguments you want). The MCP automatically \
 upgrades a bare `claude` invocation to the Alt+P peer-enabled form \
@@ -353,6 +357,34 @@ fn tools_spec() -> Value {
                         "description": "Optional free-form role label attached to the new pane."
                     }
                 }
+            }
+        },
+        {
+            "name": "inspect_pane",
+            "description": "Snapshot the visible screen of a pane in the current ccmux tab. Returns the rendered contents so you can detect interactive prompts (e.g. y/n confirmations), error banners, or mode indicators in another pane without asking its Claude. The `lines` option trims the response to the bottom N rows (blank rows preserved, useful for anchoring on a status bar). `format=\"grid\"` switches the text block to JSON with one row object per line; the full structured payload is always available in `structuredContent`.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Pane to inspect. Numeric id (from list_panes), stable name, or the literal 'focused'. All-digit strings are always interpreted as ids — a pane literally named '7' cannot be addressed by name, use its id instead."
+                    },
+                    "lines": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional — trim the response to the bottom N rows of the screen grid. Blank rows are preserved. Omit for the full visible screen."
+                    },
+                    "include_cursor": {
+                        "type": "boolean",
+                        "description": "When true, the payload includes a `cursor` object ({visible, row, col}). Defaults to false."
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["text", "grid"],
+                        "description": "'text' (default) returns the plain rendered screen as the content text. 'grid' returns a JSON blob with one object per row. `structuredContent` is always populated with the full payload regardless of this choice."
+                    }
+                },
+                "required": ["target"]
             }
         }
     ])
@@ -502,6 +534,7 @@ fn handle_tools_call(id: &Value, params: &Value, ctx: &PeerCtx) -> Result<Value>
         "close_pane" => handle_close_pane(id, &args, ctx),
         "focus_pane" => handle_focus_pane(id, &args, ctx),
         "new_tab" => handle_new_tab(id, &args, ctx),
+        "inspect_pane" => handle_inspect_pane(id, &args, ctx),
         other => err_response(id, -32601, &format!("unknown tool: {other}")),
     })
 }
@@ -808,6 +841,114 @@ fn handle_new_tab(id: &Value, args: &Value, ctx: &PeerCtx) -> Value {
             id,
             -32603,
             &format!("ccmux refused new_tab: {}", fmt_code(&message, &code)),
+        ),
+        Ok(other) => err_response(id, -32603, &format!("unexpected ccmux response: {other:?}")),
+        Err(e) => err_response(id, -32603, &format!("ccmux call failed: {e}")),
+    }
+}
+
+// ── inspect_pane (pane screen snapshot over MCP) ──────────────
+
+/// Cap on the `lines` argument. The underlying screen is bounded by
+/// the pane's terminal height (< 1000 under any sane desktop), but
+/// accept a generous ceiling so callers can request "everything I can
+/// possibly see" without hand-tuning. Values above this are clamped
+/// silently to match how `ccmux inspect --lines` treats oversized
+/// requests.
+const INSPECT_MAX_LINES: u64 = 10_000;
+
+fn parse_inspect_format(raw: Option<&str>) -> std::result::Result<InspectFormat, String> {
+    match raw.map(str::trim) {
+        None | Some("") | Some("text") => Ok(InspectFormat::Text),
+        Some("grid") => Ok(InspectFormat::Grid),
+        Some(other) => Err(format!(
+            "invalid format {other:?}; expected 'text' or 'grid'"
+        )),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InspectFormat {
+    Text,
+    Grid,
+}
+
+/// Render the Inspect IPC payload's `text` field as the content
+/// block, defaulting to an empty string when absent so Claude
+/// never sees a missing field crash.
+fn inspect_text_block(payload: &Value) -> String {
+    payload
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Render the Inspect IPC payload's `lines` array as a
+/// human-inspectable JSON grid. Falls back to the raw payload text
+/// when the array is absent so a malformed payload doesn't silently
+/// produce an empty response.
+fn inspect_grid_block(payload: &Value) -> String {
+    match payload.get("lines") {
+        Some(lines) => serde_json::to_string_pretty(lines).unwrap_or_else(|_| lines.to_string()),
+        None => inspect_text_block(payload),
+    }
+}
+
+fn handle_inspect_pane(id: &Value, args: &Value, ctx: &PeerCtx) -> Value {
+    let raw_target = args.get("target").and_then(|v| v.as_str()).unwrap_or("");
+    if raw_target.trim().is_empty() {
+        return err_response(
+            id,
+            -32602,
+            "inspect_pane requires a non-empty target (pane id or name)",
+        );
+    }
+    let target = parse_target(Some(raw_target));
+    let lines = args.get("lines").and_then(|v| v.as_u64()).map(|n| {
+        let clamped = n.min(INSPECT_MAX_LINES);
+        clamped as usize
+    });
+    let include_cursor = args
+        .get("include_cursor")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let format = match parse_inspect_format(args.get("format").and_then(|v| v.as_str())) {
+        Ok(f) => f,
+        Err(msg) => return err_response(id, -32602, &msg),
+    };
+
+    let (_caller_pane, endpoint) = match require_connected(ctx, id, "inspect pane") {
+        Ok(t) => t,
+        Err(resp) => return resp,
+    };
+
+    match client::send_request(
+        endpoint,
+        &Request::Inspect {
+            target,
+            lines,
+            include_cursor,
+        },
+    ) {
+        Ok(Response::Ok { data }) => {
+            let text = match format {
+                InspectFormat::Text => inspect_text_block(&data),
+                InspectFormat::Grid => inspect_grid_block(&data),
+            };
+            ok_response(
+                id,
+                json!({
+                    "content": [ { "type": "text", "text": text } ],
+                    "isError": false,
+                    "structuredContent": data,
+                }),
+            )
+        }
+        Ok(Response::Err { message, code }) => err_response(
+            id,
+            -32603,
+            &format!("ccmux refused inspect_pane: {}", fmt_code(&message, &code)),
         ),
         Ok(other) => err_response(id, -32603, &format!("unexpected ccmux response: {other:?}")),
         Err(e) => err_response(id, -32603, &format!("ccmux call failed: {e}")),
@@ -1174,6 +1315,7 @@ mod tests {
             "close_pane",
             "focus_pane",
             "new_tab",
+            "inspect_pane",
         ] {
             assert!(
                 names.contains(&expected),
@@ -1363,6 +1505,152 @@ mod tests {
         }
     }
 
+    // ── inspect_pane unit tests ───────────────────────────────
+
+    #[test]
+    fn parse_inspect_format_defaults_to_text() {
+        assert_eq!(parse_inspect_format(None), Ok(InspectFormat::Text));
+        assert_eq!(parse_inspect_format(Some("")), Ok(InspectFormat::Text));
+        assert_eq!(parse_inspect_format(Some("  ")), Ok(InspectFormat::Text));
+        assert_eq!(parse_inspect_format(Some("text")), Ok(InspectFormat::Text));
+    }
+
+    #[test]
+    fn parse_inspect_format_accepts_grid() {
+        assert_eq!(parse_inspect_format(Some("grid")), Ok(InspectFormat::Grid));
+    }
+
+    #[test]
+    fn parse_inspect_format_rejects_unknown() {
+        assert!(parse_inspect_format(Some("json")).is_err());
+        assert!(parse_inspect_format(Some("GRID")).is_err());
+    }
+
+    #[test]
+    fn inspect_text_block_returns_text_field() {
+        let payload = json!({
+            "text": "line1\nline2",
+            "lines": [{ "row": 0, "text": "line1" }],
+        });
+        assert_eq!(inspect_text_block(&payload), "line1\nline2");
+    }
+
+    #[test]
+    fn inspect_text_block_returns_empty_on_missing_field() {
+        // A malformed payload without `text` must not panic — callers
+        // rely on the tool never crashing the MCP dispatcher even when
+        // the inspect response shape regresses.
+        let payload = json!({ "lines": [] });
+        assert_eq!(inspect_text_block(&payload), "");
+    }
+
+    #[test]
+    fn inspect_grid_block_renders_lines_as_pretty_json() {
+        let payload = json!({
+            "lines": [
+                { "row": 0, "text": "hello" },
+                { "row": 1, "text": "world" },
+            ],
+            "text": "hello\nworld",
+        });
+        let out = inspect_grid_block(&payload);
+        // Pretty-printed JSON starts with `[` on its own line and
+        // contains each row's text.
+        assert!(out.starts_with('['), "expected JSON array, got {out:?}");
+        assert!(out.contains("\"hello\""), "missing line text: {out}");
+        assert!(out.contains("\"world\""), "missing line text: {out}");
+    }
+
+    #[test]
+    fn inspect_grid_block_falls_back_to_text_when_lines_missing() {
+        // Forward-compat: if a future ccmux server returns only `text`
+        // without `lines`, we still surface something useful instead of
+        // an empty string that looks like "nothing to see".
+        let payload = json!({ "text": "only-text" });
+        assert_eq!(inspect_grid_block(&payload), "only-text");
+    }
+
+    #[test]
+    fn handle_inspect_pane_rejects_empty_target() {
+        let ctx = PeerCtx {
+            mode: Mode::Detached {
+                reason: "not relevant".into(),
+            },
+        };
+        let id = json!(1);
+        let resp = handle_inspect_pane(&id, &json!({ "target": "   " }), &ctx);
+        assert_eq!(
+            resp.get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|v| v.as_i64()),
+            Some(-32602),
+            "expected invalid-params error, got {resp}"
+        );
+    }
+
+    #[test]
+    fn handle_inspect_pane_rejects_unknown_format() {
+        // Format validation runs before any IPC round-trip, so a bad
+        // `format` must come back as -32602 even in detached mode.
+        let ctx = PeerCtx {
+            mode: Mode::Detached {
+                reason: "not relevant".into(),
+            },
+        };
+        let id = json!(1);
+        let resp = handle_inspect_pane(&id, &json!({ "target": "1", "format": "csv" }), &ctx);
+        assert_eq!(
+            resp.get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|v| v.as_i64()),
+            Some(-32602),
+            "expected invalid-params error for bad format, got {resp}"
+        );
+    }
+
+    #[test]
+    fn handle_inspect_pane_detached_surfaces_friendly_text() {
+        // Detached mode must not error; instead return the standard
+        // "ccmux not reachable" text so Claude can relay it to the user.
+        let ctx = PeerCtx {
+            mode: Mode::Detached {
+                reason: "CCMUX_PANE_ID not set".into(),
+            },
+        };
+        let id = json!(1);
+        let resp = handle_inspect_pane(&id, &json!({ "target": "1" }), &ctx);
+        let text = resp
+            .pointer("/result/content/0/text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            text.contains("ccmux not reachable"),
+            "missing explanation in {text:?}"
+        );
+    }
+
+    #[test]
+    fn inspect_pane_schema_requires_target() {
+        // Pin the Issue #116 contract: the tool schema must enforce
+        // `target` as required so Claude can't call without it.
+        let spec = tools_spec();
+        let inspect = spec
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("inspect_pane"))
+            .expect("inspect_pane entry");
+        let required: Vec<&str> = inspect
+            .get("inputSchema")
+            .and_then(|s| s.get("required"))
+            .and_then(|r| r.as_array())
+            .expect("required array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(required, vec!["target"], "{required:?}");
+    }
+
     #[test]
     fn tools_call_routes_to_pane_control_handlers() {
         // Smoke test on the dispatch: each new tool name must route
@@ -1384,6 +1672,7 @@ mod tests {
             ("close_pane", json!({ "target": "1" })),
             ("focus_pane", json!({ "target": "1" })),
             ("new_tab", json!({})),
+            ("inspect_pane", json!({ "target": "1" })),
         ] {
             let params = json!({ "name": name, "arguments": args });
             let resp = handle_tools_call(&id, &params, &ctx).expect("dispatch");


### PR DESCRIPTION
## Summary

Adds the `inspect_pane` MCP tool on `ccmux-peers`, closing #116 and ticking the second box of Epic #119.

- Wraps the existing `Request::Inspect` IPC path as a thin MCP handler — no changes to the ccmux server itself.
- Defaults to plain-text rendering in the `content` block; `structuredContent` always carries the full Inspect payload so machine callers don't re-parse.
- `format="grid"` switches the text block to pretty-printed row-addressable JSON.
- `lines=N` trims to the bottom N rows (blank rows preserved so callers can still anchor on status-bar positions).
- `include_cursor=true` adds the cursor object to the payload.
- Error code vocabulary inherited from the existing IPC layer: `PANE_NOT_FOUND`, `PANE_VANISHED`, `INTERNAL`.
- Detached mode (mcp-peer spawned outside ccmux) returns the standard "ccmux not reachable" explanatory text instead of erroring.

## Test plan

- [x] `cargo test` → 365 / 365 passed (9 new `inspect_pane` tests covering format parsing, text/grid rendering, empty-target rejection, schema contract, and detached-mode friendly text).
- [x] `cargo fmt --all -- --check` clean.
- [x] `codex review --base main` pass applied.

## Codex review note

Codex flagged that `App::handle_inspect` resolves against `self.ws()` (the active workspace) rather than the caller pane's workspace, so `inspect_pane` would inspect the wrong pane when the mcp-peer lives in an inactive tab.

This is a **pre-existing, platform-wide** gap shared by every pane-control MCP tool (`list_panes`, `close_pane`, `focus_pane`, `spawn_pane` all use the same `self.ws()`-scoped IPC requests). Cross-tab resolution is tracked by #71; fixing it there will transparently fix `inspect_pane` too. This PR deliberately matches the existing semantics rather than introducing divergent behavior for a single tool.

## Out of scope for this PR

- Cross-tab pane resolution → #71.
- `poll_events` (#117) → shipped separately in #120.
- `send_keys` (#118) → separate follow-up PR.

## Refs

- Closes #116
- Part of Epic #119
- Related: #71 (cross-tab pane operations)