### PR TITLE
docs(lp): sync IME and MCP surface copy

### DIFF
--- a/lp/index.html
+++ b/lp/index.html
@@ -188,8 +188,9 @@
           caret inside the box, so Japanese / Chinese / Korean
           composition stops chasing Claude's moving cursor. Press
           <code>Alt+Enter</code> to send, <code>Enter</code> for a
-          newline, pair with <code>--ime-freeze-panes</code> to
-          silence background flicker.
+          newline, <code>Esc</code>/<code>Ctrl+C</code> to close
+          temporarily and reopen the same draft later, and pair with
+          <code>--ime-freeze-panes</code> to silence background flicker.
         </figcaption>
       </figure>
 
@@ -308,9 +309,9 @@ $ npm install -g @suisya-systems/renga</code></pre>
           </tr>
           <tr>
             <td>
-              MCP pane control from inside Claude Code
+              MCP pane control + orchestration from inside Claude Code
               <br /><span style="color: var(--muted); font-size: 0.85em;">
-                Same <code>renga mcp install</code> exposes <code>list_panes</code>, <code>spawn_pane</code>, <code>close_pane</code>, <code>focus_pane</code>, <code>new_tab</code> so a Claude instance can split the layout, spin up a sibling Claude, or switch focus — without the user leaving the conversation. A bare <code>command="claude"</code> is auto-upgraded to the <code>Alt+P</code> peer-enabled launch, so new Claude panes join the peer network automatically.
+                Same <code>renga mcp install</code> exposes <code>list_panes</code>, <code>spawn_pane</code>, <code>spawn_claude_pane</code>, <code>close_pane</code>, <code>focus_pane</code>, <code>new_tab</code>, <code>inspect_pane</code>, <code>send_keys</code>, <code>set_pane_identity</code>, and <code>poll_events</code> so a Claude instance can split the layout, launch a sibling Claude, inspect another pane's screen, answer an interactive prompt, rename workers, and watch pane lifecycle changes — without the user leaving the conversation. A bare <code>command="claude"</code> is auto-upgraded to the <code>Alt+P</code> peer-enabled launch, so new Claude panes join the peer network automatically.
               </span>
             </td>
             <td class="mark">—</td>

--- a/lp/ja.html
+++ b/lp/ja.html
@@ -182,6 +182,7 @@
           ホスト OS の IME 候補窓がキャレットに吸着するので、
           日本語 / 中国語 / 韓国語の変換中に候補窓が Claude のカーソルに振り回されません。
           <code>Alt+Enter</code> で送信、<code>Enter</code> は改行、
+          <code>Esc</code>/<code>Ctrl+C</code> で一旦閉じても同じドラフトを後で開き直せます。
           <code>--ime-freeze-panes</code> を組み合わせると背後のちらつきも止まります。
         </figcaption>
       </figure>
@@ -294,9 +295,9 @@ $ npm install -g @suisya-systems/renga</code></pre>
           </tr>
           <tr>
             <td>
-              Claude Code から MCP 経由でペインを操作
+              Claude Code から MCP 経由でペイン操作 + オーケストレーション
               <br /><span style="color: var(--muted); font-size: 0.85em;">
-                同じ <code>renga mcp install</code> で <code>list_panes</code> / <code>spawn_pane</code> / <code>close_pane</code> / <code>focus_pane</code> / <code>new_tab</code> が使えるようになり、Claude が会話から離れずにペイン分割・相方 Claude の起動・フォーカス移動まで自分でできる。<code>command="claude"</code> を渡せば <code>Alt+P</code> と同じメッセージング対応の起動コマンドに自動書き換えするので、新しく立ち上げた Claude も peer ネットワークに最初から繋がる。
+                同じ <code>renga mcp install</code> で <code>list_panes</code> / <code>spawn_pane</code> / <code>spawn_claude_pane</code> / <code>close_pane</code> / <code>focus_pane</code> / <code>new_tab</code> / <code>inspect_pane</code> / <code>send_keys</code> / <code>set_pane_identity</code> / <code>poll_events</code> が使えるようになり、Claude が会話から離れずにペイン分割・相方 Claude の起動・別ペイン画面の確認・対話プロンプトへの応答・ワーカー名付け・ペイン寿命監視まで自分でできる。<code>command="claude"</code> を渡せば <code>Alt+P</code> と同じメッセージング対応の起動コマンドに自動書き換えするので、新しく立ち上げた Claude も peer ネットワークに最初から繋がる。
               </span>
             </td>
             <td class="mark">—</td>


### PR DESCRIPTION
## Summary
- update the landing-page IME overlay copy to mention draft restore on reopen
- expand the landing-page MCP orchestration copy to match the current tool surface
- keep the English and Japanese LPs aligned with the README/docs follow-ups

## Motivation
The LP copy had drifted behind the README and docs. It still described the older IME-close behavior and an earlier MCP tool surface.

## Testing
- docs-only change; reviewed diff locally
