### PR TITLE
docs: mention pane cwd in list_panes summary

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -289,7 +289,7 @@ _ペイン操作 (`new_tab` を除き同一タブ内):_
 
 | ツール | 役割 |
 |---|---|
-| `list_panes` | 同じタブの全ペインを id / 名前 / role / フォーカス状態 / レイアウト位置込みで一覧する。 |
+| `list_panes` | 同じタブの全ペインを id / 名前 / role / フォーカス状態 / cwd / レイアウト位置込みで一覧する。 |
 | `spawn_pane(direction, …)` | 指定ペインを分割して新ペインを生やす。`command`・`name`・`role`・`cwd` はどれもオプション。`command="claude"` (または `claude <args>`) を渡したときは `Alt+P` と同じ peer 対応コマンドに自動書き換えするので、毎回 `--dangerously-load-development-channels` を覚えていなくてもメッセージング付きの Claude が立ち上がる。 |
 | `spawn_claude_pane(direction, …)` | Claude 起動専用の高レベル API。`command` の代わりに `permission_mode` / `model` / `args[]` を構造化フィールドで受け取り、peer チャネルを必ず有効にした状態で Claude Code を立ち上げる。orchestrator 側で shell クオートや launch policy を管理せず renga 側に集約できるので、`spawn_pane(command="claude ...")` を合成するより agent harness 向き。`args[]` に予約済みフラグ（`--dangerously-load-development-channels` / `--permission-mode` / `--model`）が入っていると `invalid-params` で拒否する。 |
 | `close_pane(target)` | ペインを閉じる。最後のタブの最後のペインを閉じようとしたときは `last_pane` で拒否。 |

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ _Pane control (same tab, except `new_tab`):_
 
 | Tool | Effect |
 |---|---|
-| `list_panes` | Lists every pane in the caller's tab with id, optional name/role, focus flag, and terminal geometry. |
+| `list_panes` | Lists every pane in the caller's tab with id, optional name/role, focus flag, cwd, and terminal geometry. |
 | `spawn_pane(direction, …)` | Splits a target pane. Optional `command`, `name`, `role`, `cwd`. A bare `command="claude"` (or `claude <args>`) is auto-upgraded to the `Alt+P` peer-enabled launch line so the new pane joins the renga-peers network without the caller having to remember `--dangerously-load-development-channels`. |
 | `spawn_claude_pane(direction, …)` | Higher-level convenience for launching Claude. Takes structured `permission_mode` / `model` / `args[]` fields instead of a free-form command string, always enables the peer channel, and keeps launch policy in renga. Prefer this over `spawn_pane(command="claude ...")` when the target process is Claude Code — orchestrator prompts don't have to synthesize shell-quoted command strings. Reserved flags (`--dangerously-load-development-channels` / `--permission-mode` / `--model`) inside `args[]` are rejected with `invalid-params`. |
 | `close_pane(target)` | Closes a pane. Refuses with `last_pane` when it's the only pane of the only tab. |


### PR DESCRIPTION
## Summary
- mention cwd in the list_panes summary row in the English and Japanese README tables
- align the README wording with the current MCP response surface

## Motivation
The more detailed docs already describe pane cwd support, but the condensed README tool table still omitted it from list_panes.

## Testing
- docs-only change; reviewed diff locally
