### PR TITLE
chore(release): bump version to 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "ccmux"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ name = "ccmux"
 # Claude launches: structured permission_mode / model / args[] fields
 # replace free-form command string synthesis, with the peer channel
 # enabled by construction. Minor bump because it's a new MCP tool.
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux-fork",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Claude Code Multiplexer (fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "ccmux": "bin/cli.js"


### PR DESCRIPTION
## Summary
- Patch release containing #148 (caret wrap + ← back-to-prompt-row regression fix).

## Test plan
- [x] cargo test (458 passed)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo fmt --all --check (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)