### PR TITLE
docs(branching): align upstream-sync skill and CLAUDE.md with divergence policy

### DIFF
--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -1,29 +1,37 @@
 ---
 name: upstream-sync
-description: Use ONLY when the user explicitly asks to cherry-pick a specific commit from the Shin-sibainu/ccmux upstream, or to send a one-off PR back to upstream. renga is an independent project — there is no scheduled or periodic sync. Triggers on phrases like "上流から cherry-pick", "upstream の <commit> を取り込む", "上流に PR を返す", "cherry-pick from upstream", "send PR to upstream ccmux". Do NOT trigger on generic "fork sync" / "週次 sync" requests — those are no longer policy.
+description: Use when the user explicitly asks to cherry-pick a specific commit from the Shin-sibainu/ccmux upstream into renga's main, or to send a one-off PR from renga back to that upstream. This is an ad-hoc, per-commit workflow — renga is an independent project and does not do periodic upstream merges. Triggers on phrases like "cherry-pick from upstream", "上流から cherry-pick", "send PR to upstream ccmux", "上流に PR を返す", "pull commit X from Shin-sibainu/ccmux", "upstream の <commit> を取り込む".
 ---
 
 # Upstream Cherry-pick Skill
 
-renga (`suisya-systems/renga`) は [`Shin-sibainu/ccmux`](https://github.com/Shin-sibainu/ccmux) から派生したが、**現在は独立した本流として開発している**。
-定期的な上流 sync / 週次マージは行わない。`BRANCHING.md` の divergence policy が正本で、この Skill はその ad-hoc な cherry-pick と逆 PR 手順だけを補助する。
+renga (`suisya-systems/renga`) was forked from [`Shin-sibainu/ccmux`](https://github.com/Shin-sibainu/ccmux), but is now developed as an independent main line. `BRANCHING.md` is the source of truth for branch policy; this skill only assists with the two ad-hoc workflows that need an actual procedure: pulling a single upstream commit into `main`, and sending a one-off reverse PR back to upstream.
 
-## いつ使うか / 使わないか
+## When this skill should fire — and when it should NOT
 
-- ✅ 使う: ユーザーから「upstream のこの commit を取り込んで」「この修正を上流に PR して返して」といった**具体的な単発指示**を受けたとき
-- ❌ 使わない: 「上流と同期して」「最近の upstream を取り込んで」といった包括的な依頼 — まずユーザーに「renga は独立 main で運用しており包括 sync はしない」旨を伝え、本当に欲しい個別 commit を確認する
-- ❌ 使わない: ユーザーから明示の指示がないのに「上流に還元しよう」と提案する (root `CLAUDE.md` のポリシーに反する)
+✅ Fire when the user names a concrete operation:
+- "Cherry-pick upstream commit `<sha>` into main."
+- "Send this fix back to upstream as a PR."
+- "Update `master` to `upstream/master` so I can cherry-pick from it."
 
-## ブランチ役割 (要点)
+❌ Do NOT fire — and instead push back to the user — when the request is generic or periodic:
+- "Sync the fork with upstream", "merge in the latest upstream", "do the weekly upstream sync", anything implying a blanket merge.
+  - renga has no scheduled or periodic sync. Tell the user that, and ask which specific upstream commit(s) they actually want.
+- "Open a PR to upstream for our recent improvements" without an explicit go-ahead.
+  - Per root `CLAUDE.md`, do not propose or open reverse PRs unless the user explicitly asks for one.
 
-- `main` = renga の本流 (default / リリース対象)。上流とは独立に進化
-- `master` = `upstream/master` を必要なときだけ FF 追従するスナップショット (記録 / cherry-pick ベース用)。独自 commit は乗せない
-- 通常の機能ブランチは `main` から切って `main` に PR
-- 上流還元用ブランチ (`upstream-pr/*`) は `master` から切る
+## Branch roles (summary)
 
-詳細は `BRANCHING.md` を参照。
+- `main` — renga's mainline (default branch, release target). Evolves independently of upstream.
+- `master` — snapshot mirror of `upstream/master`, kept around as a base for cherry-picks and as a record. Carries no renga-specific commits.
+- Feature branches — branched from `main`, PR'd into `main`.
+- `upstream-pr/*` — branched from `master` for reverse PRs only.
 
-## 前提: upstream remote の追加 (任意・未追加なら一度だけ)
+See `BRANCHING.md` for the full policy.
+
+## Prerequisite: add the upstream remote (one-time, optional)
+
+renga's normal development does not need the upstream remote. Add it only when this skill is invoked:
 
 ```bash
 git remote -v | grep upstream || \
@@ -31,57 +39,67 @@ git remote -v | grep upstream || \
 git fetch upstream
 ```
 
-renga の通常開発に upstream remote は不要。cherry-pick / 逆 PR をするときに初めて追加する。
+## A. Cherry-pick a specific upstream commit into `main`
 
-## A. 上流の特定 commit を main に cherry-pick する
-
-包括 sync ではなく、**ユーザーが指定した個別 commit (またはごく少数)** を取り込む手順。
+Used when the user has named one (or a small number of) upstream commits to bring into renga.
 
 ```bash
 git fetch upstream
 
-# 1. master を upstream/master に FF 追従 (スナップショット更新、任意)
+# 1. Update the master snapshot to upstream/master (recommended but optional).
 git checkout master
 git merge --ff-only upstream/master
 git push origin master
+```
 
-# 2. main から作業ブランチを切って cherry-pick
+If the FF merge fails because upstream rebased `master`, this is the one sanctioned case for force-pushing `master` (see `BRANCHING.md` §"ブランチ構成"):
+
+```bash
+git fetch upstream
+git checkout master
+git reset --hard upstream/master
+git push --force-with-lease origin master
+```
+
+`master` is a pure mirror, so a forced reset is safe — never do this on `main`.
+
+```bash
+# 2. Branch off main and cherry-pick the requested commit(s).
 git checkout main
 git pull
 git checkout -b chore/cherry-pick-<topic>
 git cherry-pick <upstream-sha> [<upstream-sha> ...]
-# コンフリクトが大きい場合は cherry-pick を中断し、renga 流で書き直すことを検討
+# If conflicts are large, abort and reimplement in renga's own style instead.
 cargo build --release && cargo test
 git push -u origin HEAD
 gh pr create --base main --title "chore: cherry-pick <topic> from upstream ccmux"
 ```
 
-注意点:
-- **rebase ではなく cherry-pick**。`main` は公開タグ済みで履歴改変禁止
-- renga 側との実装乖離が大きいので、コンフリクトが激しい場合は cherry-pick を諦めて renga 流で再実装する方が早いことが多い
-- 取り込んだ upstream commit の SHA を PR description に書く (後追いトレース用)
+Notes:
+- Use `cherry-pick`, never `rebase` or a blanket merge of `master` into `main`. `main` carries published tags and must not have its history rewritten.
+- Record the source upstream SHA(s) in the PR description so the provenance is traceable later.
+- renga's implementation has diverged enough that conflicts often dominate the cherry-pick. When that happens, abandon the cherry-pick and reimplement the change the renga way — that is normally faster and cleaner.
 
-## B. 上流に PR を返す (ユーザー明示指示時のみ)
+## B. Send a reverse PR to upstream (only on explicit user request)
 
-`main` から直接 upstream に PR を出さない — renga 独自の commit が混入する。必ず `master` ベースで新ブランチを切り、必要な commit だけ cherry-pick する。
+Never PR upstream from `main` directly — renga-specific commits would leak in. Always branch from `master` and cherry-pick exactly the commits you want to upstream.
 
 ```bash
 git fetch upstream
 git checkout master
-git merge --ff-only upstream/master
+git merge --ff-only upstream/master    # or the force-with-lease recovery above if upstream rebased
 git checkout -b upstream-pr/<topic>
 git cherry-pick <main-side-sha> [<main-side-sha> ...]
-# renga 固有の依存 / 命名 (renga, @suisya-systems/renga 等) が混入していないか必ず確認
+# Audit the diff for renga-specific identifiers (renga, @suisya-systems/renga, renga-only files, etc.)
+# and remove or rewrite them before pushing.
 git push -u origin HEAD
 gh pr create --repo Shin-sibainu/ccmux --base master
 ```
 
-ユーザーから明示の指示がない限り、上流 PR は提案も実行もしない (root `CLAUDE.md` の Fork & Branching ポリシー)。
+## Forbidden
 
-## 禁止事項
-
-- `main` を force-push しない
-- `main` から upstream へ直接 PR しない
-- `master` に独自 commit を追加しない (常に upstream のミラー)
-- 上流取り込みを rebase で行わない
-- 包括的 / 定期的 sync を勝手に行わない (divergence policy に反する)
+- Force-pushing `main`.
+- Opening PRs against upstream from `main` directly.
+- Adding renga-specific commits to `master` (it must stay a pure mirror of `upstream/master`).
+- Pulling upstream into `main` via `rebase` or via a blanket `git merge upstream/master`.
+- Performing a periodic / blanket "fork sync" without an explicit, per-commit user instruction.

--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -1,73 +1,87 @@
 ---
 name: upstream-sync
-description: Use when syncing this fork with Shin-sibainu/ccmux upstream, merging upstream changes into main, or sending a PR back to upstream. Triggers on phrases like "上流を取り込む", "upstream sync", "フォーク元と同期", "上流に PR", "sync fork".
+description: Use ONLY when the user explicitly asks to cherry-pick a specific commit from the Shin-sibainu/ccmux upstream, or to send a one-off PR back to upstream. renga is an independent project — there is no scheduled or periodic sync. Triggers on phrases like "上流から cherry-pick", "upstream の <commit> を取り込む", "上流に PR を返す", "cherry-pick from upstream", "send PR to upstream ccmux". Do NOT trigger on generic "fork sync" / "週次 sync" requests — those are no longer policy.
 ---
 
-# Upstream Sync Skill
+# Upstream Cherry-pick Skill
 
-このリポジトリは `Shin-sibainu/ccmux` のフォーク (`happy-ryo/ccmux`)。
-上流同期と逆 PR の正しい手順は `BRANCHING.md` が正本。この Skill はその要約。
+renga (`suisya-systems/renga`) は [`Shin-sibainu/ccmux`](https://github.com/Shin-sibainu/ccmux) から派生したが、**現在は独立した本流として開発している**。
+定期的な上流 sync / 週次マージは行わない。`BRANCHING.md` の divergence policy が正本で、この Skill はその ad-hoc な cherry-pick と逆 PR 手順だけを補助する。
+
+## いつ使うか / 使わないか
+
+- ✅ 使う: ユーザーから「upstream のこの commit を取り込んで」「この修正を上流に PR して返して」といった**具体的な単発指示**を受けたとき
+- ❌ 使わない: 「上流と同期して」「最近の upstream を取り込んで」といった包括的な依頼 — まずユーザーに「renga は独立 main で運用しており包括 sync はしない」旨を伝え、本当に欲しい個別 commit を確認する
+- ❌ 使わない: ユーザーから明示の指示がないのに「上流に還元しよう」と提案する (root `CLAUDE.md` のポリシーに反する)
 
 ## ブランチ役割 (要点)
 
-- `main` = 独自開発の本流 (default / リリース対象)
-- `master` = `upstream/master` のミラー専用 (FF のみ)
-- 通常ブランチは `main` から切って `main` に PR
-- 上流への PR は `master` から切って cherry-pick
+- `main` = renga の本流 (default / リリース対象)。上流とは独立に進化
+- `master` = `upstream/master` を必要なときだけ FF 追従するスナップショット (記録 / cherry-pick ベース用)。独自 commit は乗せない
+- 通常の機能ブランチは `main` から切って `main` に PR
+- 上流還元用ブランチ (`upstream-pr/*`) は `master` から切る
 
-## 前提確認
+詳細は `BRANCHING.md` を参照。
 
-最初に以下を確認する:
-
-```bash
-git remote -v | grep upstream
-```
-
-`upstream` remote が無ければ:
+## 前提: upstream remote の追加 (任意・未追加なら一度だけ)
 
 ```bash
-git remote add upstream https://github.com/Shin-sibainu/ccmux.git
+git remote -v | grep upstream || \
+  git remote add upstream https://github.com/Shin-sibainu/ccmux.git
 git fetch upstream
 ```
 
-## A. 上流を main に取り込む
+renga の通常開発に upstream remote は不要。cherry-pick / 逆 PR をするときに初めて追加する。
+
+## A. 上流の特定 commit を main に cherry-pick する
+
+包括 sync ではなく、**ユーザーが指定した個別 commit (またはごく少数)** を取り込む手順。
 
 ```bash
 git fetch upstream
 
-# master を upstream/master に FF 追従
+# 1. master を upstream/master に FF 追従 (スナップショット更新、任意)
 git checkout master
 git merge --ff-only upstream/master
 git push origin master
 
-# main に取り込む sync PR を作成
+# 2. main から作業ブランチを切って cherry-pick
 git checkout main
 git pull
-git checkout -b chore/sync-upstream-$(date +%Y%m%d)
-git merge master     # コンフリクトは解消する
+git checkout -b chore/cherry-pick-<topic>
+git cherry-pick <upstream-sha> [<upstream-sha> ...]
+# コンフリクトが大きい場合は cherry-pick を中断し、renga 流で書き直すことを検討
+cargo build --release && cargo test
 git push -u origin HEAD
-gh pr create --base main --title "chore: sync upstream $(date +%Y-%m-%d)"
+gh pr create --base main --title "chore: cherry-pick <topic> from upstream ccmux"
 ```
 
-**rebase ではなく merge**。`main` は公開タグ済みで履歴改変禁止。
+注意点:
+- **rebase ではなく cherry-pick**。`main` は公開タグ済みで履歴改変禁止
+- renga 側との実装乖離が大きいので、コンフリクトが激しい場合は cherry-pick を諦めて renga 流で再実装する方が早いことが多い
+- 取り込んだ upstream commit の SHA を PR description に書く (後追いトレース用)
 
-## B. 上流に PR を返す
+## B. 上流に PR を返す (ユーザー明示指示時のみ)
 
-`main` から直接 PR しない (独自コミットが混入する)。必ず `master` ベースで新ブランチを切り、必要な commit だけ cherry-pick する。
+`main` から直接 upstream に PR を出さない — renga 独自の commit が混入する。必ず `master` ベースで新ブランチを切り、必要な commit だけ cherry-pick する。
 
 ```bash
 git fetch upstream
 git checkout master
 git merge --ff-only upstream/master
 git checkout -b upstream-pr/<topic>
-git cherry-pick <sha>...          # main の該当コミット
+git cherry-pick <main-side-sha> [<main-side-sha> ...]
+# renga 固有の依存 / 命名 (renga, @suisya-systems/renga 等) が混入していないか必ず確認
 git push -u origin HEAD
 gh pr create --repo Shin-sibainu/ccmux --base master
 ```
 
+ユーザーから明示の指示がない限り、上流 PR は提案も実行もしない (root `CLAUDE.md` の Fork & Branching ポリシー)。
+
 ## 禁止事項
 
 - `main` を force-push しない
-- `main` から上流へ直接 PR しない
-- `master` に独自コミットを追加しない (常に upstream ミラー)
+- `main` から upstream へ直接 PR しない
+- `master` に独自 commit を追加しない (常に upstream のミラー)
 - 上流取り込みを rebase で行わない
+- 包括的 / 定期的 sync を勝手に行わない (divergence policy に反する)

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -98,4 +98,4 @@ GitHub 側で以下を設定:
 ## 関連
 
 - リリース手順の詳細は `CLAUDE.md` の Release Process を参照
-- (内部) `.claude/skills/upstream-sync/` Skill は ccmux 由来の旧 fork-policy 想定で書かれており、本ドキュメントの divergence policy が正本です。Skill 自体はいずれ追随更新する予定です
+- (内部) `.claude/skills/upstream-sync/` Skill は本ドキュメントの divergence policy に追随しており、ad-hoc な cherry-pick / 逆 PR 手順の補助に用途を絞っています。本 BRANCHING.md が常に正本です

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,16 @@ cargo run            # Run the app
 ### やってはいけない
 - **手動で `npm publish` や `gh release create` しないこと** — バージョン衝突の原因になる
 
-## Fork & Branching
-このリポジトリは `Shin-sibainu/ccmux` のフォーク。ブランチ運用 (main = 独自本流 / master = 上流ミラー) と上流同期手順は `BRANCHING.md` を参照。上流取り込みや逆 PR の作業時は `.claude/skills/upstream-sync/` Skill が自動発動する。
+## Fork & Branching (Divergence Policy)
+renga は `Shin-sibainu/ccmux` から派生したが、**現在は独立した本流として開発している**。定期的な上流 sync / 週次マージは行わず、上流に有用な変更があれば必要に応じて単発で cherry-pick する程度。詳細は `BRANCHING.md` (正本) を参照。
 
-**上流への逆 PR はユーザーからの明示的な指示がない限り提案・実行しない。** フォークで実装した機能について「汎用性があるので上流還元候補」といったラベルを umbrella Issue に残すのは OK だが、タスクの次候補として「upstream PR を出す」を勝手に積まない。上流の受け入れタイミングに依存して進捗が止まるのを避けるため、フォーク内の独自開発に集中する方針。
+要点だけ:
+- `main` = renga 本流 (default / リリース対象)。上流とは独立に進化
+- `master` = `upstream/master` を必要なときだけ FF 追従するスナップショット用 (記録 / cherry-pick ベース)。独自 commit は乗せない
+- 上流からの取り込みは「ユーザーが指定した個別 commit を cherry-pick」する ad-hoc 運用のみ。包括的 sync は行わない
+- `.claude/skills/upstream-sync/` Skill は上記 ad-hoc cherry-pick / 逆 PR 手順の補助。包括 sync 系の依頼では発動させない
+
+**上流への逆 PR はユーザーからの明示的な指示がない限り提案・実行しない。** フォークで実装した機能について「汎用性があるので上流還元候補」といったラベルを umbrella Issue に残すのは OK だが、タスクの次候補として「upstream PR を出す」を勝手に積まない。上流の受け入れタイミングに依存して renga の進捗が止まるのを避けるため、独自開発に集中する方針。
 
 ## Intentional `ccmux` References (post-rename)
 Issue #102 renamed the project from `ccmux` to `renga`. The following residual references to `ccmux` are intentional and should NOT be swept:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,15 +52,15 @@ cargo run            # Run the app
 - **手動で `npm publish` や `gh release create` しないこと** — バージョン衝突の原因になる
 
 ## Fork & Branching (Divergence Policy)
-renga は `Shin-sibainu/ccmux` から派生したが、**現在は独立した本流として開発している**。定期的な上流 sync / 週次マージは行わず、上流に有用な変更があれば必要に応じて単発で cherry-pick する程度。詳細は `BRANCHING.md` (正本) を参照。
+renga was forked from `Shin-sibainu/ccmux` but is now developed as an **independent main line**. There is no periodic / weekly upstream sync; useful upstream changes are pulled in only as ad-hoc, per-commit cherry-picks when explicitly requested. `BRANCHING.md` is the source of truth — see it for the full policy.
 
-要点だけ:
-- `main` = renga 本流 (default / リリース対象)。上流とは独立に進化
-- `master` = `upstream/master` を必要なときだけ FF 追従するスナップショット用 (記録 / cherry-pick ベース)。独自 commit は乗せない
-- 上流からの取り込みは「ユーザーが指定した個別 commit を cherry-pick」する ad-hoc 運用のみ。包括的 sync は行わない
-- `.claude/skills/upstream-sync/` Skill は上記 ad-hoc cherry-pick / 逆 PR 手順の補助。包括 sync 系の依頼では発動させない
+Key points:
+- `main` — renga's mainline (default branch, release target). Evolves independently of upstream.
+- `master` — snapshot mirror of `upstream/master`, FF-updated only when needed as a base for cherry-picks. Never carries renga-specific commits.
+- Upstream changes enter renga only via cherry-pick of specific commits the user has named. No blanket sync.
+- `.claude/skills/upstream-sync/` skill assists with those ad-hoc cherry-pick and reverse-PR procedures. It must NOT fire on generic "sync the fork" / "merge in upstream" requests — push back to the user instead.
 
-**上流への逆 PR はユーザーからの明示的な指示がない限り提案・実行しない。** フォークで実装した機能について「汎用性があるので上流還元候補」といったラベルを umbrella Issue に残すのは OK だが、タスクの次候補として「upstream PR を出す」を勝手に積まない。上流の受け入れタイミングに依存して renga の進捗が止まるのを避けるため、独自開発に集中する方針。
+**Do not propose or open reverse PRs against upstream unless the user explicitly asks for one.** It is fine to label individual features as "potentially generalizable upstream" on an umbrella issue, but do not queue "open an upstream PR" as a follow-up task on your own — renga's progress should not be gated on upstream's review cadence.
 
 ## Intentional `ccmux` References (post-rename)
 Issue #102 renamed the project from `ccmux` to `renga`. The following residual references to `ccmux` are intentional and should NOT be swept:


### PR DESCRIPTION
## Summary
PR #161 rewrote `BRANCHING.md` from a fork-policy (weekly upstream sync from `Shin-sibainu/ccmux`) to a divergence policy (renga is now an independent main; upstream changes only enter via ad-hoc, per-commit cherry-picks). Two follow-up surfaces were left out of sync:

- `.claude/skills/upstream-sync/SKILL.md` still described periodic upstream sync as a routine workflow.
- Root `CLAUDE.md`'s `## Fork & Branching` section still framed the repo as a tracked fork rather than an independent line.

This PR brings both into alignment.

## Changes

- **`.claude/skills/upstream-sync/SKILL.md`** — full rewrite (English body, bilingual triggers retained):
  - Narrowed the `description` to positive triggers only (cherry-pick / reverse-PR by explicit per-commit user request). Moved generic "sync the fork" / "週次 sync" cases into the body's "should NOT fire" section so keyword/embedding routing cannot mistake the negation for positive trigger material.
  - Documented the sanctioned `master` recovery path (reset to `upstream/master` and force-with-lease push) for the upstream-rebase case that `BRANCHING.md` explicitly allows.
  - Restructured the body around the two real workflows: A) cherry-pick a specific upstream commit into `main`; B) send a one-off PR back to upstream from a `master`-based branch.

- **`CLAUDE.md` `## Fork & Branching`** — rewrote in English as a brief divergence-policy summary that defers to `BRANCHING.md`. The reverse-PR-only-when-explicitly-requested rule is preserved verbatim.

- **`BRANCHING.md`** — removed the stale "the skill will be updated later" footnote now that the skill matches this policy.

## Test plan
- [x] `git grep -in "fork policy" / "weekly" / "scheduled"` — no remaining stale references in shipped artifacts
- [x] No source code touched; CI build/test unaffected
- [x] Codex self-review (Blocker/Major only); both Major findings (description-keyword leakage and missing force-push recovery) addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
