### PR TITLE
chore(release): bump version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,11 @@ name = "ccmux"
 # 0.17.0 adds set_pane_identity MCP tool and ccmux rename CLI (#136 / #142)
 # for renaming / (re)assigning name / role on existing panes. Minor bump
 # because it's a new API surface, not a bug fix.
-version = "0.17.0"
+# 0.18.0 adds spawn_claude_pane MCP tool (#137 / #144) for structured
+# Claude launches: structured permission_mode / model / args[] fields
+# replace free-form command string synthesis, with the peer channel
+# enabled by construction. Minor bump because it's a new MCP tool.
+version = "0.18.0"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
Release bump for #144 (spawn_claude_pane MCP tool, closes #137). Minor bump — additive surface, no backwards-incompatible changes.

After merge, tag v0.18.0 to kick off the release workflow.