### PR TITLE
chore(release): bump version to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,13 @@ name = "ccmux"
 # caret is pinned to the input row found by its `❯` prompt glyph
 # rather than chasing vt100's cursor. Patch bump because the change
 # is a bug fix on top of 0.15.0's editing baseline.
-version = "0.15.1"
+# 0.15.2 follow-up to #138: tighten the sticky Claude-caret
+# tracking so panes that previously hosted Claude Code don't stay
+# latched into caret-tracking mode after returning to a normal
+# shell prompt. Sticky-caret path now engages only while the PTY
+# cursor is actually hidden; new regression test covers the gating
+# helper. Patch bump — pure bug fix on top of 0.15.1.
+version = "0.15.2"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- Patch release v0.15.2
- Bundles the sticky-caret gating fix (#138)

## What changed since v0.15.1
- **#138** — Tighten the sticky Claude-caret tracking so panes that previously hosted Claude Code don't stay latched into caret-tracking mode after returning to a regular shell prompt. Sticky-caret path now engages only while the PTY cursor is actually hidden; added regression test for the gating helper.

## Why patch (not minor)
Bug fix on top of 0.15.1's editing baseline; no new features, no behavior change for users who never hit the stuck-caret-in-shell scenario.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check` — builds clean, Cargo.lock regenerated at 0.15.2
- [ ] CI: rustfmt, clippy, test (ubuntu / windows / macos)
- [ ] Release workflow: GitHub Release + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)