### PR TITLE
docs(readme): correct binary size from ~1 MB to ~8-10 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A lightweight terminal multiplexer built specifically for running multiple [Clau
 - **Scrollback** — 10,000 lines of terminal history per pane
 - **Dark theme** — Claude-inspired color scheme
 - **Cross-platform** — Windows, macOS, Linux
-- **Single binary** — ~1MB, no runtime dependencies
+- **Single binary** — ~8–10 MB depending on platform, no runtime dependencies
 
 ## Install
 


### PR DESCRIPTION
## Summary

Updates the README feature bullet so the binary-size claim matches reality.

The `~1MB` line predates the current dependency footprint. Release v0.13.0 assets actually measure **7.5–9.7 MB** across platforms:

| Platform | Size |
|---|---|
| Windows x64 (`ccmux-windows-x64.exe`) | 7.56 MB |
| macOS arm64 (`ccmux-macos-arm64`) | 8.28 MB |
| macOS x64 (`ccmux-macos-x64`) | 8.72 MB |
| Linux x64 (`ccmux-linux-x64`) | 9.68 MB |

Using a range (`~8–10 MB depending on platform`) rather than a single number so the line stays honest across minor dependency shifts without needing another edit each release.

## Reproduce

```bash
gh release view v0.13.0 --repo happy-ryo/ccmux --json assets --jq '.assets[] | "\(.name): \(.size) bytes"'
```

## Test plan

Docs-only, one-line edit. No code paths touched.