### PR TITLE
feat(api): set_pane_identity MCP tool and ccmux rename CLI (closes #136)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -246,6 +246,7 @@ _ペイン操作 (`new_tab` を除き同一タブ内):_
 | `close_pane(target)` | ペインを閉じる。最後のタブの最後のペインを閉じようとしたときは `last_pane` で拒否。 |
 | `focus_pane(target)` | 同じタブ内でフォーカス移動。ユーザーの手元からフォーカスを奪うことになるので使いどころに注意。 |
 | `new_tab(…)` | 新しいタブを 1 枚開いてそこへフォーカスを移す。`spawn_pane` と同じ `claude` 自動アップグレードが効く。 |
+| `set_pane_identity(target, name?, role?)` | 既存ペインの安定 `name` / `role` を付け直す・クリアする。3 ステート: キー省略 = 現状維持、`null` = クリア、文字列 = 設定。`ccmux --layout ops` を忘れて起動したセッションで secretary ペインに `id = "secretary"` が付いていない、といった状態からのリカバリに使う。全桁数字の name は数値 id と曖昧化するため拒否、同一タブ内の name 衝突も拒否。CLI では `ccmux rename [--id \| --name \| --focused] [--to-name \| --clear-name] [--to-role \| --clear-role]`。 |
 
 > この `claude` 自動アップグレードは layout TOML (`ccmux --layout <name>`) 経由で起動するペインにも適用される。layout toml に `command = "claude"` と書けばペイン起動時に peer 対応コマンドへ書き換えられるので、各エントリで毎回 `--dangerously-load-development-channels server:ccmux-peers` を書く必要はない。
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ _Pane control (same tab, except `new_tab`):_
 | `close_pane(target)` | Closes a pane. Refuses with `last_pane` when it's the only pane of the only tab. |
 | `focus_pane(target)` | Moves keyboard focus inside the same tab. Use sparingly — yanking focus out from under the user is disruptive. |
 | `new_tab(…)` | Opens a brand-new tab with a fresh pane and switches focus to it. Same `claude` auto-upgrade as `spawn_pane`. |
+| `set_pane_identity(target, name?, role?)` | Rename or (re)assign the stable `name` / `role` of an existing pane. Three-state fields: omit a key to keep, `null` to clear, a string to set. Use this to recover when a session was launched without the intended layout (e.g. secretary pane booted without `id = "secretary"` so peers can't address it by name). Rejects all-digit names (would collide with numeric ids) and same-tab name collisions. Also exposed as `ccmux rename [--id \| --name \| --focused] [--to-name \| --clear-name] [--to-role \| --clear-role]`. |
 
 > The same `claude` auto-upgrade also applies to panes declared in a layout TOML (`ccmux --layout <name>`): a bare `command = "claude"` in the toml is rewritten to the peer-enabled launch line when the pane starts, so layouts join the ccmux-peers network without each entry having to repeat `--dangerously-load-development-channels server:ccmux-peers`.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5533,6 +5533,38 @@ mod tests {
     }
 
     #[test]
+    fn handle_set_pane_identity_removes_all_stale_name_entries() {
+        // Defense-in-depth: even though normal flow keeps at most one
+        // pane_names entry per pane, planting two manually must not
+        // leave the stale one behind after a rename or clear. The
+        // filter loop walks every key that maps to this pane; this
+        // regression guard pins that behavior.
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_id = app.ws().focused_pane_id;
+        app.ws_mut().pane_names.insert("one".into(), pane_id);
+        app.ws_mut().pane_names.insert("two".into(), pane_id);
+
+        // Rename to a fresh name — both stale entries must vanish.
+        let info = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, Some(Some("fresh".into())), None)
+            .expect("rename succeeds");
+        assert_eq!(info.name.as_deref(), Some("fresh"));
+        assert!(!app.ws().pane_names.contains_key("one"));
+        assert!(!app.ws().pane_names.contains_key("two"));
+        assert_eq!(app.ws().pane_names.get("fresh").copied(), Some(pane_id));
+
+        // Plant two again and clear — both must be removed.
+        app.ws_mut().pane_names.insert("alt".into(), pane_id);
+        let info = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, Some(None), None)
+            .expect("clear succeeds");
+        assert!(info.name.is_none());
+        assert!(!app.ws().pane_names.contains_key("fresh"));
+        assert!(!app.ws().pane_names.contains_key("alt"));
+        app.shutdown();
+    }
+
+    #[test]
     fn handle_set_pane_identity_rejects_unknown_pane() {
         let mut app = App::new(40, 80).expect("App::new");
         let err = app

--- a/src/app.rs
+++ b/src/app.rs
@@ -93,6 +93,17 @@ pub enum AppCommand {
         body: String,
         reply: oneshot::Sender<std::result::Result<(), ipc::CodedError>>,
     },
+    /// Rename or clear the `name` / `role` of an existing pane. See
+    /// [`ipc::Request::SetPaneIdentity`] for the three-state semantics
+    /// of each field. Success returns the pane's updated [`PaneInfo`]
+    /// so callers can confirm the new identity without a separate
+    /// `List` round-trip.
+    SetPaneIdentity {
+        target: PaneRef,
+        name: Option<Option<String>>,
+        role: Option<Option<String>>,
+        reply: oneshot::Sender<std::result::Result<PaneInfo, ipc::CodedError>>,
+    },
 }
 
 /// Resolve a [`PaneRef`] to a concrete pane id.
@@ -3039,6 +3050,15 @@ impl App {
                 let result = self.handle_peer_send(from_pane, &target, body);
                 let _ = reply.send(result);
             }
+            AppCommand::SetPaneIdentity {
+                target,
+                name,
+                role,
+                reply,
+            } => {
+                let result = self.handle_set_pane_identity(&target, name, role);
+                let _ = reply.send(result);
+            }
         }
     }
 
@@ -3125,6 +3145,131 @@ impl App {
             ts_ms: ipc::events::now_ms(),
         });
         Ok(())
+    }
+
+    /// Apply a name / role change to an existing pane. See
+    /// [`ipc::Request::SetPaneIdentity`] for the three-state semantics.
+    /// Both updates are validated up-front so a bad name never leaves
+    /// the role half-applied.
+    fn handle_set_pane_identity(
+        &mut self,
+        target: &PaneRef,
+        name: Option<Option<String>>,
+        role: Option<Option<String>>,
+    ) -> std::result::Result<PaneInfo, ipc::CodedError> {
+        let (ws_idx, pane_id) = self.resolve_pane_across_workspaces(target).ok_or_else(|| {
+            ipc::CodedError::new(
+                ipc::err_code::PANE_NOT_FOUND,
+                format!("pane not found: {target:?}"),
+            )
+        })?;
+
+        // Validate the requested name *before* mutating anything so an
+        // in_use / invalid result leaves both name and role untouched.
+        // Keep the "current name" lookup so idempotent re-sets are a
+        // no-op instead of a collision with the caller themselves.
+        if let Some(Some(new_name)) = &name {
+            {
+                let trimmed = new_name.trim();
+                if trimmed.is_empty() {
+                    return Err(ipc::CodedError::new(
+                        ipc::err_code::NAME_INVALID,
+                        "name must not be empty — pass null to clear",
+                    ));
+                }
+                if trimmed.chars().all(|c| c.is_ascii_digit()) {
+                    return Err(ipc::CodedError::new(
+                        ipc::err_code::NAME_INVALID,
+                        format!(
+                            "name {trimmed:?} is all-digits; would collide with numeric pane ids"
+                        ),
+                    ));
+                }
+                // Name characters match the layout TOML rule so all
+                // addressing surfaces agree on the character set.
+                if !trimmed
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                {
+                    return Err(ipc::CodedError::new(
+                        ipc::err_code::NAME_INVALID,
+                        format!("name {trimmed:?} has invalid characters; allowed: [A-Za-z0-9_-]"),
+                    ));
+                }
+                // Collision check, scoped to this pane's workspace so
+                // the same name may exist in other tabs (mirrors the
+                // layout rule). Self-collision is fine — it's how
+                // idempotent re-sets stay no-ops.
+                let ws = &self.workspaces[ws_idx];
+                if let Some(&holder) = ws.pane_names.get(trimmed) {
+                    if holder != pane_id {
+                        return Err(ipc::CodedError::new(
+                            ipc::err_code::NAME_IN_USE,
+                            format!(
+                                "name {trimmed:?} is already held by pane {holder} in this tab"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Validation passed — apply updates.
+        let ws = &mut self.workspaces[ws_idx];
+        if let Some(name_change) = name {
+            // Drop any existing entry keyed to this pane first so the
+            // pre/post maps never transiently both contain it. Matters
+            // when the pane's existing name equals the new one with
+            // different casing, or when clearing.
+            let keys_to_remove: Vec<String> = ws
+                .pane_names
+                .iter()
+                .filter_map(|(k, &v)| (v == pane_id).then_some(k.clone()))
+                .collect();
+            for k in keys_to_remove {
+                ws.pane_names.remove(&k);
+            }
+            if let Some(new_name) = name_change {
+                ws.pane_names.insert(new_name.trim().to_string(), pane_id);
+            }
+        }
+        if let Some(role_change) = role {
+            if let Some(pane) = ws.panes.get_mut(&pane_id) {
+                pane.role = role_change
+                    .map(|r| r.trim().to_string())
+                    .filter(|r| !r.is_empty());
+            }
+        }
+        self.dirty = true;
+
+        // Build a PaneInfo reply mirroring the shape produced by
+        // `AppCommand::List` so callers can consume both uniformly.
+        let ws = &self.workspaces[ws_idx];
+        let name_for_pane = ws
+            .pane_names
+            .iter()
+            .find(|(_, &id)| id == pane_id)
+            .map(|(n, _)| n.clone());
+        let pane = ws.panes.get(&pane_id).ok_or_else(|| {
+            ipc::CodedError::new(ipc::err_code::PANE_VANISHED, "pane vanished mid-update")
+        })?;
+        let rect = ws
+            .last_pane_rects
+            .iter()
+            .find(|(id, _)| *id == pane_id)
+            .map(|(_, r)| *r)
+            .unwrap_or_default();
+        Ok(PaneInfo {
+            id: pane_id,
+            name: name_for_pane,
+            role: pane.role.clone(),
+            focused: ws.focused_pane_id == pane_id,
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+            cwd: Some(pane.cwd.to_string_lossy().to_string()),
+        })
     }
 
     fn handle_inspect(
@@ -5255,6 +5400,145 @@ mod tests {
         assert_eq!(name.as_deref(), Some("tab-pane"));
         assert_eq!(role.as_deref(), Some("tab-role"));
 
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_sets_name_and_role() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_id = app.ws().focused_pane_id;
+
+        let info = app
+            .handle_set_pane_identity(
+                &ipc::PaneRef::Focused,
+                Some(Some("secretary".into())),
+                Some(Some("leader".into())),
+            )
+            .expect("set identity succeeds");
+        assert_eq!(info.id, pane_id);
+        assert_eq!(info.name.as_deref(), Some("secretary"));
+        assert_eq!(info.role.as_deref(), Some("leader"));
+        assert_eq!(app.ws().pane_names.get("secretary").copied(), Some(pane_id));
+        assert_eq!(
+            app.ws()
+                .panes
+                .get(&pane_id)
+                .and_then(|p| p.role.clone())
+                .as_deref(),
+            Some("leader")
+        );
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_null_clears_existing_value() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_id = app.ws().focused_pane_id;
+        app.ws_mut().pane_names.insert("old".into(), pane_id);
+        if let Some(pane) = app.ws_mut().panes.get_mut(&pane_id) {
+            pane.role = Some("old-role".into());
+        }
+
+        let info = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, Some(None), Some(None))
+            .expect("clear succeeds");
+        assert!(info.name.is_none());
+        assert!(info.role.is_none());
+        assert!(!app.ws().pane_names.contains_key("old"));
+        assert!(app.ws().panes.get(&pane_id).unwrap().role.is_none());
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_keep_leaves_values_untouched() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_id = app.ws().focused_pane_id;
+        app.ws_mut().pane_names.insert("keeper".into(), pane_id);
+        if let Some(pane) = app.ws_mut().panes.get_mut(&pane_id) {
+            pane.role = Some("keeper-role".into());
+        }
+
+        // Both fields None → no-op call errors out? No — the handler
+        // allows it (MCP layer guards against accidental no-op). Here
+        // we exercise "update role only, keep name".
+        let info = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, None, Some(Some("updated".into())))
+            .expect("role-only update");
+        assert_eq!(info.name.as_deref(), Some("keeper"));
+        assert_eq!(info.role.as_deref(), Some("updated"));
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_rejects_name_collision() {
+        // Split so we have two panes, name them distinctly, then try
+        // to rename pane B to pane A's name. Must refuse with
+        // NAME_IN_USE and leave both existing mappings intact.
+        let mut app = App::new(40, 80).expect("App::new");
+        let a_id = app.ws().focused_pane_id;
+        app.ws_mut().pane_names.insert("alpha".into(), a_id);
+        let b_id = app
+            .handle_split(
+                &ipc::PaneRef::Focused,
+                ipc::Direction::Vertical,
+                None,
+                Some("beta".into()),
+                None,
+                None,
+            )
+            .expect("split");
+
+        let err = app
+            .handle_set_pane_identity(&ipc::PaneRef::Id(b_id), Some(Some("alpha".into())), None)
+            .expect_err("colliding rename must fail");
+        assert_eq!(err.code, Some(ipc::err_code::NAME_IN_USE));
+        // Pre-collision state preserved.
+        assert_eq!(app.ws().pane_names.get("alpha").copied(), Some(a_id));
+        assert_eq!(app.ws().pane_names.get("beta").copied(), Some(b_id));
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_idempotent_on_self_name() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let pane_id = app.ws().focused_pane_id;
+        app.ws_mut().pane_names.insert("keeper".into(), pane_id);
+
+        let info = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, Some(Some("keeper".into())), None)
+            .expect("self-name must not collide");
+        assert_eq!(info.name.as_deref(), Some("keeper"));
+        assert_eq!(app.ws().pane_names.get("keeper").copied(), Some(pane_id));
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_rejects_all_digit_name() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let err = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, Some(Some("123".into())), None)
+            .expect_err("all-digit name must fail");
+        assert_eq!(err.code, Some(ipc::err_code::NAME_INVALID));
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_rejects_invalid_characters() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let err = app
+            .handle_set_pane_identity(&ipc::PaneRef::Focused, Some(Some("has space".into())), None)
+            .expect_err("space in name must fail");
+        assert_eq!(err.code, Some(ipc::err_code::NAME_INVALID));
+        app.shutdown();
+    }
+
+    #[test]
+    fn handle_set_pane_identity_rejects_unknown_pane() {
+        let mut app = App::new(40, 80).expect("App::new");
+        let err = app
+            .handle_set_pane_identity(&ipc::PaneRef::Id(9999), Some(Some("anything".into())), None)
+            .expect_err("unknown pane must fail");
+        assert_eq!(err.code, Some(ipc::err_code::PANE_NOT_FOUND));
         app.shutdown();
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -224,6 +224,37 @@ pub enum IpcCommand {
         #[arg(long)]
         count: Option<usize>,
     },
+    /// Rename or (re)assign the stable `name` / `role` of an existing
+    /// pane. Useful when a session was launched without the intended
+    /// layout, so a pane needs to be adopted into a role-based
+    /// addressing scheme retroactively. Pass `--clear-name` /
+    /// `--clear-role` to remove the current value; `--to-name` /
+    /// `--to-role` to set. Exactly one of target selectors is required.
+    Rename {
+        /// Target pane by stable name.
+        #[arg(long, conflicts_with_all = ["id", "focused"])]
+        name: Option<String>,
+        /// Target pane by numeric id.
+        #[arg(long, conflicts_with_all = ["name", "focused"])]
+        id: Option<usize>,
+        /// Target the focused pane (default if no other selector is
+        /// given).
+        #[arg(long, conflicts_with_all = ["name", "id"])]
+        focused: bool,
+        /// New stable name to assign. Refused with `name_in_use` if
+        /// another pane in the same tab already owns it.
+        #[arg(long, conflicts_with = "clear_name")]
+        to_name: Option<String>,
+        /// Remove the pane's stable name.
+        #[arg(long, conflicts_with = "to_name")]
+        clear_name: bool,
+        /// New role label to assign.
+        #[arg(long, conflicts_with = "clear_role")]
+        to_role: Option<String>,
+        /// Remove the pane's role label.
+        #[arg(long, conflicts_with = "to_role")]
+        clear_role: bool,
+    },
     /// Run as a stdio MCP server for Claude Code (see issue #97). Not
     /// a true IPC subcommand — it doesn't dispatch a request and
     /// expect a reply. `main` intercepts this variant and hands off to
@@ -358,6 +389,36 @@ impl IpcCommand {
                     id: id.clone(),
                     role: role.clone(),
                     cwd: resolve_cli_cwd(cwd.as_deref())?,
+                })
+            }
+            IpcCommand::Rename {
+                name,
+                id,
+                focused,
+                to_name,
+                clear_name,
+                to_role,
+                clear_role,
+            } => {
+                if to_name.is_none() && !clear_name && to_role.is_none() && !clear_role {
+                    anyhow::bail!(
+                        "rename requires at least one of --to-name / --clear-name / --to-role / --clear-role"
+                    );
+                }
+                let name_change: Option<Option<String>> = if *clear_name {
+                    Some(None)
+                } else {
+                    to_name.as_ref().map(|s| Some(s.clone()))
+                };
+                let role_change: Option<Option<String>> = if *clear_role {
+                    Some(None)
+                } else {
+                    to_role.as_ref().map(|s| Some(s.clone()))
+                };
+                Ok(Request::SetPaneIdentity {
+                    target: pick_ref(name, id, *focused)?,
+                    name: name_change,
+                    role: role_change,
                 })
             }
             IpcCommand::Events { .. } => Ok(Request::Subscribe),

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -716,6 +716,24 @@ mod tests {
     }
 
     #[test]
+    fn set_pane_identity_omits_keys_when_keep_keep() {
+        // Regression guard: `skip_serializing_if = "Option::is_none"`
+        // on name / role must keep omit semantics on the wire. If a
+        // future refactor drops the attribute, a server round-tripping
+        // a "leave unchanged" record would silently turn it into
+        // "clear both" — `null` deserializes to Some(None) via the
+        // double_option helper.
+        let r = Request::SetPaneIdentity {
+            target: PaneRef::Focused,
+            name: None,
+            role: None,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(!s.contains("\"name\""), "name key leaked: {s}");
+        assert!(!s.contains("\"role\""), "role key leaked: {s}");
+    }
+
+    #[test]
     fn set_pane_identity_roundtrips() {
         let r = Request::SetPaneIdentity {
             target: PaneRef::Name("worker".into()),

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -169,6 +169,71 @@ pub enum Request {
         target: PaneRef,
         body: String,
     },
+    /// Rename or (re)assign the stable `name` / `role` of an existing
+    /// pane. Both fields use three-state semantics over the wire:
+    ///
+    /// - missing key        → leave the current value unchanged
+    /// - `null`             → clear the current value
+    /// - `"some-string"`    → set to the provided value
+    ///
+    /// Serde handles this via [`double_option`] on the two fields.
+    ///
+    /// Validation (server-side):
+    /// - a non-empty `name` must not collide with another pane in the
+    ///   same tab (`name_in_use`).
+    /// - a non-empty `name` must not be all-digits, since the pane
+    ///   addressing rule interprets digit strings as numeric ids
+    ///   (`name_invalid`).
+    /// - setting `name` to the target's current name or `role` to the
+    ///   target's current role is a silent no-op (idempotent).
+    SetPaneIdentity {
+        target: PaneRef,
+        #[serde(
+            default,
+            with = "double_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        name: Option<Option<String>>,
+        #[serde(
+            default,
+            with = "double_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        role: Option<Option<String>>,
+    },
+}
+
+/// Serde helper for the "missing / null / value" three-state pattern
+/// used by [`Request::SetPaneIdentity`]. Missing key deserializes to
+/// `None`, explicit `null` to `Some(None)`, and any value to
+/// `Some(Some(value))`. Requires `#[serde(default)]` on the field so
+/// missing keys resolve to `None` rather than an error.
+pub mod double_option {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S, T>(value: &Option<Option<T>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize,
+    {
+        match value {
+            Some(inner) => inner.serialize(serializer),
+            // `skip_serializing_if = "Option::is_none"` on the field
+            // means we never reach this arm for outer-None; serializing
+            // the outer-None as a bare `null` would be wrong anyway —
+            // a caller round-tripping that record back through the
+            // wire would turn "leave unchanged" into "clear".
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        Ok(Some(Option::<T>::deserialize(deserializer)?))
+    }
 }
 
 /// Identifies a pane in a request. Names are user-friendly and stable
@@ -330,6 +395,15 @@ pub mod err_code {
     /// directory. Emitted by `Split` / `NewTab` before any pane is
     /// created so failed calls never leave a half-mutated layout.
     pub const CWD_INVALID: &str = "cwd_invalid";
+    /// `SetPaneIdentity` was asked to assign a name that another pane
+    /// in the same workspace already holds. The caller should either
+    /// pick a different name or retire the existing holder first.
+    pub const NAME_IN_USE: &str = "name_in_use";
+    /// `SetPaneIdentity` was asked to assign a name that violates
+    /// the naming rules (currently: non-empty and not all-digits,
+    /// since digit strings are interpreted as numeric ids by
+    /// `PaneRef::Name` resolution).
+    pub const NAME_INVALID: &str = "name_invalid";
 }
 
 /// App-side error carrying a free-form message plus an optional
@@ -587,6 +661,68 @@ mod tests {
             } => {}
             other => panic!("expected empty NewTab, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn set_pane_identity_missing_fields_default_to_keep() {
+        // Bare payload with just `target` must deserialize to both
+        // name / role in "keep" state (outer None). Prevents a regression
+        // where `#[serde(default)]` would be dropped from the field and
+        // every call implicitly cleared the values.
+        let raw = r#"{"cmd":"set_pane_identity","target":{"focused":null}}"#;
+        let parsed: Request = serde_json::from_str(raw).unwrap();
+        match parsed {
+            Request::SetPaneIdentity {
+                target,
+                name: None,
+                role: None,
+            } => {
+                assert!(matches!(target, PaneRef::Focused));
+            }
+            other => panic!("expected SetPaneIdentity keep/keep, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_pane_identity_null_means_clear() {
+        let raw =
+            r#"{"cmd":"set_pane_identity","target":{"focused":null},"name":null,"role":null}"#;
+        let parsed: Request = serde_json::from_str(raw).unwrap();
+        match parsed {
+            Request::SetPaneIdentity {
+                name: Some(None),
+                role: Some(None),
+                ..
+            } => {}
+            other => panic!("expected clear/clear, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_pane_identity_string_means_set() {
+        let raw = r#"{"cmd":"set_pane_identity","target":{"focused":null},"name":"secretary","role":"leader"}"#;
+        let parsed: Request = serde_json::from_str(raw).unwrap();
+        match parsed {
+            Request::SetPaneIdentity {
+                name: Some(Some(n)),
+                role: Some(Some(r)),
+                ..
+            } => {
+                assert_eq!(n, "secretary");
+                assert_eq!(r, "leader");
+            }
+            other => panic!("expected set/set, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_pane_identity_roundtrips() {
+        let r = Request::SetPaneIdentity {
+            target: PaneRef::Name("worker".into()),
+            name: Some(Some("renamed".into())),
+            role: Some(None),
+        };
+        assert_eq!(roundtrip(&r), r);
     }
 
     #[test]

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -548,6 +548,32 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
             body,
             reply,
         }),
+        Request::SetPaneIdentity { target, name, role } => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if command_tx
+                .send(AppCommand::SetPaneIdentity {
+                    target,
+                    name,
+                    role,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
+            }
+            match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+                Ok(Ok(pane)) => match serde_json::to_value(&pane) {
+                    Ok(v) => Response::ok_value(serde_json::json!({ "pane": v })),
+                    Err(e) => {
+                        Response::err_coded(err_code::INTERNAL, format!("serialize pane: {e}"))
+                    }
+                },
+                Ok(Err(err)) => err.into_response(),
+                Err(e) => {
+                    Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
+                }
+            }
+        }
     }
 }
 

--- a/src/mcp_peer/mod.rs
+++ b/src/mcp_peer/mod.rs
@@ -501,6 +501,27 @@ fn tools_spec() -> Value {
             }
         },
         {
+            "name": "set_pane_identity",
+            "description": "Rename or (re)assign the stable `name` and/or `role` of an existing pane in the current tab. Use this to recover from sessions launched without the intended layout (e.g. when the secretary pane was spawned without an `id`, so peers can't address it as `to_id=\"secretary\"`). Both fields use three-state semantics: omit the key to keep the current value, pass `null` to clear it, or pass a string to set it. Validation: name cannot be empty, all-digits, or collide with another pane in this tab; allowed characters are [A-Za-z0-9_-]. Role has no uniqueness constraint. Returns the updated pane record so callers can confirm without a separate list round-trip.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Pane to update. Numeric id (from list_panes), stable name, or the literal 'focused' (default). All-digit strings are always ids."
+                    },
+                    "name": {
+                        "type": ["string", "null"],
+                        "description": "New name, or null to clear. Omit to leave unchanged."
+                    },
+                    "role": {
+                        "type": ["string", "null"],
+                        "description": "New role label, or null to clear. Omit to leave unchanged."
+                    }
+                }
+            }
+        },
+        {
             "name": "poll_events",
             "description": "Long-poll for pane lifecycle events (pane_started, pane_exited, events_dropped, and any forward-compatible variants). Returns events accumulated since the given cursor; if none are buffered, blocks up to `timeout_ms` for the next one. The first call (omit `since`) starts at \"right now\" — no historical replay, matching `ccmux events --timeout` semantics. Each response body is a JSON object with `next_since` (an opaque cursor string to pass back) and `events` (an array of event objects in ccmux's wire format).",
             "inputSchema": {
@@ -673,6 +694,7 @@ fn handle_tools_call(id: &Value, params: &Value, ctx: &PeerCtx) -> Result<Value>
         "inspect_pane" => handle_inspect_pane(id, &args, ctx),
         "send_keys" => handle_send_keys(id, &args, ctx),
         "poll_events" => handle_poll_events(id, &args, ctx),
+        "set_pane_identity" => handle_set_pane_identity(id, &args, ctx),
         other => err_response(id, -32601, &format!("unknown tool: {other}")),
     })
 }
@@ -1054,6 +1076,92 @@ fn handle_new_tab(id: &Value, args: &Value, ctx: &PeerCtx) -> Value {
             id,
             -32603,
             &format!("ccmux refused new_tab: {}", fmt_code(&message, &code)),
+        ),
+        Ok(other) => err_response(id, -32603, &format!("unexpected ccmux response: {other:?}")),
+        Err(e) => err_response(id, -32603, &format!("ccmux call failed: {e}")),
+    }
+}
+
+// ── set_pane_identity (rename / re-assign role) ──────────────
+
+/// Three-state arg extractor for `set_pane_identity`. Maps:
+///
+/// - key absent → `None`                       (leave unchanged)
+/// - key present & JSON null → `Some(None)`    (clear)
+/// - key present & JSON string → `Some(Some))` (set)
+///
+/// Any other JSON type (number, bool, object, array) is rejected —
+/// the schema forbids it but Claude might still try, and silently
+/// accepting a coerced value would confuse the three-state contract.
+fn parse_identity_field(
+    args: &Value,
+    key: &str,
+) -> std::result::Result<Option<Option<String>>, String> {
+    match args.get(key) {
+        None => Ok(None),
+        Some(v) if v.is_null() => Ok(Some(None)),
+        Some(Value::String(s)) => Ok(Some(Some(s.clone()))),
+        Some(other) => Err(format!("`{key}` must be a string or null; got {}", other)),
+    }
+}
+
+fn handle_set_pane_identity(id: &Value, args: &Value, ctx: &PeerCtx) -> Value {
+    let target = parse_target(args.get("target").and_then(|v| v.as_str()));
+    let name = match parse_identity_field(args, "name") {
+        Ok(v) => v,
+        Err(msg) => return err_response(id, -32602, &msg),
+    };
+    let role = match parse_identity_field(args, "role") {
+        Ok(v) => v,
+        Err(msg) => return err_response(id, -32602, &msg),
+    };
+    if name.is_none() && role.is_none() {
+        // Nothing to do — return an explicit error so Claude doesn't
+        // silently succeed on a typo'd payload (`nmae` instead of
+        // `name`, etc.). The server would otherwise treat it as a
+        // valid "no-op" call.
+        return err_response(
+            id,
+            -32602,
+            "set_pane_identity requires at least one of `name` / `role`",
+        );
+    }
+
+    let (_caller_pane, endpoint) = match require_connected(ctx, id, "set pane identity") {
+        Ok(t) => t,
+        Err(resp) => return resp,
+    };
+    match client::send_request(endpoint, &Request::SetPaneIdentity { target, name, role }) {
+        Ok(Response::Ok { data }) => {
+            // Surface the updated pane record as a human-readable
+            // line so Claude can confirm the new identity without
+            // parsing structuredContent.
+            let pane = data.get("pane").cloned().unwrap_or(Value::Null);
+            let pane_id = pane.get("id").and_then(|v| v.as_u64());
+            let pane_name = pane
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let pane_role = pane
+                .get("role")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let mut parts = Vec::new();
+            if let Some(n) = pane_id {
+                parts.push(format!("id={n}"));
+            }
+            parts.push(format!("name={}", pane_name.as_deref().unwrap_or("(none)")));
+            parts.push(format!("role={}", pane_role.as_deref().unwrap_or("(none)")));
+            let msg = format!("Updated pane: {}.", parts.join(" "));
+            ok_response(id, tool_text_result(&msg))
+        }
+        Ok(Response::Err { message, code }) => err_response(
+            id,
+            -32603,
+            &format!(
+                "ccmux refused set_pane_identity: {}",
+                fmt_code(&message, &code)
+            ),
         ),
         Ok(other) => err_response(id, -32603, &format!("unexpected ccmux response: {other:?}")),
         Err(e) => err_response(id, -32603, &format!("ccmux call failed: {e}")),
@@ -1859,6 +1967,41 @@ mod tests {
             .expect("required array");
         let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
         assert!(required_names.contains(&"direction"), "{required_names:?}");
+    }
+
+    #[test]
+    fn tools_spec_advertises_set_pane_identity() {
+        // Guard for issue #136: the rename API must appear in the MCP
+        // tool list so Claude knows it exists without reading docs.
+        let spec = tools_spec();
+        let names: Vec<&str> = spec
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|v| v.as_str()))
+            .collect();
+        assert!(
+            names.contains(&"set_pane_identity"),
+            "set_pane_identity missing from tools list: {names:?}"
+        );
+    }
+
+    #[test]
+    fn set_pane_identity_rejects_empty_payload() {
+        // MCP-side guard: calling set_pane_identity with neither
+        // `name` nor `role` must return an invalid-params error so
+        // typo'd payloads (`nmae`) don't silently succeed.
+        let ctx = connected_ctx_with(Arc::new((
+            Mutex::new(EventBuffer::default()),
+            Condvar::new(),
+        )));
+        let id = json!(1);
+        let resp = handle_set_pane_identity(&id, &json!({ "target": "focused" }), &ctx);
+        let error_code = resp
+            .get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64());
+        assert_eq!(error_code, Some(-32602), "resp={resp}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #136. Adds a way to rename or (re)assign the stable `name` / `role` of an **existing** pane — until now these fields could only be set at creation time (spawn_pane / new_tab / layout toml `[root] id = \"...\"`).

Recovery path for the concrete aainc-ops scenario: when an ops session is launched without \`--layout ops\`, the secretary pane boots with no \`name\` / \`role\` and workers can't address it as \`to_id=\"secretary\"\`. Today the only fix is to tear down and relaunch; after this, a single \`set_pane_identity\` call from the orchestrator re-establishes the stable name.

## New surfaces

- IPC: \`Request::SetPaneIdentity { target, name, role }\` with **three-state** field semantics:
  - key omitted → leave unchanged
  - \`null\` → clear
  - \`\"string\"\` → set
  (Serde plumbing via a new \`double_option\` helper module.)
- MCP: \`set_pane_identity\` tool exposing the same contract.
- CLI: \`ccmux rename [--id | --name | --focused] [--to-name | --clear-name] [--to-role | --clear-role]\`.
- New error codes: \`name_in_use\`, \`name_invalid\`.

## Validation

- Non-empty name required (pass \`null\` to clear).
- All-digit names rejected (would collide with numeric pane-id addressing).
- Character set matches the layout TOML rule: \`[A-Za-z0-9_-]\`.
- Name collisions within the same workspace rejected before mutation.
- Self-collisions (setting the current name to the same value) are idempotent no-ops.
- Role has no uniqueness constraint.
- Cross-field atomicity: validation runs up-front so a bad name never leaves the role half-applied.

On success the server returns the updated \`PaneInfo\` so callers can confirm without a separate \`list\` round-trip.

## Test plan

- [x] \`cargo test\` (425 tests pass, +16 new)
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] Codex static review — conditional LGTM, both required follow-up tests added (serde omit guard, multi-entry pane_names cleanup)
- [ ] Manual smoke test of \`ccmux rename\` / MCP tool once merged

## Downstream impact

For aainc-ops (and any other harness using \`to_id=\"<name>\"\` peer addressing), this unblocks the \"attach to a session that was launched without the intended layout\" recovery flow without touching long-lived panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)