### PR TITLE
chore(release): bump version to 0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,10 @@ name = "renga"
 # Claude launches: structured permission_mode / model / args[] fields
 # replace free-form command string synthesis, with the peer channel
 # enabled by construction. Minor bump because it's a new MCP tool.
-version = "0.18.1"
+# 0.18.2 republishes the 0.18.1 artifacts with corrected package metadata
+# (repository/homepage URLs from the renga rename + URL sweep — #136 / #154
+# follow-up). No code changes.
+version = "0.18.2"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Claude Code Multiplexer (fork, formerly ccmux-fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary
- Republish 0.18.1 with corrected npm package metadata (renga rename URL sweep, #154)
- 0.18.1 was published before #154 landed, so its `repository`/`homepage` fields on npm still pointed at the old `happy-ryo/ccmux` URLs. 0.18.2 carries the corrected URLs.
- **No code changes** vs 0.18.1. Cargo.toml bump is for workspace consistency / release-tag workflow only (this repo does not publish to crates.io).

## Test plan
- [x] cargo build --release
- [x] cargo fmt --all --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (458 passed)

## Publish path (manual for now)
Trusted Publisher is **not yet bound** (claude-org#136 step 5 pending). After merge:
```bash
cd /local/renga
git pull --ff-only
cd npm
npm publish --access public  # NPM_TOKEN already in ~/.npmrc
```
After this republish + Trusted Publisher binding, future releases (`v0.18.3+`) can use the automated `release.yml` (tag push → 4-platform build + GitHub Release + OIDC publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
