### PR TITLE
chore(release): bump version to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ name = "ccmux"
 # arbitrary `text`) so callers can answer interactive prompts or
 # toggle Claude Code's Plan→AcceptEdits mode without touching the
 # CLI. Three new MCP tools on the wire, hence the minor bump.
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` / `Cargo.lock` / `npm/package.json` to **0.14.1**
- Patch release covering changes since v0.14.0:
  - #127 — fix(layout): auto-upgrade bare `claude` command in layout TOML
  - #124 / #125 — README binary-size doc fixes

## Test plan
- [ ] CI green (build + rustfmt)
- [ ] After merge: tag `v0.14.1` and let `release.yml` publish GitHub Release + npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)