### PR TITLE
Bump version to 0.18.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,12 @@ name = "renga"
 # 0.18.2 republishes the 0.18.1 artifacts with corrected package metadata
 # (repository/homepage URLs from the renga rename + URL sweep — #136 / #154
 # follow-up). No code changes.
-version = "0.18.2"
+# 0.18.3 follows up the IME overlay bootstrap-on-open work: visible
+# prompt text now transfers into the overlay when Claude's draft is
+# directly readable, while `[Pasted text #…]` placeholders fall back
+# to an empty overlay so collapsed pasted content is never lost. Patch
+# bump because this is a bug fix on top of 0.18.2.
+version = "0.18.3"
 edition = "2021"
 description = "Claude Code Multiplexer — manage multiple Claude Code instances in TUI panes"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Claude Code Multiplexer (fork, formerly ccmux-fork) — manage multiple Claude Code instances in TUI split panes",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary
- bump the crate and npm package versions from 0.18.2 to 0.18.3
- document the IME overlay visible-input bootstrap and pasted-placeholder fallback as a patch-level bug fix

## Testing
- cargo test input::overlay -- --nocapture
