### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ name = "ccmux"
 # shell prompt. Sticky-caret path now engages only while the PTY
 # cursor is actually hidden; new regression test covers the gating
 # helper. Patch bump — pure bug fix on top of 0.15.1.
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
Release bump for #140 (structured `cwd` support on pane-creation APIs, closes #135).

Minor version bump because the surface changes are purely additive:

- `Request::Split` / `Request::NewTab` accept optional `cwd`
- `PaneInfo.cwd` surfaced by `list_panes`
- MCP `spawn_pane` / `new_tab` get `cwd` argument
- `ccmux split --cwd` / `ccmux new-tab --cwd`
- layout TOML `[type = \"pane\"]` nodes accept `cwd`
- new `err_code::CWD_INVALID`

No backwards-incompatible changes — callers without `cwd` continue to behave exactly as before.

After merge, tagging `v0.16.0` kicks off the release workflow (4-platform build + GitHub Release + npm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)