### PR TITLE
Add opt-in Codex auto-nudge

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -254,6 +254,8 @@ renga mcp install --client codex   # Codex peer も使う場合
 - **Claude Code** は MCP の experimental channel 機能を使うので、起動時に毎回 `--dangerously-load-development-channels server:renga-peers` が必要です。
 - **Codex** は `renga mcp install --client codex` で入れた MCP 登録を使います。これが `RENGA_PEER_CLIENT_KIND=codex` を MCP サブプロセスに注入するので、起動自体は plain `codex` で足ります。受信は `check_messages` による pull です。
 
+Codex の auto-nudge は opt-in です。`codex` を起動する親シェルで `RENGA_CODEX_AUTO_NUDGE=1` を設定してください。`renga mcp install --client codex` を実行してあれば、その env var は `renga-peers` の MCP サブプロセスまで自動で引き継がれます。
+
 Claude の起動フラグを毎回手で打たなくて済むように、renga 側から 2 つの経路を用意しています。
 
 - **`Alt+P`** — フォーカス中のペインに `claude --dangerously-load-development-channels server:renga-peers ` を入力してくれる (末尾にスペース、**Enter は押されない**)。そのまま Enter で起動してもいいし、追加の引数 (例 `/foo`) を続けて書いてから Enter でも OK。シェル (bash / zsh / fish / pwsh) の種類を問わず同じ動作。
@@ -325,6 +327,7 @@ _イベント監視:_
 - **`list_peers` が "renga not reachable from this peer client" を返す** — client が renga の外で起動されたか、renga ペインの環境変数を引き継げていません。renga のペイン内から起動し直してください（Claude は `Alt+P` / `renga split --role claude`、Codex は `renga mcp install --client codex` 後の plain `codex` または `spawn_codex_pane`）。
 - **相手に送ったメッセージが `<channel>` タグで表示されない** — 起動時のフラグ `--dangerously-load-development-channels server:renga-peers` を付け忘れています。`claude` と打つ代わりに `Alt+P` を使えばフラグ付きのコマンドが挿入されるので事故りにくくなります。
 - **Codex に送ったのに反応がない** — Codex は pull 型です。メッセージは `check_messages` が呼ばれるまで queue に残ります。Codex 側の prompt / workflow が turn 開始時と長作業の節目で `check_messages` を呼ぶ前提になっているか確認してください。
+- **Codex の auto-nudge が動かない** — 既定では無効です。`renga mcp install --client codex` を実行して `RENGA_CODEX_AUTO_NUDGE` の passthrough を入れた上で、renga のペイン内から `RENGA_CODEX_AUTO_NUDGE=1` を設定した親シェルで `codex` を起動してください。
 - **`send_keys` が効いていないように見える** — `send_keys` は target ペインの PTY に生の入力バイトを書き込むだけで、帯域外の「承認」操作ではありません。まず `inspect_pane(target=..., lines=20)` で本当に入力待ちか確認し、レイアウトが動く運用ではフォーカス推測ではなく安定した pane `name` を target に使ってください。
 - **`poll_events` が想定より早く `events: []` を返す** — `types=[...]` フィルタは返却結果を絞るだけで、非一致イベントでも long-poll は解除されて `next_since` は前進します。返ってきた cursor でそのまま再 poll してください。`events_dropped` が来た場合だけ、1 回 `list_panes` で再同期すると安全です。
 - **renga をアップグレードしたら繋がらなくなった** — 登録されているバイナリのパスが古いです。`renga mcp install --client claude --force` や `renga mcp install --client codex --force` で今の `renga` に更新してください。

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Peer delivery is client-specific:
 - **Claude Code** uses the MCP experimental channel protocol, so it needs `--dangerously-load-development-channels server:renga-peers` at startup.
 - **Codex** uses the MCP registration installed by `renga mcp install --client codex`; once that is in place, a plain `codex` launch is enough and incoming peer messages are drained with `check_messages`.
 
+Optional Codex auto-nudge is opt-in. Set `RENGA_CODEX_AUTO_NUDGE=1` in the parent shell before launching `codex`; `renga mcp install --client codex` configures the MCP registration to pass that env var through to `renga-peers`.
+
 renga gives you two shortcuts so you don't have to type the Claude launch flag by hand:
 
 - **`Alt+P`** — Inserts `claude --dangerously-load-development-channels server:renga-peers ` into the focused pane (trailing space, *no* Enter). Review, optionally tack on args, press Enter to run. Works in any pane, any shell.
@@ -320,6 +322,7 @@ _Event monitoring:_
 - **`list_peers` reports "renga not reachable from this peer client"** — The client was launched outside a renga pane, or without inheriting the pane env. Re-launch from inside renga (`Alt+P` / `renga split --role claude` for Claude, or a normal `codex` / `spawn_codex_pane` launch after `renga mcp install --client codex`).
 - **Peer messages don't render as `<channel>` tags** — You probably forgot the `--dangerously-load-development-channels server:renga-peers` flag. Prefer `Alt+P` over typing `claude` directly.
 - **A message sent to Codex seems to do nothing** — Codex is pull-based. The message is queued until Codex calls `check_messages`. Make sure the Codex prompt or workflow checks its inbox at turn start and at reasonable checkpoints during longer work.
+- **Codex auto-nudge does not fire** — The feature is off by default. Run `renga mcp install --client codex` so the MCP registration includes `RENGA_CODEX_AUTO_NUDGE` passthrough, then launch `codex` from a renga pane with `RENGA_CODEX_AUTO_NUDGE=1` in the parent shell environment.
 - **`send_keys` seems to do nothing** — `send_keys` writes raw bytes to the target pane's PTY; it does not grant approval out-of-band. Snapshot first with `inspect_pane(target=..., lines=20)` to confirm the pane is actually waiting for input, and prefer a stable pane `name` over guessing by focus in changing layouts.
 - **`poll_events` returns `events: []` before the timeout you expected** — A `types=[...]` filter only narrows what is returned; a non-matching event can still wake the long-poll and advance `next_since`. Re-issue the call with the returned cursor. If you receive `events_dropped`, re-sync once with `list_panes`.
 - **Upgrading renga?** — Re-run `renga mcp install --client claude --force` and/or `renga mcp install --client codex --force` so each registered client points at your new binary.

--- a/docs/content/en/peer-messaging.mdx
+++ b/docs/content/en/peer-messaging.mdx
@@ -36,6 +36,8 @@ Peer delivery is asymmetric:
 - Claude Code uses MCP's experimental channel protocol and needs `--dangerously-load-development-channels server:renga-peers` at startup.
 - Codex uses the MCP registration installed by `renga mcp install --client codex`; once that exists, a plain `codex` launch is enough and incoming peer messages are drained with `check_messages`.
 
+Codex auto-nudge is optional. Set `RENGA_CODEX_AUTO_NUDGE=1` in the parent shell before launching `codex`; `renga mcp install --client codex` ensures that env var is passed through to the `renga-peers` MCP subprocess.
+
 renga gives you shortcuts so you do not have to type the Claude launch flag by hand.
 
 ### `Alt+P` — works in any pane
@@ -165,6 +167,10 @@ You launched Claude Code without `--dangerously-load-development-channels server
 ### A message sent to Codex seems to do nothing
 
 Codex is pull-based. The message is queued until Codex calls `check_messages`. Make sure the Codex prompt or workflow checks its inbox at turn start and at reasonable checkpoints during longer work.
+
+### Codex auto-nudge does not fire
+
+The feature is off by default. Re-run `renga mcp install --client codex` if needed so the MCP registration passes through `RENGA_CODEX_AUTO_NUDGE`, then launch `codex` from inside a renga pane with `RENGA_CODEX_AUTO_NUDGE=1` set in the parent shell.
 
 ### `send_keys` seems to do nothing
 

--- a/docs/content/en/peer-messaging.mdx
+++ b/docs/content/en/peer-messaging.mdx
@@ -21,7 +21,9 @@ renga mcp install --client claude
 renga mcp install --client codex
 ```
 
-Registers the running `renga` binary as the `renga-peers` MCP server in each selected client's user-scope config. Internally shells out to `claude mcp add-json` for Claude and `codex mcp add` for Codex, so the clients own their on-disk schema and renga stays out of its evolution.
+Registers the running `renga` binary as the `renga-peers` MCP server in each selected client's user-scope config. Internally shells out to `claude mcp add-json` for Claude and `codex mcp add` for Codex first, so the primary registration path still goes through the client CLIs.
+
+For Codex, renga also applies the minimum post-registration patch needed to preserve the required env-var passthrough on the `renga-peers` entry in `~/.codex/config.toml`. If you also want `check_messages` and `send_message` to default to auto-approve, opt in explicitly with `--codex-auto-approve-peer-tools`. It intentionally does not auto-approve riskier tools such as `send_keys` or pane-control actions.
 
 Idempotent — re-runs without `--force` print the current entry and bail. Pass `--force` to overwrite after a renga upgrade. Use `renga mcp uninstall --client ...` to remove and `renga mcp status --client ...` to inspect.
 
@@ -37,6 +39,10 @@ Peer delivery is asymmetric:
 - Codex uses the MCP registration installed by `renga mcp install --client codex`; once that exists, a plain `codex` launch is enough and incoming peer messages are drained with `check_messages`.
 
 Codex auto-nudge is optional. Set `RENGA_CODEX_AUTO_NUDGE=1` in the parent shell before launching `codex`; `renga mcp install --client codex` ensures that env var is passed through to the `renga-peers` MCP subprocess.
+
+<Callout type="warning">
+  Peer messaging on Codex is currently less stable than on Claude by design. Two constraints matter: Codex receives via pull-based `check_messages`, and MCP approvals are pane-local rather than shared across panes. The on-screen `pending messages` prompt can therefore become stale; treat `check_messages` as the source of truth.
+</Callout>
 
 renga gives you shortcuts so you do not have to type the Claude launch flag by hand.
 
@@ -168,9 +174,27 @@ You launched Claude Code without `--dangerously-load-development-channels server
 
 Codex is pull-based. The message is queued until Codex calls `check_messages`. Make sure the Codex prompt or workflow checks its inbox at turn start and at reasonable checkpoints during longer work.
 
+### Codex still shows `pending messages` but `check_messages` returns 0
+
+Codex auto-nudge is not a continuously-synchronised banner. It is a one-shot prompt nudging Codex to call `check_messages`, and that prompt remains in the Codex transcript after the inbox has been drained.
+
+If `check_messages` returns 0, treat the on-screen nudge as stale. The real inbox is already empty.
+
 ### Codex auto-nudge does not fire
 
 The feature is off by default. Re-run `renga mcp install --client codex` if needed so the MCP registration passes through `RENGA_CODEX_AUTO_NUDGE`, then launch `codex` from inside a renga pane with `RENGA_CODEX_AUTO_NUDGE=1` set in the parent shell.
+
+### A new Codex pane asks for approval again
+
+Codex MCP approvals are pane-local. Unlike Claude Code, do not assume one approval automatically propagates to other Codex panes in the same tab.
+
+Warm up each new Codex pane once:
+
+1. Send that pane a single peer message.
+2. On the `check_messages` approval prompt, choose `Always allow`.
+3. On the first `send_message` approval prompt, choose `Always allow` again.
+
+`renga mcp install --client codex --codex-auto-approve-peer-tools` tries to preconfigure those two approvals up front, but depending on the Codex version and runtime, a brand-new pane may still prompt once before the setting fully takes effect.
 
 ### `send_keys` seems to do nothing
 

--- a/docs/content/peer-messaging.mdx
+++ b/docs/content/peer-messaging.mdx
@@ -21,7 +21,9 @@ renga mcp install --client claude
 renga mcp install --client codex
 ```
 
-いま走っている `renga` バイナリを `renga-peers` という名前で、選択した client のユーザー設定に登録します。Claude では `claude mcp add-json`、Codex では `codex mcp add` を呼ぶだけなので、client 側の設定ファイル書式を renga が追う必要はありません。
+いま走っている `renga` バイナリを `renga-peers` という名前で、選択した client のユーザー設定に登録します。Claude では `claude mcp add-json`、Codex では `codex mcp add` を使って、まず client CLI 側の正規登録経路に載せます。
+
+Codex については、peer messaging に必要な env var passthrough を保つため、登録後に `~/.codex/config.toml` の `renga-peers` エントリを最小限だけ補正します。`check_messages` と `send_message` の auto-approve まで入れたい場合は、`--codex-auto-approve-peer-tools` を付けて明示的に opt-in してください。`send_keys` や pane 操作系までは自動承認しません。
 
 同じ登録を何度実行しても安全 (既に登録があれば内容を表示して止まる) で、renga をアップグレードしてバイナリのパスが変わったときだけ `--force` を付けて上書きしてください。
 
@@ -44,6 +46,10 @@ renga mcp status --client codex
 - Codex は `renga mcp install --client codex` で入れた MCP 登録を使います。そこで `RENGA_PEER_CLIENT_KIND=codex` が MCP サブプロセスに注入されるため、pane 側の起動は plain `codex` で足ります。受信は `check_messages` による pull です。
 
 Codex の auto-nudge は任意です。`codex` を起動する親シェルで `RENGA_CODEX_AUTO_NUDGE=1` を設定してください。`renga mcp install --client codex` を実行してあれば、その env var は `renga-peers` の MCP サブプロセスまで引き継がれます。
+
+<Callout type="warning">
+  Codex 側の peer messaging は、現状どうしても Claude より不安定です。理由は 2 つで、受信が `check_messages` ベースの pull 型であることと、MCP 承認が pane ごとで共有されないことです。`pending messages` の表示が stale になることもあるので、最終的な真実は常に `check_messages` の返り値を見てください。
+</Callout>
 
 Claude の起動フラグを毎回手で打たなくて済むように、renga 側から 2 つの経路を用意しています。
 
@@ -171,9 +177,27 @@ client が renga の外で起動されたか、renga ペインの環境変数を
 
 Codex は pull 型です。メッセージは `check_messages` が呼ばれるまで queue に残ります。Codex 側の prompt / workflow が turn 開始時と長作業の節目で `check_messages` を呼ぶ前提になっているか確認してください。
 
+### Codex の `pending messages` 表示が残るのに `check_messages` は 0 件
+
+Codex auto-nudge は queue 状態を常時同期するバナーではなく、`check_messages` を促す one-shot の入力です。Codex の履歴に残るので、受信箱を drain したあとでも画面上にはしばらく見えます。
+
+`check_messages` が 0 件なら、それは stale な nudge です。実 inbox 側は空なので、そのまま無視して構いません。
+
 ### Codex の auto-nudge が動かない
 
 この機能は既定で無効です。必要なら `renga mcp install --client codex` を再実行して `RENGA_CODEX_AUTO_NUDGE` の passthrough が入っている状態にし、renga のペイン内から `RENGA_CODEX_AUTO_NUDGE=1` を設定した親シェルで `codex` を起動してください。
+
+### 新しい Codex pane でまた承認が出る
+
+Codex の MCP 承認は pane ごとです。Claude Code のような「一度許可したら同じタブの別 pane にも伝播する」共有承認は前提にしていません。
+
+新しい Codex pane を立てた直後に 1 回だけ warm-up してください。
+
+1. その pane に peer message を 1 通送る
+2. `check_messages` の承認で `Always allow` を選ぶ
+3. 返信時の `send_message` の承認でも `Always allow` を選ぶ
+
+`renga mcp install --client codex --codex-auto-approve-peer-tools` はこの 2 つを事前設定しようとしますが、Codex 側のバージョンや実行形態によっては、新しい pane で一度だけ承認が必要なことがあります。
 
 ### `send_keys` が効いていないように見える
 

--- a/docs/content/peer-messaging.mdx
+++ b/docs/content/peer-messaging.mdx
@@ -43,6 +43,8 @@ renga mcp status --client codex
 - Claude Code は MCP の experimental channel を使うので、起動時に `--dangerously-load-development-channels server:renga-peers` が必要です。
 - Codex は `renga mcp install --client codex` で入れた MCP 登録を使います。そこで `RENGA_PEER_CLIENT_KIND=codex` が MCP サブプロセスに注入されるため、pane 側の起動は plain `codex` で足ります。受信は `check_messages` による pull です。
 
+Codex の auto-nudge は任意です。`codex` を起動する親シェルで `RENGA_CODEX_AUTO_NUDGE=1` を設定してください。`renga mcp install --client codex` を実行してあれば、その env var は `renga-peers` の MCP サブプロセスまで引き継がれます。
+
 Claude の起動フラグを毎回手で打たなくて済むように、renga 側から 2 つの経路を用意しています。
 
 ### `Alt+P` — どのペインからでも
@@ -168,6 +170,10 @@ client が renga の外で起動されたか、renga ペインの環境変数を
 ### Codex に送ったのに反応がない
 
 Codex は pull 型です。メッセージは `check_messages` が呼ばれるまで queue に残ります。Codex 側の prompt / workflow が turn 開始時と長作業の節目で `check_messages` を呼ぶ前提になっているか確認してください。
+
+### Codex の auto-nudge が動かない
+
+この機能は既定で無効です。必要なら `renga mcp install --client codex` を再実行して `RENGA_CODEX_AUTO_NUDGE` の passthrough が入っている状態にし、renga のペイン内から `RENGA_CODEX_AUTO_NUDGE=1` を設定した親シェルで `codex` を起動してください。
 
 ### `send_keys` が効いていないように見える
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -297,6 +297,11 @@ pub enum McpAction {
         /// Needed when upgrading renga and the command path changed.
         #[arg(long)]
         force: bool,
+        /// For Codex only: patch the `renga-peers` config entry so
+        /// `check_messages` / `send_message` default to auto-approve.
+        /// Keeps riskier tools such as `send_keys` on prompt.
+        #[arg(long)]
+        codex_auto_approve_peer_tools: bool,
     },
     /// Remove renga-peers from the selected client's MCP config.
     /// No-op if the entry is not present.
@@ -1082,13 +1087,46 @@ mod tests {
     fn parses_mcp_install_default_client_as_claude() {
         let cli = Cli::try_parse_from(["renga", "mcp", "install"]).unwrap();
         let Some(IpcCommand::Mcp {
-            action: McpAction::Install { client, force },
+            action:
+                McpAction::Install {
+                    client,
+                    force,
+                    codex_auto_approve_peer_tools,
+                },
         }) = cli.command
         else {
             panic!("expected mcp install command");
         };
         assert_eq!(client, McpClient::Claude);
         assert!(!force);
+        assert!(!codex_auto_approve_peer_tools);
+    }
+
+    #[test]
+    fn parses_mcp_install_codex_auto_approve_flag() {
+        let cli = Cli::try_parse_from([
+            "renga",
+            "mcp",
+            "install",
+            "--client",
+            "codex",
+            "--codex-auto-approve-peer-tools",
+        ])
+        .unwrap();
+        let Some(IpcCommand::Mcp {
+            action:
+                McpAction::Install {
+                    client,
+                    force,
+                    codex_auto_approve_peer_tools,
+                },
+        }) = cli.command
+        else {
+            panic!("expected mcp install command");
+        };
+        assert_eq!(client, McpClient::Codex);
+        assert!(!force);
+        assert!(codex_auto_approve_peer_tools);
     }
 
     #[test]

--- a/src/mcp_peer/install.rs
+++ b/src/mcp_peer/install.rs
@@ -1,19 +1,21 @@
 //! `renga mcp install / uninstall / status` — thin wrappers around
 //! client MCP management commands.
 //!
-//! We intentionally do **not** edit Claude Code's or Codex's config
-//! files directly. Both CLIs already own their MCP configuration
-//! formats, so we delegate registration through `claude mcp ...` or
-//! `codex mcp ...` instead of tracking on-disk schema details here.
+//! We intentionally let each client CLI own the primary MCP
+//! registration path (`claude mcp ...` / `codex mcp ...`) rather than
+//! reimplementing their full on-disk schema here.
 //!
-//! The tradeoff is a hard dependency on the target client binary being
-//! on PATH. We surface a clear error in that case rather than silently
-//! falling back to file-editing.
+//! Codex currently needs a small post-registration patch to its
+//! `config.toml` so the `renga-peers` entry carries the required
+//! env-var passthrough. Optional approval defaults are kept behind an
+//! explicit CLI flag so the default install path stays close to the
+//! client CLI's own registration semantics while still failing clearly
+//! if the target client binary is missing from PATH.
 
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::fs;
 
 use anyhow::{anyhow, bail, Context, Result};
 
@@ -27,11 +29,16 @@ const CODEX_PASSTHROUGH_ENV_VARS: &[&str] = &[
     "RENGA_TOKEN",
     "RENGA_CODEX_AUTO_NUDGE",
 ];
+const CODEX_AUTO_APPROVE_TOOLS: &[&str] = &["check_messages", "send_message"];
 
 /// Entry point from `main.rs` for the `renga mcp <action>` subcommand.
 pub fn run(action: &McpAction) -> Result<()> {
     match action {
-        McpAction::Install { force, client } => install(*force, *client),
+        McpAction::Install {
+            force,
+            client,
+            codex_auto_approve_peer_tools,
+        } => install(*force, *client, *codex_auto_approve_peer_tools),
         McpAction::Uninstall { client } => uninstall(*client),
         McpAction::Status { client } => status(*client),
     }
@@ -39,7 +46,10 @@ pub fn run(action: &McpAction) -> Result<()> {
 
 // ── install ────────────────────────────────────────────────────
 
-fn install(force: bool, client: McpClient) -> Result<()> {
+fn install(force: bool, client: McpClient, codex_auto_approve_peer_tools: bool) -> Result<()> {
+    if client != McpClient::Codex && codex_auto_approve_peer_tools {
+        bail!("--codex-auto-approve-peer-tools is only valid with --client codex");
+    }
     ensure_client_cli_available(client)?;
     let exe = current_renga_exe()?;
 
@@ -47,6 +57,9 @@ fn install(force: bool, client: McpClient) -> Result<()> {
         if !force {
             if client == McpClient::Codex {
                 ensure_codex_env_var_passthrough()?;
+                if codex_auto_approve_peer_tools {
+                    ensure_codex_auto_approve_peer_tools()?;
+                }
             }
             println!(
                 "{SERVER_NAME} is already registered in {} → {existing}\n\
@@ -64,7 +77,14 @@ fn install(force: bool, client: McpClient) -> Result<()> {
         McpClient::Codex => install_codex(&exe)?,
     }
 
-    println!("{}", install_success_message(client, &exe));
+    if client == McpClient::Codex && codex_auto_approve_peer_tools {
+        ensure_codex_auto_approve_peer_tools()?;
+    }
+
+    println!(
+        "{}",
+        install_success_message(client, &exe, codex_auto_approve_peer_tools)
+    );
     Ok(())
 }
 
@@ -107,7 +127,11 @@ fn install_codex(exe: &Path) -> Result<()> {
     Ok(())
 }
 
-fn install_success_message(client: McpClient, exe: &Path) -> String {
+fn install_success_message(
+    client: McpClient,
+    exe: &Path,
+    codex_auto_approve_peer_tools: bool,
+) -> String {
     match client {
         McpClient::Claude => format!(
             "Registered {SERVER_NAME} in Claude Code → {}\n\
@@ -121,8 +145,20 @@ fn install_success_message(client: McpClient, exe: &Path) -> String {
             "Registered {SERVER_NAME} in Codex → {}\n\
              Next: launch Codex from inside a renga pane. This registration \
              injects `{ENV_CLIENT_KIND}=codex`, so peer messages are received \
-             through `check_messages` instead of Claude channels.",
-            exe.display()
+             through `check_messages` instead of Claude channels.{}",
+            exe.display(),
+            if codex_auto_approve_peer_tools {
+                "\n\
+             renga also preconfigures Codex to auto-approve `check_messages` and \
+             `send_message` for this MCP server where supported.\n\
+             Note: Codex MCP approvals can still behave pane-locally in practice, \
+             so a newly launched pane may still need one warm-up approval."
+            } else {
+                "\n\
+             Re-run with `--codex-auto-approve-peer-tools` if you want renga to \
+             patch the Codex config entry so `check_messages` / `send_message` \
+             prompt less often."
+            }
         ),
     }
 }
@@ -306,6 +342,24 @@ fn ensure_codex_env_var_passthrough() -> Result<()> {
     Ok(())
 }
 
+fn ensure_codex_auto_approve_peer_tools() -> Result<()> {
+    let path = codex_config_path()?;
+    let current = fs::read_to_string(&path)
+        .with_context(|| format!("read Codex config at {}", path.display()))?;
+    let updated = upsert_codex_auto_approve_peer_tools(&current).ok_or_else(|| {
+        anyhow!(
+            "Codex config at {} does not contain an [{section}] section after registration",
+            path.display(),
+            section = codex_server_section_name()
+        )
+    })?;
+    if updated != current {
+        fs::write(&path, updated)
+            .with_context(|| format!("write Codex config at {}", path.display()))?;
+    }
+    Ok(())
+}
+
 fn codex_config_path() -> Result<PathBuf> {
     let home = dirs::home_dir()
         .ok_or_else(|| anyhow!("could not resolve the current user's home directory"))?;
@@ -314,6 +368,24 @@ fn codex_config_path() -> Result<PathBuf> {
 
 fn codex_server_section_name() -> String {
     format!("mcp_servers.{SERVER_NAME}")
+}
+
+fn codex_tool_section_name(tool: &str) -> String {
+    format!("{}.tools.{tool}", codex_server_section_name())
+}
+
+fn upsert_codex_auto_approve_peer_tools(src: &str) -> Option<String> {
+    let mut updated = src.to_string();
+    if !src
+        .lines()
+        .any(|line| line.trim() == format!("[{}]", codex_server_section_name()))
+    {
+        return None;
+    }
+    for tool in CODEX_AUTO_APPROVE_TOOLS {
+        updated = upsert_codex_tool_approval(&updated, tool, "approve");
+    }
+    Some(updated)
 }
 
 fn upsert_codex_env_var_passthrough(src: &str) -> Option<String> {
@@ -381,6 +453,76 @@ fn codex_env_vars_line() -> String {
             .collect::<Vec<_>>()
             .join(", ")
     )
+}
+
+fn upsert_codex_tool_approval(src: &str, tool: &str, approval_mode: &str) -> String {
+    let section = codex_tool_section_name(tool);
+    let header = format!("[{section}]");
+    let newline = if src.contains("\r\n") { "\r\n" } else { "\n" };
+    let had_trailing_newline = src.ends_with(newline);
+    let approval_line = format!("approval_mode = \"{approval_mode}\"");
+    let mut out: Vec<String> = Vec::new();
+    let mut in_section = false;
+    let mut found_section = false;
+    let mut wrote_approval = false;
+
+    for line in src.lines() {
+        let trimmed = line.trim();
+        if !in_section {
+            if trimmed == header {
+                in_section = true;
+                found_section = true;
+            }
+            out.push(line.to_string());
+            continue;
+        }
+
+        if trimmed.starts_with('[') {
+            if !wrote_approval {
+                while out.last().is_some_and(|line| line.trim().is_empty()) {
+                    out.pop();
+                }
+                out.push(approval_line.clone());
+                out.push(String::new());
+                wrote_approval = true;
+            }
+            in_section = false;
+            out.push(line.to_string());
+            continue;
+        }
+
+        if trimmed.starts_with("approval_mode") {
+            out.push(approval_line.clone());
+            wrote_approval = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+
+    if found_section {
+        if in_section && !wrote_approval {
+            out.push(approval_line);
+        }
+        let mut rebuilt = out.join(newline);
+        if had_trailing_newline {
+            rebuilt.push_str(newline);
+        }
+        return rebuilt;
+    }
+
+    while out.last().is_some_and(|line| line.trim().is_empty()) {
+        out.pop();
+    }
+    if !out.is_empty() {
+        out.push(String::new());
+    }
+    out.push(header);
+    out.push(approval_line);
+    let mut rebuilt = out.join(newline);
+    if had_trailing_newline || !rebuilt.is_empty() {
+        rebuilt.push_str(newline);
+    }
+    rebuilt
 }
 
 fn is_codex_missing_entry(stderr: &str) -> bool {
@@ -581,5 +723,50 @@ mod tests {
     fn upsert_codex_env_var_passthrough_returns_none_when_server_missing() {
         let input = "[mcp_servers.other]\ncommand = 'foo'\n";
         assert!(upsert_codex_env_var_passthrough(input).is_none());
+    }
+
+    #[test]
+    fn upsert_codex_tool_approval_appends_missing_tool_section() {
+        let input = concat!(
+            "[mcp_servers.renga-peers]\n",
+            "command = 'renga'\n",
+            "args = [\"mcp-peer\"]\n"
+        );
+        let output = upsert_codex_tool_approval(input, "check_messages", "approve");
+        assert!(output.contains(
+            "[mcp_servers.renga-peers.tools.check_messages]\napproval_mode = \"approve\"\n"
+        ));
+    }
+
+    #[test]
+    fn upsert_codex_tool_approval_replaces_existing_value() {
+        let input = concat!(
+            "[mcp_servers.renga-peers.tools.send_message]\n",
+            "approval_mode = \"prompt\"\n"
+        );
+        let output = upsert_codex_tool_approval(input, "send_message", "approve");
+        assert!(output.contains("approval_mode = \"approve\""));
+        assert!(!output.contains("approval_mode = \"prompt\""));
+    }
+
+    #[test]
+    fn upsert_codex_auto_approve_peer_tools_adds_auto_approve_tool_sections() {
+        let input = concat!(
+            "[mcp_servers.renga-peers]\n",
+            "command = 'renga'\n",
+            "args = [\"mcp-peer\"]\n"
+        );
+        let output = upsert_codex_auto_approve_peer_tools(input).expect("server section");
+        assert!(output.contains("[mcp_servers.renga-peers.tools.check_messages]"));
+        assert!(output.contains("[mcp_servers.renga-peers.tools.send_message]"));
+    }
+
+    #[test]
+    fn install_rejects_codex_auto_approve_flag_for_non_codex_clients_before_cli_lookup() {
+        let err =
+            install(false, McpClient::Claude, true).expect_err("flag should be rejected early");
+        assert!(err
+            .to_string()
+            .contains("--codex-auto-approve-peer-tools is only valid with --client codex"));
     }
 }

--- a/src/mcp_peer/install.rs
+++ b/src/mcp_peer/install.rs
@@ -13,6 +13,7 @@
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::fs;
 
 use anyhow::{anyhow, bail, Context, Result};
 
@@ -20,6 +21,12 @@ use super::ENV_CLIENT_KIND;
 use crate::cli::{McpAction, McpClient};
 
 const SERVER_NAME: &str = "renga-peers";
+const CODEX_PASSTHROUGH_ENV_VARS: &[&str] = &[
+    "RENGA_PANE_ID",
+    "RENGA_SOCKET",
+    "RENGA_TOKEN",
+    "RENGA_CODEX_AUTO_NUDGE",
+];
 
 /// Entry point from `main.rs` for the `renga mcp <action>` subcommand.
 pub fn run(action: &McpAction) -> Result<()> {
@@ -38,6 +45,9 @@ fn install(force: bool, client: McpClient) -> Result<()> {
 
     if let Some(existing) = find_existing_entry(client)? {
         if !force {
+            if client == McpClient::Codex {
+                ensure_codex_env_var_passthrough()?;
+            }
             println!(
                 "{SERVER_NAME} is already registered in {} → {existing}\n\
                  Re-run with `renga mcp install --client {client} --force` to overwrite with: {}",
@@ -93,6 +103,7 @@ fn install_codex(exe: &Path) -> Result<()> {
     if !status.success() {
         bail!("`codex mcp add` exited with status {status}");
     }
+    ensure_codex_env_var_passthrough()?;
     Ok(())
 }
 
@@ -277,6 +288,101 @@ fn codex_add_args(exe: &Path) -> Vec<OsString> {
     ]
 }
 
+fn ensure_codex_env_var_passthrough() -> Result<()> {
+    let path = codex_config_path()?;
+    let current = fs::read_to_string(&path)
+        .with_context(|| format!("read Codex config at {}", path.display()))?;
+    let updated = upsert_codex_env_var_passthrough(&current).ok_or_else(|| {
+        anyhow!(
+            "Codex config at {} does not contain an [{section}] section after registration",
+            path.display(),
+            section = codex_server_section_name()
+        )
+    })?;
+    if updated != current {
+        fs::write(&path, updated)
+            .with_context(|| format!("write Codex config at {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn codex_config_path() -> Result<PathBuf> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| anyhow!("could not resolve the current user's home directory"))?;
+    Ok(home.join(".codex").join("config.toml"))
+}
+
+fn codex_server_section_name() -> String {
+    format!("mcp_servers.{SERVER_NAME}")
+}
+
+fn upsert_codex_env_var_passthrough(src: &str) -> Option<String> {
+    let header = format!("[{}]", codex_server_section_name());
+    let newline = if src.contains("\r\n") { "\r\n" } else { "\n" };
+    let had_trailing_newline = src.ends_with(newline);
+    let mut out: Vec<String> = Vec::new();
+    let mut in_section = false;
+    let mut found_section = false;
+    let mut wrote_env_vars = false;
+
+    for line in src.lines() {
+        let trimmed = line.trim();
+        if !in_section {
+            if trimmed == header {
+                in_section = true;
+                found_section = true;
+            }
+            out.push(line.to_string());
+            continue;
+        }
+
+        if trimmed.starts_with('[') {
+            if !wrote_env_vars {
+                while out.last().is_some_and(|line| line.trim().is_empty()) {
+                    out.pop();
+                }
+                out.push(codex_env_vars_line());
+                out.push(String::new());
+                wrote_env_vars = true;
+            }
+            in_section = false;
+            out.push(line.to_string());
+            continue;
+        }
+
+        if trimmed.starts_with("env_vars") {
+            out.push(codex_env_vars_line());
+            wrote_env_vars = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+
+    if !found_section {
+        return None;
+    }
+    if in_section && !wrote_env_vars {
+        out.push(codex_env_vars_line());
+    }
+
+    let mut rebuilt = out.join(newline);
+    if had_trailing_newline {
+        rebuilt.push_str(newline);
+    }
+    Some(rebuilt)
+}
+
+fn codex_env_vars_line() -> String {
+    format!(
+        "env_vars = [{}]",
+        CODEX_PASSTHROUGH_ENV_VARS
+            .iter()
+            .map(|name| format!("\"{name}\""))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 fn is_codex_missing_entry(stderr: &str) -> bool {
     stderr.contains(&format!("No MCP server named '{SERVER_NAME}' found."))
 }
@@ -439,5 +545,41 @@ mod tests {
         assert!(is_cmd_script(Path::new("C:/Users/example/codex.cmd")));
         assert!(is_cmd_script(Path::new("C:/Users/example/codex.BAT")));
         assert!(!is_cmd_script(Path::new("C:/Users/example/codex.exe")));
+    }
+
+    #[test]
+    fn upsert_codex_env_var_passthrough_inserts_before_env_subtable() {
+        let input = concat!(
+            "[mcp_servers.renga-peers]\n",
+            "command = 'C:\\Users\\iwama\\.cargo\\bin\\renga.exe'\n",
+            "args = [\"mcp-peer\"]\n",
+            "\n",
+            "[mcp_servers.renga-peers.env]\n",
+            "RENGA_PEER_CLIENT_KIND = \"codex\"\n"
+        );
+        let output = upsert_codex_env_var_passthrough(input).unwrap();
+        assert!(output.contains(&format!(
+            "{}\n\n[mcp_servers.renga-peers.env]",
+            codex_env_vars_line()
+        )));
+    }
+
+    #[test]
+    fn upsert_codex_env_var_passthrough_replaces_existing_line() {
+        let input = concat!(
+            "[mcp_servers.renga-peers]\n",
+            "command = 'renga'\n",
+            "args = [\"mcp-peer\"]\n",
+            "env_vars = [\"OLD\"]\n"
+        );
+        let output = upsert_codex_env_var_passthrough(input).unwrap();
+        assert!(output.contains(&codex_env_vars_line()));
+        assert!(!output.contains("env_vars = [\"OLD\"]"));
+    }
+
+    #[test]
+    fn upsert_codex_env_var_passthrough_returns_none_when_server_missing() {
+        let input = "[mcp_servers.other]\ncommand = 'foo'\n";
+        assert!(upsert_codex_env_var_passthrough(input).is_none());
     }
 }

--- a/src/mcp_peer/mod.rs
+++ b/src/mcp_peer/mod.rs
@@ -51,6 +51,10 @@ const SERVER_NAME: &str = "renga-peers";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const ENV_PANE_ID: &str = "RENGA_PANE_ID";
 pub(crate) const ENV_CLIENT_KIND: &str = "RENGA_PEER_CLIENT_KIND";
+const ENV_CODEX_AUTO_NUDGE: &str = "RENGA_CODEX_AUTO_NUDGE";
+const CODEX_AUTO_NUDGE_TEXT: &str =
+    "renga-peers has pending messages. Run check_messages, handle them, then resume.";
+const CODEX_AUTO_NUDGE_COOLDOWN: Duration = Duration::from_secs(30);
 
 fn log_stderr(msg: &str) {
     eprintln!("[renga-mcp-peer] {msg}");
@@ -106,6 +110,7 @@ struct PeerCtx {
     client_kind: PeerClientKind,
     events: EventSink,
     inbox: InboxSink,
+    codex_auto_nudge: CodexAutoNudge,
 }
 
 /// Soft cap on the per-process lifecycle event buffer used by
@@ -178,6 +183,38 @@ fn new_inbox_sink() -> InboxSink {
 }
 
 #[derive(Clone)]
+struct CodexAutoNudge {
+    enabled: bool,
+    last_sent_at: Arc<Mutex<Option<Instant>>>,
+}
+
+impl CodexAutoNudge {
+    fn load(client_kind: PeerClientKind) -> Self {
+        Self {
+            enabled: client_kind == PeerClientKind::Codex && env_flag_enabled(ENV_CODEX_AUTO_NUDGE),
+            last_sent_at: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[cfg(test)]
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            last_sent_at: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn arm_if_ready(&self, inbox_was_empty: bool, now: Instant) -> bool {
+        let mut last_sent = self.last_sent_at.lock().unwrap_or_else(|p| p.into_inner());
+        if !should_send_codex_auto_nudge(self.enabled, inbox_was_empty, *last_sent, now) {
+            return false;
+        }
+        *last_sent = Some(now);
+        true
+    }
+}
+
+#[derive(Clone)]
 enum Mode {
     /// Running inside a renga pane with a reachable IPC endpoint.
     Connected {
@@ -198,6 +235,7 @@ impl PeerCtx {
             .ok()
             .and_then(|s| parse_client_kind(&s))
             .unwrap_or(PeerClientKind::Claude);
+        let codex_auto_nudge = CodexAutoNudge::load(client_kind);
         let pane_id = match std::env::var(ENV_PANE_ID) {
             Ok(s) => match s.parse::<usize>() {
                 Ok(v) => v,
@@ -209,6 +247,7 @@ impl PeerCtx {
                         events,
                         inbox,
                         client_kind,
+                        codex_auto_nudge,
                     };
                 }
             },
@@ -222,6 +261,7 @@ impl PeerCtx {
                     events,
                     inbox,
                     client_kind,
+                    codex_auto_nudge,
                 };
             }
         };
@@ -231,6 +271,7 @@ impl PeerCtx {
                 events,
                 inbox,
                 client_kind,
+                codex_auto_nudge,
             },
             Err(e) => PeerCtx {
                 mode: Mode::Detached {
@@ -239,6 +280,7 @@ impl PeerCtx {
                 events,
                 inbox,
                 client_kind,
+                codex_auto_nudge,
             },
         }
     }
@@ -249,6 +291,45 @@ fn parse_client_kind(raw: &str) -> Option<PeerClientKind> {
         "claude" => Some(PeerClientKind::Claude),
         "codex" => Some(PeerClientKind::Codex),
         _ => None,
+    }
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+fn should_send_codex_auto_nudge(
+    enabled: bool,
+    inbox_was_empty: bool,
+    last_sent_at: Option<Instant>,
+    now: Instant,
+) -> bool {
+    enabled
+        && inbox_was_empty
+        && last_sent_at
+            .is_none_or(|last| now.saturating_duration_since(last) >= CODEX_AUTO_NUDGE_COOLDOWN)
+}
+
+fn send_codex_auto_nudge(endpoint: &EndpointName, pane_id: usize) -> Result<()> {
+    match client::send_request(
+        endpoint,
+        &Request::Send {
+            target: PaneRef::Id(pane_id),
+            data: CODEX_AUTO_NUDGE_TEXT.to_string(),
+            append_enter: true,
+        },
+    ) {
+        Ok(Response::Ok { .. }) => Ok(()),
+        Ok(Response::Err { message, code }) => Err(anyhow!(
+            "renga refused Codex auto-nudge: {}",
+            fmt_code(&message, &code)
+        )),
+        Ok(other) => Err(anyhow!(
+            "unexpected IPC response for Codex auto-nudge: {other:?}"
+        )),
+        Err(e) => Err(e).context("send Codex auto-nudge"),
     }
 }
 
@@ -280,6 +361,26 @@ fn err_response(id: &Value, code: i32, message: &str) -> Value {
 
 fn tool_text_result(text: &str) -> Value {
     json!({ "content": [ { "type": "text", "text": text } ], "isError": false })
+}
+
+fn queue_pull_message(
+    inbox: &InboxSink,
+    auto_nudge: &CodexAutoNudge,
+    endpoint: &EndpointName,
+    pane_id: usize,
+    message: QueuedPeerMessage,
+) {
+    let should_nudge = {
+        let mut q = inbox.lock().unwrap_or_else(|p| p.into_inner());
+        let was_empty = q.is_empty();
+        q.push_back(message);
+        auto_nudge.arm_if_ready(was_empty, Instant::now())
+    };
+    if should_nudge {
+        if let Err(e) = send_codex_auto_nudge(endpoint, pane_id) {
+            log_stderr(&format!("failed to send Codex auto-nudge: {e}"));
+        }
+    }
 }
 
 // ── channel notification (the whole point of #97) ─────────────
@@ -2155,6 +2256,7 @@ fn spawn_inbox_subscriber(ctx: PeerCtx) {
     let endpoint_clone = endpoint.clone();
     let sink = ctx.events.clone();
     let inbox = ctx.inbox.clone();
+    let auto_nudge = ctx.codex_auto_nudge.clone();
     let client_kind = ctx.client_kind;
     thread::Builder::new()
         .name("renga-mcp-peer-inbox".into())
@@ -2191,8 +2293,7 @@ fn spawn_inbox_subscriber(ctx: PeerCtx) {
                         ..
                     } if target_pane == pane_id => {
                         if client_kind.receive_mode() == ipc::PeerReceiveMode::Pull {
-                            let mut q = inbox.lock().unwrap_or_else(|p| p.into_inner());
-                            q.push_back(QueuedPeerMessage {
+                            queue_pull_message(&inbox, &auto_nudge, &endpoint_clone, pane_id, QueuedPeerMessage {
                                 from_id: from_pane.to_string(),
                                 from_name: from_name.clone(),
                                 from_kind,
@@ -2225,8 +2326,7 @@ fn spawn_inbox_subscriber(ctx: PeerCtx) {
                             "renga event bus dropped {count} event(s) before they reached this peer client. A peer message may have been lost — consider asking the sender to retry."
                         );
                         if client_kind.receive_mode() == ipc::PeerReceiveMode::Pull {
-                            let mut q = inbox.lock().unwrap_or_else(|p| p.into_inner());
-                            q.push_back(QueuedPeerMessage {
+                            queue_pull_message(&inbox, &auto_nudge, &endpoint_clone, pane_id, QueuedPeerMessage {
                                 from_id: "renga".to_string(),
                                 from_name: Some("renga runtime".to_string()),
                                 from_kind: None,
@@ -2270,6 +2370,46 @@ fn should_buffer_for_poll(event: &ipc::Event) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static L: OnceLock<Mutex<()>> = OnceLock::new();
+        L.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        name: String,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn clear(name: &str) -> Self {
+            let prev = std::env::var_os(name);
+            std::env::remove_var(name);
+            Self {
+                name: name.to_string(),
+                prev,
+            }
+        }
+
+        fn set(name: &str, value: &str) -> Self {
+            let prev = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self {
+                name: name.to_string(),
+                prev,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(&self.name, v),
+                None => std::env::remove_var(&self.name),
+            }
+        }
+    }
 
     #[test]
     fn parse_target_defaults_to_focused_on_none() {
@@ -3288,6 +3428,7 @@ mod tests {
             client_kind: PeerClientKind::Claude,
             events: new_event_sink(),
             inbox: new_inbox_sink(),
+            codex_auto_nudge: CodexAutoNudge::disabled(),
         }
     }
 
@@ -3300,6 +3441,7 @@ mod tests {
             client_kind,
             events,
             inbox: new_inbox_sink(),
+            codex_auto_nudge: CodexAutoNudge::disabled(),
         }
     }
 
@@ -3337,6 +3479,62 @@ mod tests {
         assert_eq!(b, 2);
         assert_eq!(buf.last_seq, 2);
         assert_eq!(buf.events.len(), 2);
+    }
+
+    #[test]
+    fn env_flag_enabled_treats_non_empty_non_zero_as_true() {
+        assert!(!env_flag_enabled("__RENGA_TEST_UNSET__"));
+        let _lock = env_lock().lock().unwrap();
+
+        {
+            let _guard = EnvGuard::clear(ENV_CODEX_AUTO_NUDGE);
+            assert!(!env_flag_enabled(ENV_CODEX_AUTO_NUDGE));
+        }
+        {
+            let _guard = EnvGuard::set(ENV_CODEX_AUTO_NUDGE, "");
+            assert!(!env_flag_enabled(ENV_CODEX_AUTO_NUDGE));
+        }
+        {
+            let _guard = EnvGuard::set(ENV_CODEX_AUTO_NUDGE, "0");
+            assert!(!env_flag_enabled(ENV_CODEX_AUTO_NUDGE));
+        }
+        {
+            let _guard = EnvGuard::set(ENV_CODEX_AUTO_NUDGE, "1");
+            assert!(env_flag_enabled(ENV_CODEX_AUTO_NUDGE));
+        }
+        {
+            let _guard = EnvGuard::set(ENV_CODEX_AUTO_NUDGE, "yes");
+            assert!(env_flag_enabled(ENV_CODEX_AUTO_NUDGE));
+        }
+    }
+
+    #[test]
+    fn codex_auto_nudge_only_enables_for_codex_clients() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set(ENV_CODEX_AUTO_NUDGE, "1");
+
+        assert!(!CodexAutoNudge::load(PeerClientKind::Claude).enabled);
+        assert!(CodexAutoNudge::load(PeerClientKind::Codex).enabled);
+    }
+
+    #[test]
+    fn should_send_codex_auto_nudge_requires_empty_to_non_empty_transition_and_cooldown() {
+        let now = Instant::now();
+        assert!(!should_send_codex_auto_nudge(false, true, None, now));
+        assert!(!should_send_codex_auto_nudge(true, false, None, now));
+        assert!(should_send_codex_auto_nudge(true, true, None, now));
+        assert!(!should_send_codex_auto_nudge(
+            true,
+            true,
+            Some(now - Duration::from_secs(5)),
+            now
+        ));
+        assert!(should_send_codex_auto_nudge(
+            true,
+            true,
+            Some(now - CODEX_AUTO_NUDGE_COOLDOWN),
+            now
+        ));
     }
 
     #[test]

--- a/src/mcp_peer/mod.rs
+++ b/src/mcp_peer/mod.rs
@@ -53,7 +53,7 @@ const ENV_PANE_ID: &str = "RENGA_PANE_ID";
 pub(crate) const ENV_CLIENT_KIND: &str = "RENGA_PEER_CLIENT_KIND";
 const ENV_CODEX_AUTO_NUDGE: &str = "RENGA_CODEX_AUTO_NUDGE";
 const CODEX_AUTO_NUDGE_TEXT: &str =
-    "renga-peers has pending messages. Run check_messages, handle them, then resume.";
+    "renga-peers may have pending messages. Run check_messages; if it returns 0, this nudge is stale and can be ignored.";
 const CODEX_AUTO_NUDGE_COOLDOWN: Duration = Duration::from_secs(30);
 
 fn log_stderr(msg: &str) {
@@ -312,25 +312,113 @@ fn should_send_codex_auto_nudge(
             .is_none_or(|last| now.saturating_duration_since(last) >= CODEX_AUTO_NUDGE_COOLDOWN)
 }
 
-fn send_codex_auto_nudge(endpoint: &EndpointName, pane_id: usize) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexAutoNudgeDelivery {
+    SubmitNow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexAutoNudgeChunk {
+    data: String,
+    append_enter: bool,
+}
+
+fn codex_auto_nudge_chunks(delivery: CodexAutoNudgeDelivery) -> Vec<CodexAutoNudgeChunk> {
+    match delivery {
+        // Codex on Windows accepted the nudge only when the submit keys
+        // arrived as a second write after the text had already landed in
+        // the composer. Mirror that exact sequence here, but express the
+        // second step as a dedicated Enter so renga writes the same bytes
+        // as the higher-level send_keys path.
+        CodexAutoNudgeDelivery::SubmitNow => vec![
+            CodexAutoNudgeChunk {
+                data: CODEX_AUTO_NUDGE_TEXT.to_string(),
+                append_enter: false,
+            },
+            CodexAutoNudgeChunk {
+                data: "\r".to_string(),
+                append_enter: false,
+            },
+        ],
+    }
+}
+
+fn codex_auto_nudge_delivery_from_screen(screen_text: &str) -> CodexAutoNudgeDelivery {
+    // When Codex is busy its status bar may advertise "tab to queue
+    // message", but queueing the nudge defers `check_messages` until
+    // the current task ends. That makes simultaneous peer pings look
+    // flaky because only idle panes reply promptly. Always submit the
+    // nudge now so pull-based peers drain their inbox immediately.
+    let _ = screen_text;
+    CodexAutoNudgeDelivery::SubmitNow
+}
+
+fn detect_codex_auto_nudge_delivery(
+    endpoint: &EndpointName,
+    pane_id: usize,
+) -> CodexAutoNudgeDelivery {
     match client::send_request(
         endpoint,
-        &Request::Send {
+        &Request::Inspect {
             target: PaneRef::Id(pane_id),
-            data: CODEX_AUTO_NUDGE_TEXT.to_string(),
-            append_enter: true,
+            lines: Some(8),
+            include_cursor: false,
         },
     ) {
-        Ok(Response::Ok { .. }) => Ok(()),
-        Ok(Response::Err { message, code }) => Err(anyhow!(
-            "renga refused Codex auto-nudge: {}",
-            fmt_code(&message, &code)
-        )),
-        Ok(other) => Err(anyhow!(
-            "unexpected IPC response for Codex auto-nudge: {other:?}"
-        )),
-        Err(e) => Err(e).context("send Codex auto-nudge"),
+        Ok(Response::Ok { data }) => codex_auto_nudge_delivery_from_screen(
+            data.get("text").and_then(|v| v.as_str()).unwrap_or(""),
+        ),
+        Ok(other) => {
+            log_stderr(&format!(
+                "unexpected IPC response while probing Codex queue mode: {other:?}"
+            ));
+            CodexAutoNudgeDelivery::SubmitNow
+        }
+        Err(e) => {
+            log_stderr(&format!(
+                "failed to inspect Codex pane before auto-nudge: {e}"
+            ));
+            CodexAutoNudgeDelivery::SubmitNow
+        }
     }
+}
+
+fn send_codex_auto_nudge(endpoint: &EndpointName, pane_id: usize) -> Result<()> {
+    let delivery = detect_codex_auto_nudge_delivery(endpoint, pane_id);
+    let chunks = codex_auto_nudge_chunks(delivery);
+    let chunk_count = chunks.len();
+    for (idx, chunk) in chunks.into_iter().enumerate() {
+        match client::send_request(
+            endpoint,
+            &Request::Send {
+                target: PaneRef::Id(pane_id),
+                data: chunk.data,
+                append_enter: chunk.append_enter,
+            },
+        ) {
+            Ok(Response::Ok { .. }) => {}
+            Ok(Response::Err { message, code }) => {
+                return Err(anyhow!(
+                    "renga refused Codex auto-nudge: {}",
+                    fmt_code(&message, &code)
+                ));
+            }
+            Ok(other) => {
+                return Err(anyhow!(
+                    "unexpected IPC response for Codex auto-nudge: {other:?}"
+                ));
+            }
+            Err(e) => return Err(e).context("send Codex auto-nudge"),
+        }
+        if idx + 1 < chunk_count {
+            // Codex on Windows appears to collapse back-to-back PTY writes
+            // into a single "typed text" burst, which leaves the submit
+            // keys inert. A small gap makes the second write behave like a
+            // real follow-up keypress.
+            std::thread::sleep(Duration::from_millis(75));
+        }
+    }
+    Ok(())
 }
 
 // ── stdio JSON-RPC frame plumbing ─────────────────────────────
@@ -430,7 +518,11 @@ calling send_message with their from_id.\n\n"
         PeerClientKind::Codex => {
             "IMPORTANT: This client uses pull-based message receipt. Call check_messages at the start \
 of a turn and at reasonable checkpoints during longer work. If messages are waiting, respond \
-promptly with send_message before resuming your prior task.\n\n"
+promptly with send_message before resuming your prior task.\n\n\
+Treat the auto-nudge text as best-effort only: if the screen says there may be pending peer \
+messages but check_messages returns 0, the nudge is stale and can be ignored.\n\n\
+MCP approvals in Codex are pane-local. On a newly launched pane, the first check_messages and \
+send_message calls may need approval before peer messaging becomes reliable.\n\n"
         }
     };
     format!(
@@ -3535,6 +3627,44 @@ mod tests {
             Some(now - CODEX_AUTO_NUDGE_COOLDOWN),
             now
         ));
+    }
+
+    #[test]
+    fn codex_auto_nudge_delivery_submits_even_when_status_bar_mentions_queueing() {
+        let screen =
+            "\n• Working (48s • esc to interrupt)\n\n  tab to queue message68% context left\n";
+        assert_eq!(
+            codex_auto_nudge_delivery_from_screen(screen),
+            CodexAutoNudgeDelivery::SubmitNow
+        );
+    }
+
+    #[test]
+    fn codex_auto_nudge_delivery_submits_when_queue_hint_absent() {
+        let screen = "› ready for input\n\n  enter to send";
+        assert_eq!(
+            codex_auto_nudge_delivery_from_screen(screen),
+            CodexAutoNudgeDelivery::SubmitNow
+        );
+    }
+
+    #[test]
+    fn codex_auto_nudge_submit_path_uses_separate_enter_send() {
+        let chunks = codex_auto_nudge_chunks(CodexAutoNudgeDelivery::SubmitNow);
+        assert_eq!(
+            chunks,
+            vec![
+                CodexAutoNudgeChunk {
+                    data: CODEX_AUTO_NUDGE_TEXT.to_string(),
+                    append_enter: false,
+                },
+                CodexAutoNudgeChunk {
+                    data: "\r".to_string(),
+                    append_enter: false,
+                }
+            ],
+            "submit path should split text and CR into separate sends"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add opt-in Codex auto-nudge in `renga mcp-peer` for pull-based peer inbox messages
- pass `RENGA_CODEX_AUTO_NUDGE` through the Codex MCP registration and repair `env_vars` insertion logic
- document how to enable and troubleshoot the feature in the English/Japanese README and peer-messaging docs

## Testing

- `cargo test mcp_peer -- --nocapture`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`

Closes #184.
