### PR TITLE
chore(claude): block accidental gh pr create against upstream

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create*)",
+            "command": "cmd=$(jq -r '.tool_input.command'); if echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+Shin-sibainu/ccmux'; then echo 'Blocked: PR target is upstream Shin-sibainu/ccmux. Add --repo happy-ryo/ccmux --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi; if ! echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+happy-ryo/ccmux'; then echo 'Blocked: gh pr create without --repo defaults to upstream Shin-sibainu/ccmux. Add --repo happy-ryo/ccmux --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- 上流(`Shin-sibainu/ccmux`)への誤 PR 作成を CLI レベルで防ぐ Claude Code PreToolUse フックを追加
- 設置先: `.claude/settings.json`(プロジェクト共有、コミット対象)

## 背景
caret 修正 PR (#129) を作成した際、`gh pr create` が `--repo` 指定なしで実行された結果、デフォルトで upstream に PR (#9) が誤って作成された。CLAUDE.md には「上流への逆 PR は明示指示なしには出さない」とあり、即クローズして fork に作り直したが、同じ事故を再発させないために自動ガードを入れる。

## 内容
`.claude/settings.json` に PreToolUse フックを追加:
- マッチ対象: `Bash` ツール、`if` フィルタで `Bash(gh pr create*)` のみ発火
- ブロック条件:
  - `--repo` の引数として upstream リポジトリが明示的に含まれる
  - `--repo happy-ryo/ccmux` が含まれていない(= デフォルトで upstream に行く)
- 動作: stderr に修正方法を表示して `exit 2`(Claude Code がツール実行を拒否)

## 動作確認
| コマンド | 結果 |
| --- | --- |
| `gh pr create` | ❌ ブロック |
| `gh pr create --title foo` | ❌ ブロック |
| upstream 指定 | ❌ ブロック |
| `gh pr create --repo happy-ryo/ccmux --base main` | ✅ 通過 |
| `gh pr list` / `git status` | ✅ 通過(対象外) |

実際の Claude Code セッションで誤コマンドを試行 → フックが正常に発火してエラー表示で停止することを確認済み。本 PR を作成する際にフック自体が `--body` 内の説明テキストを誤検知することがあったので、body はファイル経由で渡す運用に切り替えた(本 PR がそのケース)。

## Test plan
- [x] フック発火確認(実セッション)
- [x] `jq -e` によるスキーマ検証
- [x] 別セッション・別環境(他のフォーク maintainer)でも同様にロード・発火するか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
