### PR TITLE
fix(layout): auto-upgrade bare `claude` command in layout TOML (#126)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -238,6 +238,8 @@ _ペイン操作 (`new_tab` を除き同一タブ内):_
 | `focus_pane(target)` | 同じタブ内でフォーカス移動。ユーザーの手元からフォーカスを奪うことになるので使いどころに注意。 |
 | `new_tab(…)` | 新しいタブを 1 枚開いてそこへフォーカスを移す。`spawn_pane` と同じ `claude` 自動アップグレードが効く。 |
 
+> この `claude` 自動アップグレードは layout TOML (`ccmux --layout <name>`) 経由で起動するペインにも適用される。layout toml に `command = "claude"` と書けばペイン起動時に peer 対応コマンドへ書き換えられるので、各エントリで毎回 `--dangerously-load-development-channels server:ccmux-peers` を書く必要はない。
+
 ### うまく動かないとき
 
 - **`list_peers` が "ccmux not reachable from this Claude Code instance" を返す** — Claude Code が ccmux の外で起動されたか、ccmux ペインの環境変数を引き継げていません。ccmux のペイン内で `Alt+P` か `ccmux split --role claude` から起動し直してください。

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ _Pane control (same tab, except `new_tab`):_
 | `focus_pane(target)` | Moves keyboard focus inside the same tab. Use sparingly — yanking focus out from under the user is disruptive. |
 | `new_tab(…)` | Opens a brand-new tab with a fresh pane and switches focus to it. Same `claude` auto-upgrade as `spawn_pane`. |
 
+> The same `claude` auto-upgrade also applies to panes declared in a layout TOML (`ccmux --layout <name>`): a bare `command = "claude"` in the toml is rewritten to the peer-enabled launch line when the pane starts, so layouts join the ccmux-peers network without each entry having to repeat `--dangerously-load-development-channels server:ccmux-peers`.
+
 ### Troubleshooting
 
 - **`list_peers` reports "ccmux not reachable from this Claude Code instance"** — Claude Code was launched outside a ccmux pane, or without inheriting the env. Re-launch via `Alt+P` or `ccmux split --role claude` from within ccmux.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1708,7 +1708,14 @@ impl App {
                         pane.role = Some(r.clone());
                     }
                     if let Some(cmd) = command {
-                        pane.queue_startup_command(cmd);
+                        // Mirror MCP `spawn_pane` / `new_tab` behavior:
+                        // a bare `claude` invocation is upgraded to the
+                        // peer-enabled launch line so panes declared in
+                        // layout toml join the ccmux-peers network
+                        // without the author having to repeat
+                        // `--dangerously-load-development-channels`.
+                        let upgraded = crate::mcp_peer::upgrade_claude_command(cmd);
+                        pane.queue_startup_command(&upgraded);
                     }
                 }
                 Ok(())
@@ -4672,6 +4679,61 @@ mod tests {
         assert!(default_command_for_role(None).is_none());
         assert!(default_command_for_role(Some("worker")).is_none());
         assert!(default_command_for_role(Some("")).is_none());
+    }
+
+    #[test]
+    fn apply_layout_auto_upgrades_bare_claude_command() {
+        // Issue #126: layout toml's `command = "claude"` should receive
+        // the same peer-enabled launch-line upgrade as MCP spawn_pane /
+        // Alt+P, so layout-declared panes join the ccmux-peers network.
+        let cfg = crate::layout_config::LayoutConfig {
+            version: 1,
+            name: "upgrade-test".into(),
+            root: crate::layout_config::LayoutNodeSpec::Pane {
+                id: "secretary".into(),
+                command: Some("claude".into()),
+                role: None,
+            },
+        };
+        let mut app = App::new(40, 80).expect("App::new");
+        app.apply_layout(&cfg).expect("apply_layout");
+
+        let pane_id = *app.ws().pane_names.get("secretary").expect("registered");
+        let pane = app.ws().panes.get(&pane_id).expect("pane");
+        let queued = pane
+            .pending_startup
+            .as_ref()
+            .expect("startup command queued");
+        let queued_str = std::str::from_utf8(queued).expect("utf8");
+        assert!(
+            queued_str.contains("--dangerously-load-development-channels server:ccmux-peers"),
+            "layout `claude` should be upgraded to peer-enabled form; got: {queued_str:?}"
+        );
+        app.shutdown();
+    }
+
+    #[test]
+    fn apply_layout_preserves_non_claude_command() {
+        // Non-`claude` commands must pass through untouched.
+        let cfg = crate::layout_config::LayoutConfig {
+            version: 1,
+            name: "passthrough-test".into(),
+            root: crate::layout_config::LayoutNodeSpec::Pane {
+                id: "worker".into(),
+                command: Some("echo hello".into()),
+                role: None,
+            },
+        };
+        let mut app = App::new(40, 80).expect("App::new");
+        app.apply_layout(&cfg).expect("apply_layout");
+
+        let pane_id = *app.ws().pane_names.get("worker").expect("registered");
+        let pane = app.ws().panes.get(&pane_id).expect("pane");
+        let queued_str =
+            std::str::from_utf8(pane.pending_startup.as_ref().expect("queued")).expect("utf8");
+        assert!(queued_str.starts_with("echo hello"));
+        assert!(!queued_str.contains("--dangerously-load-development-channels"));
+        app.shutdown();
     }
 
     #[test]

--- a/src/mcp_peer/mod.rs
+++ b/src/mcp_peer/mod.rs
@@ -741,7 +741,7 @@ fn opt_string(args: &Value, key: &str) -> Option<String> {
 /// - Preserve the caller's trailing arguments: `"claude --resume"`
 ///   becomes `"claude --dangerously-load-development-channels
 ///   server:ccmux-peers --resume"`.
-fn upgrade_claude_command(cmd: &str) -> String {
+pub(crate) fn upgrade_claude_command(cmd: &str) -> String {
     if cmd.contains("--dangerously-load-development-channels") {
         return cmd.to_string();
     }


### PR DESCRIPTION
## Summary
- Issue #126 案A を採用: `apply_layout_node` で `upgrade_claude_command` を通すようにして、layout toml の `command = "claude"` も MCP `spawn_pane` / `Alt+P` と同様に peer 対応コマンド (`--dangerously-load-development-channels server:ccmux-peers`) に自動書き換えされるようにした。
- README / README.ja にも layout toml が同じ auto-upgrade の対象である旨を追記。
- `upgrade_claude_command` を `pub(crate)` に昇格して `app.rs` から呼べるようにした (内部可視性のみ)。

## Why
- layout で `command = "claude"` と書いた pane が peer ネットワークに参加できず、`send_message` の push が届かない挙動は実質バグだった (aainc-ops の `ccmux-layouts/ops.toml` で踏んだ)。
- MCP / Alt+P との一貫性を優先し、toml 側に `--dangerously-load-development-channels` を書かせる運用を避ける。

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test` (394 passed)
- [x] 新規ユニットテスト:
  - `apply_layout_auto_upgrades_bare_claude_command` — layout の `claude` が peer フラグ付きに書き換わる
  - `apply_layout_preserves_non_claude_command` — `echo hello` 等はそのまま
- [x] `ccmux --layout <foo>` で実機確認

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)