### PR TITLE
docs: sync peer tool surface and npm README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -295,7 +295,15 @@ _ペイン操作 (`new_tab` を除き同一タブ内):_
 | `close_pane(target)` | ペインを閉じる。最後のタブの最後のペインを閉じようとしたときは `last_pane` で拒否。 |
 | `focus_pane(target)` | 同じタブ内でフォーカス移動。ユーザーの手元からフォーカスを奪うことになるので使いどころに注意。 |
 | `new_tab(…)` | 新しいタブを 1 枚開いてそこへフォーカスを移す。`spawn_pane` と同じ `cwd` オプションと `claude` 自動アップグレードが効く。 |
+| `inspect_pane(target, …)` | 別ペインの可視画面をスナップショットして、プロンプト待ち・警告バナー・モード変化などをそのペイン自身に説明させず検出できる。デフォルトはプレーンテキスト、`format="grid"` で行アドレス付き JSON、`lines=N` で末尾 N 行に絞り込み。 |
+| `send_keys(target, …)` | 別ペインの PTY に生のキー入力 (`Enter` / `Esc` / 矢印 / `Ctrl+<letter>` / 任意テキストなど) を送る。`send_message` を解釈できない対話プロンプトや TUI を操作したいとき向け。 |
 | `set_pane_identity(target, name?, role?)` | 既存ペインの安定 `name` / `role` を付け直す・クリアする。3 ステート: キー省略 = 現状維持、`null` = クリア、文字列 = 設定。`renga --layout ops` を忘れて起動したセッションで secretary ペインに `id = "secretary"` が付いていない、といった状態からのリカバリに使う。全桁数字の name は数値 id と曖昧化するため拒否、同一タブ内の name 衝突も拒否。CLI では `renga rename [--id \| --name \| --focused] [--to-name \| --clear-name] [--to-role \| --clear-role]`。 |
+
+_イベント監視:_
+
+| ツール | 役割 |
+|---|---|
+| `poll_events(timeout_ms?, since?, types?)` | `pane_started` / `pane_exited` / `events_dropped` を cursor 付き long-poll で受け取る。オーケストレータが毎ターン pane 一覧を総当たりせずに、ワーカーの起動・終了だけを追いたいとき向け。 |
 
 > この `claude` 自動アップグレードは layout TOML (`renga --layout <name>`) 経由で起動するペインにも適用される。layout toml に `command = "claude"` と書けばペイン起動時に peer 対応コマンドへ書き換えられるので、各エントリで毎回 `--dangerously-load-development-channels server:renga-peers` を書く必要はない。
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,15 @@ _Pane control (same tab, except `new_tab`):_
 | `close_pane(target)` | Closes a pane. Refuses with `last_pane` when it's the only pane of the only tab. |
 | `focus_pane(target)` | Moves keyboard focus inside the same tab. Use sparingly — yanking focus out from under the user is disruptive. |
 | `new_tab(…)` | Opens a brand-new tab with a fresh pane and switches focus to it. Accepts the same `cwd` option as `spawn_pane`. Same `claude` auto-upgrade. |
+| `inspect_pane(target, …)` | Snapshots another pane's visible screen so an orchestrator can detect prompts, banners, or mode switches without asking the target Claude to describe itself. Text by default; `format="grid"` returns row-addressable JSON and `lines=N` trims to the last N rows. |
+| `send_keys(target, …)` | Sends raw PTY key input (`Enter`, `Esc`, arrows, `Ctrl+<letter>`, literal text, etc.) to another pane. Use this for interactive prompts or TUIs that cannot consume `send_message`. |
 | `set_pane_identity(target, name?, role?)` | Rename or (re)assign the stable `name` / `role` of an existing pane. Three-state fields: omit a key to keep, `null` to clear, a string to set. Use this to recover when a session was launched without the intended layout (e.g. secretary pane booted without `id = "secretary"` so peers can't address it by name). Rejects all-digit names (would collide with numeric ids) and same-tab name collisions. Also exposed as `renga rename [--id \| --name \| --focused] [--to-name \| --clear-name] [--to-role \| --clear-role]`. |
+
+_Event monitoring:_
+
+| Tool | Effect |
+|---|---|
+| `poll_events(timeout_ms?, since?, types?)` | Long-polls pane lifecycle events (`pane_started`, `pane_exited`, `events_dropped`) with a cursor-based API. Use this when an orchestrator needs to notice worker births/exits without polling the full pane list every turn. |
 
 > The same `claude` auto-upgrade also applies to panes declared in a layout TOML (`renga --layout <name>`): a bare `command = "claude"` in the toml is rewritten to the peer-enabled launch line when the pane starts, so layouts join the renga-peers network without each entry having to repeat `--dangerously-load-development-channels server:renga-peers`.
 

--- a/docs/content/en/peer-messaging.mdx
+++ b/docs/content/en/peer-messaging.mdx
@@ -57,12 +57,36 @@ An explicit `--command "…"` overrides the auto-launch, so the role path is a d
 
 Exposed by the MCP server to each Claude pane:
 
+### Peer messaging
+
 | Tool | Effect |
 |---|---|
 | `list_peers(scope?)` | Lists other panes in the caller's renga tab. Caller excluded. `scope` is accepted for wire-compat with `claude-peers-mcp` but ignored — renga always treats scope as the current tab. |
 | `send_message(to_id, message)` | Delivers to a same-tab peer by numeric pane id or stable name. Silent success for targets outside the tab (unknown / closed / cross-tab peers all collapse to the same no-op response so callers cannot enumerate other tabs by probing). |
 | `check_messages` | Manual inbox drain. Channel push is the primary delivery path; this is a fallback for when you suspect a dropped push. |
 | `set_summary(text)` | v1 stub (accepted and ignored). `list_peers` surfaces pane `name` / `role` as the summary substitute; a real `set_summary` may land in v2. |
+
+### Pane control
+
+| Tool | Effect |
+|---|---|
+| `list_panes` | Lists every pane in the caller's tab with id, optional name / role, focus flag, cwd, and terminal geometry. |
+| `spawn_pane(direction, …)` | Splits a target pane. Optional `command`, `name`, `role`, `cwd`. A bare `command="claude"` (or `claude <args>`) is auto-upgraded to the `Alt+P` peer-enabled launch line so the new pane joins the `renga-peers` network without the caller having to remember `--dangerously-load-development-channels`. |
+| `spawn_claude_pane(direction, …)` | Higher-level convenience for launching Claude. Takes structured `permission_mode` / `model` / `args[]` fields instead of a free-form command string, always enables the peer channel, and keeps launch policy in renga. Reserved flags (`--dangerously-load-development-channels` / `--permission-mode` / `--model`) inside `args[]` are rejected with `invalid-params`. |
+| `close_pane(target)` | Closes a pane. Refuses with `last_pane` when it's the only pane of the only tab. |
+| `focus_pane(target)` | Moves keyboard focus inside the same tab. Use sparingly — yanking focus out from under the user is disruptive. |
+| `new_tab(…)` | Opens a brand-new tab with a fresh pane and switches focus to it. Accepts the same `cwd` option as `spawn_pane`, plus the same `claude` auto-upgrade when `command` starts with `claude`. |
+| `inspect_pane(target, …)` | Snapshots another pane's visible screen so an orchestrator can detect prompts, banners, or mode changes without asking the target Claude to describe itself. Text by default; `format="grid"` returns row-addressable JSON and `lines=N` trims to the last N rows. |
+| `send_keys(target, …)` | Sends raw PTY key input (`Enter`, `Esc`, arrows, `Ctrl+<letter>`, literal text, etc.) to another pane. Use this for interactive prompts or TUIs that cannot consume `send_message`. |
+| `set_pane_identity(target, name?, role?)` | Rename or (re)assign the stable `name` / `role` of an existing pane. Three-state fields: omit a key to keep, `null` to clear, a string to set. Rejects all-digit names and same-tab name collisions. Also exposed as `renga rename`. |
+
+### Event monitoring
+
+| Tool | Effect |
+|---|---|
+| `poll_events(timeout_ms?, since?, types?)` | Long-polls pane lifecycle events (`pane_started`, `pane_exited`, `events_dropped`) with a cursor-based API. Use this when an orchestrator needs to notice worker births / exits without polling the full pane list every turn. |
+
+Use `cwd` on `spawn_pane` / `new_tab` instead of embedding `cd <dir> && ...` inside `command`. That keeps path resolution structured and preserves the `claude` auto-upgrade behavior.
 
 ## Two-pane example
 

--- a/docs/content/peer-messaging.mdx
+++ b/docs/content/peer-messaging.mdx
@@ -60,7 +60,7 @@ renga split --direction vertical --role claude
 
 ## 提供ツール
 
-Claude Code から見える MCP ツールは次の 4 つです。
+### ピアメッセージング
 
 | ツール | 役割 |
 |---|---|
@@ -68,6 +68,28 @@ Claude Code から見える MCP ツールは次の 4 つです。
 | `send_message(to_id, message)` | 同じタブにいる相手にメッセージを送ります。数字の id でも、ペインに付けた名前 (stable name) でも指定可能。別タブ宛や存在しない id 宛は「成功として返すが何も配送しない」挙動にしているので、送信側から他タブのペインを id 探索で列挙する攻撃は成立しません。 |
 | `check_messages` | 受信箱を手動で取り出すフォールバック。通常は channel で push されてくるので出番は少ないですが、取りこぼしを疑うときに使えます。 |
 | `set_summary(text)` | v1 では受け取るだけで保存しません。`list_peers` ではペイン名と役割 (role) を summary の代わりに返しているので実質不要になっています。本格的な実装は v2 の検討事項。 |
+
+### ペイン操作
+
+| ツール | 役割 |
+|---|---|
+| `list_panes` | 同じタブの全ペインを id / 名前 / role / フォーカス状態 / cwd / レイアウト位置込みで一覧します。 |
+| `spawn_pane(direction, …)` | 指定ペインを分割して新ペインを生やします。`command`・`name`・`role`・`cwd` はどれもオプション。`command="claude"` (または `claude <args>`) を渡したときは `Alt+P` と同じ peer 対応コマンドに自動書き換えするので、毎回 `--dangerously-load-development-channels` を覚えていなくてもメッセージング付きの Claude が立ち上がります。 |
+| `spawn_claude_pane(direction, …)` | Claude 起動専用の高レベル API。`permission_mode` / `model` / `args[]` を構造化フィールドで受け取り、peer チャネルを必ず有効にした状態で Claude Code を立ち上げます。`args[]` に予約済みフラグ（`--dangerously-load-development-channels` / `--permission-mode` / `--model`）が入っていると `invalid-params` で拒否します。 |
+| `close_pane(target)` | ペインを閉じます。最後のタブの最後のペインを閉じようとしたときは `last_pane` で拒否します。 |
+| `focus_pane(target)` | 同じタブ内でフォーカス移動します。ユーザーの手元からフォーカスを奪うことになるので使いどころには注意が必要です。 |
+| `new_tab(…)` | 新しいタブを 1 枚開いてそこへフォーカスを移します。`spawn_pane` と同じ `cwd` オプションと `claude` 自動アップグレードが効きます。 |
+| `inspect_pane(target, …)` | 別ペインの可視画面をスナップショットし、プロンプト待ち・警告バナー・モード変化などをそのペイン自身に説明させず検出できます。デフォルトはプレーンテキスト、`format="grid"` で行アドレス付き JSON、`lines=N` で末尾 N 行に絞り込みます。 |
+| `send_keys(target, …)` | 別ペインの PTY に生のキー入力 (`Enter` / `Esc` / 矢印 / `Ctrl+<letter>` / 任意テキストなど) を送ります。`send_message` を解釈できない対話プロンプトや TUI を操作したいとき向けです。 |
+| `set_pane_identity(target, name?, role?)` | 既存ペインの安定 `name` / `role` を付け直す・クリアします。3 ステート: キー省略 = 現状維持、`null` = クリア、文字列 = 設定。全桁数字の name は数値 id と曖昧化するため拒否、同一タブ内の name 衝突も拒否します。CLI では `renga rename` でも同じ操作ができます。 |
+
+### イベント監視
+
+| ツール | 役割 |
+|---|---|
+| `poll_events(timeout_ms?, since?, types?)` | `pane_started` / `pane_exited` / `events_dropped` を cursor 付き long-poll で受け取ります。オーケストレータが毎ターン pane 一覧を総当たりせずに、ワーカーの起動・終了だけを追いたいとき向けです。 |
+
+`spawn_pane` / `new_tab` の作業ディレクトリ指定は `cwd` フィールドを使うのが推奨です。`command` に `cd <dir> && ...` を埋め込むと、`claude` 自動アップグレードの恩恵を受けにくくなります。
 
 ## 2 ペインでのやり取りの例
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -31,12 +31,13 @@ renga /path/to/project   # Launch in specified directory
 
 ## Features
 
-- Multi-pane terminal splits (vertical/horizontal)
+- Peer messaging between Claude panes via the built-in `renga-peers` MCP channel
+- Pane-control MCP tools (`spawn_claude_pane`, `set_pane_identity`, `new_tab`, `send_keys`, `inspect_pane`, ...)
+- Centered IME composition overlay for JP / CJK input with pane freeze + draft restore on reopen
+- Multi-pane splits, tab workspaces, and layout TOML
 - File tree sidebar with syntax-highlighted preview
-- Tab workspaces
 - Claude Code auto-detection (pane border turns orange)
 - Mouse support (click, drag resize, text selection)
-- Terminal scrollback (10,000 lines)
 - Cross-platform (Windows, macOS, Linux)
 
 ## Links


### PR DESCRIPTION
## Summary
- expand the peer-messaging docs to match the current MCP tool surface
- add missing pane-control and event-monitoring tools to the README tool tables
- refresh the npm README feature list so it reflects the current product surface

## Motivation
The README and docs had fallen behind the implementation. In particular, the peer-messaging docs still described only the original four tools even though the MCP now exposes pane-control, inspection, key-input, and event-polling APIs.

## Testing
- docs-only change; reviewed diff locally
