### PR TITLE
chore(release): bump version to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,14 @@ name = "ccmux"
 # inverse-video pseudo-caret across blink, redraw, and remote-row
 # update phases instead of vanishing or jumping. User-visible
 # editing behavior change, hence the minor bump.
-version = "0.15.0"
+# 0.15.1 follow-up to #131: stop the native IME composition pre-edit
+# from warping onto Claude's spinner / status row while Claude is
+# streaming output. Two pieces — Windows conpty caret leak now hidden
+# every frame instead of only behind the IME overlay, and the host
+# caret is pinned to the input row found by its `❯` prompt glyph
+# rather than chasing vt100's cursor. Patch bump because the change
+# is a bug fix on top of 0.15.0's editing baseline.
+version = "0.15.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- Patch release v0.15.1
- Bundles the IME-pre-edit-warp fix (#133, closes #131) and the npm-update README guidance

## What changed since v0.15.0
- **#133 / fixes #131** — Native IME composition pre-edit no longer warps onto Claude's spinner / status row while Claude is streaming output.
  - Windows conpty caret leak hidden every frame instead of only when the IME overlay is open.
  - Host caret pinned to the input row found by its `❯` prompt glyph instead of chasing vt100's cursor.
- README.md / README.ja.md now document the `npm install -g ccmux-fork@latest` update flow for users whose `npm update -g` no-ops.

## Why patch (not minor)
Bug fix on top of 0.15.0's editing baseline; no new features, no behavior change for users who never hit the warp.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build`
- [x] `cargo test` — 394 passing
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manual verification on Windows + Windows Terminal + Claude Code v2.1.117
- [ ] CI: rustfmt, clippy, test (ubuntu / windows / macos)
- [ ] Release workflow: GitHub Release + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
