### PR TITLE
chore(release): bump version to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,15 @@ name = "ccmux"
 # shell prompt. Sticky-caret path now engages only while the PTY
 # cursor is actually hidden; new regression test covers the gating
 # helper. Patch bump — pure bug fix on top of 0.15.1.
-version = "0.16.0"
+# 0.16.0 adds structured cwd support to pane creation APIs (#135 / #140):
+# spawn_pane / new_tab / ccmux split / ccmux new-tab / layout TOML all accept
+# an optional `cwd` field, PaneInfo.cwd is surfaced by list_panes, and invalid
+# cwd fails with err_code::CWD_INVALID before any layout mutation. Minor bump
+# because it's a new API surface, not a bug fix.
+# 0.17.0 adds set_pane_identity MCP tool and ccmux rename CLI (#136 / #142)
+# for renaming / (re)assigning name / role on existing panes. Minor bump
+# because it's a new API surface, not a bug fix.
+version = "0.17.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
Release bump for #142 (set_pane_identity MCP tool + ccmux rename CLI, closes #136). Minor bump — additive surface, no backwards-incompatible changes.

After merge, tag v0.17.0 to kick off the release workflow.