### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,26 @@ name = "ccmux"
 # instead of starting at a single row and growing as the user typed
 # (#112). Overlay-open dimensions are visible behavior so this is a
 # minor bump, not a patch.
-version = "0.13.0"
+# 0.13.0 brings the peer MCP pane-control tool suite and the Alt+P
+# claude auto-upgrade (#114): the `ccmux-peers` MCP server gains
+# `spawn_pane` / `close_pane` / `focus_pane` / `list_panes` / `new_tab`
+# so orchestrators can manage the layout without shelling out, and any
+# bare `claude` command the MCP is asked to run is rewritten to the
+# peer-enabled form so the spawned instance joins the channel. The new
+# tools and the implicit rewrite are visible behavior for anyone using
+# the MCP, hence the minor bump.
+# 0.14.0 closes Epic #119: the `ccmux-peers` MCP grows three more
+# tools so downstream orchestrators can drop every remaining
+# `Bash(ccmux *)` permission. `inspect_pane` (#116 / #121) exposes
+# `ccmux inspect` screen snapshots with a text or grid rendering;
+# `poll_events` (#117 / #120) surfaces pane lifecycle events
+# (pane_started / pane_exited / events_dropped) via a cursor-based
+# long-poll with an optional `types` filter; `send_keys` (#118 /
+# #122) delivers raw key input (Enter, Shift+Tab, Esc, Ctrl+<letter>,
+# arbitrary `text`) so callers can answer interactive prompts or
+# toggle Claude Code's Plan→AcceptEdits mode without touching the
+# CLI. Three new MCP tools on the wire, hence the minor bump.
+version = "0.14.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary

Bumps `Cargo.toml` and `npm/package.json` to **0.14.0**, closing Epic #119.

Three new MCP tools landed on `ccmux-peers` across #121 / #120 / #122 so downstream orchestrators can drop every remaining `Bash(ccmux *)` permission:

- **`inspect_pane`** (#116 / #121) — `ccmux inspect` screen snapshots with text or grid rendering; `structuredContent` always carries the full payload.
- **`poll_events`** (#117 / #120) — cursor-based long-poll over pane lifecycle events (pane_started / pane_exited / events_dropped / forward-compatible variants) with an optional `types` filter.
- **`send_keys`** (#118 / #122) — raw PTY key input (Enter, Shift+Tab, Esc, Ctrl+<A-Z>, arrow keys, literal `text`) so callers can answer interactive prompts or toggle Claude Code's Plan→AcceptEdits mode without touching the CLI.

Three new MCP tools on the wire is visible behavior, so this is a minor bump rather than a patch.

## Release process

After merge, tag `v0.14.0` and push to trigger `.github/workflows/release.yml`:
- 4-platform release builds (Windows x64, macOS x64/arm64, Linux x64)
- GitHub Release + `checksums.txt`
- `npm publish` via Trusted Publishing (`ccmux-fork@0.14.0` on `latest`)

## Test plan

- [x] `cargo build` on the bumped tree (compiles as `ccmux v0.14.0`).
- [x] `Cargo.lock` regenerated by the build.
- [x] `npm/package.json` matches `Cargo.toml` (both at 0.14.0).