### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,12 @@ name = "ccmux"
 # arbitrary `text`) so callers can answer interactive prompts or
 # toggle Claude Code's Plan→AcceptEdits mode without touching the
 # CLI. Three new MCP tools on the wire, hence the minor bump.
-version = "0.14.1"
+# 0.15.0 fixes the long-standing Claude Code caret rendering bug on
+# Claude panes (#129): the host hardware caret now tracks Claude's
+# inverse-video pseudo-caret across blink, redraw, and remote-row
+# update phases instead of vanishing or jumping. User-visible
+# editing behavior change, hence the minor bump.
+version = "0.15.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- v0.15.0 リリース
- Claude Code caret rendering fix (#129) と上流誤 PR ブロック Hook (#130) を取り込んだバージョン

## ユーザー影響
- **Claude pane でのキャレット表示が安定**:
  - Claude のタスクタイトル更新で消えない
  - 行末・行内編集どちらも位置合致
  - blink で位置がオシレートしない
  - Claude が画面の他所(streaming output、status line)を更新中も飛ばない
- 残課題: スピナー描画中に IME 候補ウィンドウだけ位置がワープするケース → #131 で追跡

## 内訳
- #129: caret tracking 全般のフィックス
- #130: 上流誤 PR ブロック Hook(プロジェクト共有 .claude/settings.json)
- #131: スピナーワープの既知バグ(本リリースでは未対応、次バージョン以降で検討)

## なぜ minor bump か
ユーザー実機検証で「半角編集メチャクチャ安定」と確認済みの実体験改善。patch ではなく minor にする価値あり。

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build`
- [x] `cargo test` 394/394
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI(rustfmt, clippy, test x3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
