### PR TITLE
docs: document pane cwd option (follow-up to #140)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -242,12 +242,14 @@ _ペイン操作 (`new_tab` を除き同一タブ内):_
 | ツール | 役割 |
 |---|---|
 | `list_panes` | 同じタブの全ペインを id / 名前 / role / フォーカス状態 / レイアウト位置込みで一覧する。 |
-| `spawn_pane(direction, …)` | 指定ペインを分割して新ペインを生やす。`command`・`name`・`role` はどれもオプション。`command="claude"` (または `claude <args>`) を渡したときは `Alt+P` と同じ peer 対応コマンドに自動書き換えするので、毎回 `--dangerously-load-development-channels` を覚えていなくてもメッセージング付きの Claude が立ち上がる。 |
+| `spawn_pane(direction, …)` | 指定ペインを分割して新ペインを生やす。`command`・`name`・`role`・`cwd` はどれもオプション。`command="claude"` (または `claude <args>`) を渡したときは `Alt+P` と同じ peer 対応コマンドに自動書き換えするので、毎回 `--dangerously-load-development-channels` を覚えていなくてもメッセージング付きの Claude が立ち上がる。 |
 | `close_pane(target)` | ペインを閉じる。最後のタブの最後のペインを閉じようとしたときは `last_pane` で拒否。 |
 | `focus_pane(target)` | 同じタブ内でフォーカス移動。ユーザーの手元からフォーカスを奪うことになるので使いどころに注意。 |
-| `new_tab(…)` | 新しいタブを 1 枚開いてそこへフォーカスを移す。`spawn_pane` と同じ `claude` 自動アップグレードが効く。 |
+| `new_tab(…)` | 新しいタブを 1 枚開いてそこへフォーカスを移す。`spawn_pane` と同じ `cwd` オプションと `claude` 自動アップグレードが効く。 |
 
 > この `claude` 自動アップグレードは layout TOML (`ccmux --layout <name>`) 経由で起動するペインにも適用される。layout toml に `command = "claude"` と書けばペイン起動時に peer 対応コマンドへ書き換えられるので、各エントリで毎回 `--dangerously-load-development-channels server:ccmux-peers` を書く必要はない。
+
+> **ペインの `cwd`** — `spawn_pane` / `new_tab` / `ccmux split --cwd` / `ccmux new-tab --cwd` / layout TOML `cwd = "..."` で新ペインの作業ディレクトリを指定できる。絶対パスはそのまま、相対パスは呼び出し元ペインの cwd（MCP）・シェルの cwd（CLI）・ccmux プロセスの cwd（layout TOML）を基準に解決される。存在しないパスはレイアウトを変更する前に `cwd_invalid` で失敗するので half-mutated なレイアウトにならない。`command` に `cd <dir> && ...` を書くと `claude` 自動アップグレードが効かなくなるので、`cwd` フィールド側で指定するのが推奨。
 
 ### うまく動かないとき
 

--- a/README.md
+++ b/README.md
@@ -237,12 +237,14 @@ _Pane control (same tab, except `new_tab`):_
 | Tool | Effect |
 |---|---|
 | `list_panes` | Lists every pane in the caller's tab with id, optional name/role, focus flag, and terminal geometry. |
-| `spawn_pane(direction, …)` | Splits a target pane. Optional `command`, `name`, `role`. A bare `command="claude"` (or `claude <args>`) is auto-upgraded to the `Alt+P` peer-enabled launch line so the new pane joins the ccmux-peers network without the caller having to remember `--dangerously-load-development-channels`. |
+| `spawn_pane(direction, …)` | Splits a target pane. Optional `command`, `name`, `role`, `cwd`. A bare `command="claude"` (or `claude <args>`) is auto-upgraded to the `Alt+P` peer-enabled launch line so the new pane joins the ccmux-peers network without the caller having to remember `--dangerously-load-development-channels`. |
 | `close_pane(target)` | Closes a pane. Refuses with `last_pane` when it's the only pane of the only tab. |
 | `focus_pane(target)` | Moves keyboard focus inside the same tab. Use sparingly — yanking focus out from under the user is disruptive. |
-| `new_tab(…)` | Opens a brand-new tab with a fresh pane and switches focus to it. Same `claude` auto-upgrade as `spawn_pane`. |
+| `new_tab(…)` | Opens a brand-new tab with a fresh pane and switches focus to it. Accepts the same `cwd` option as `spawn_pane`. Same `claude` auto-upgrade. |
 
 > The same `claude` auto-upgrade also applies to panes declared in a layout TOML (`ccmux --layout <name>`): a bare `command = "claude"` in the toml is rewritten to the peer-enabled launch line when the pane starts, so layouts join the ccmux-peers network without each entry having to repeat `--dangerously-load-development-channels server:ccmux-peers`.
+
+> **Pane `cwd`** — `spawn_pane` / `new_tab` / `ccmux split --cwd` / `ccmux new-tab --cwd` / layout TOML `cwd = "..."` all accept a working directory for the new pane. Absolute paths are used as-is; relative paths resolve against the caller pane's cwd (MCP), the shell cwd (CLI), or the ccmux process cwd (layout TOML). Invalid paths fail with error code `cwd_invalid` **before** any layout mutation. Prefer this over embedding `cd <dir> && ...` inside `command` — the `claude` auto-upgrade only fires when `command` starts with `claude`.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Follow-up to #140. The structured cwd support landed but the README's MCP tool table and layout TOML note didn't surface it, so callers still see only the `command` / `name` / `role` surface.

This PR:

- Adds `cwd` to the `spawn_pane` row and the `new_tab` note in both README.md and README.ja.md.
- Adds a callout listing all four cwd-accepting surfaces (MCP `spawn_pane` / `new_tab`, CLI `ccmux split --cwd` / `ccmux new-tab --cwd`, layout TOML `cwd = "..."`), their resolution bases (caller pane / shell / process cwd), and the `cwd_invalid` pre-mutation contract.

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)