### PR TITLE
Make Codex approval patch opt-in

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -247,6 +247,14 @@ renga mcp install --client codex   # Codex peer も使う場合
 
 同じ登録を複数回実行しても安全で、既に登録があれば内容を表示して止まります。renga をアップグレードしてバイナリのパスが変わったときだけ `--force` で上書きしてください。外したいときは `renga mcp uninstall --client ...`、今どう登録されているかは `renga mcp status --client ...` で確認できます。
 
+Codex では、既定の install は client CLI の正規登録経路を尊重しつつ、peer messaging に必要な最小限の `env_vars` passthrough だけを補正します。`check_messages` と `send_message` も auto-approve 寄りにしたい場合は、明示的に opt-in してください。
+
+```bash
+renga mcp install --client codex --codex-auto-approve-peer-tools
+```
+
+このフラグは `send_keys` や pane 操作系のような、より強いツールまでは自動承認しません。
+
 ### Claude Code / Codex をメッセージング対応で起動する
 
 配送方式は client ごとに違います。
@@ -328,6 +336,7 @@ _イベント監視:_
 - **相手に送ったメッセージが `<channel>` タグで表示されない** — 起動時のフラグ `--dangerously-load-development-channels server:renga-peers` を付け忘れています。`claude` と打つ代わりに `Alt+P` を使えばフラグ付きのコマンドが挿入されるので事故りにくくなります。
 - **Codex に送ったのに反応がない** — Codex は pull 型です。メッセージは `check_messages` が呼ばれるまで queue に残ります。Codex 側の prompt / workflow が turn 開始時と長作業の節目で `check_messages` を呼ぶ前提になっているか確認してください。
 - **Codex の auto-nudge が動かない** — 既定では無効です。`renga mcp install --client codex` を実行して `RENGA_CODEX_AUTO_NUDGE` の passthrough を入れた上で、renga のペイン内から `RENGA_CODEX_AUTO_NUDGE=1` を設定した親シェルで `codex` を起動してください。
+- **新しい Codex pane で `check_messages` / `send_message` の承認がまた出る** — Codex の承認は pane-local に振る舞うことがあります。`renga mcp install --client codex --codex-auto-approve-peer-tools` で安全な peer messaging 系の承認を事前設定できますが、Codex のバージョンや実行形態によっては、新しい pane で一度だけ warm-up 承認が必要です。
 - **`send_keys` が効いていないように見える** — `send_keys` は target ペインの PTY に生の入力バイトを書き込むだけで、帯域外の「承認」操作ではありません。まず `inspect_pane(target=..., lines=20)` で本当に入力待ちか確認し、レイアウトが動く運用ではフォーカス推測ではなく安定した pane `name` を target に使ってください。
 - **`poll_events` が想定より早く `events: []` を返す** — `types=[...]` フィルタは返却結果を絞るだけで、非一致イベントでも long-poll は解除されて `next_since` は前進します。返ってきた cursor でそのまま再 poll してください。`events_dropped` が来た場合だけ、1 回 `list_panes` で再同期すると安全です。
 - **renga をアップグレードしたら繋がらなくなった** — 登録されているバイナリのパスが古いです。`renga mcp install --client claude --force` や `renga mcp install --client codex --force` で今の `renga` に更新してください。

--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ renga mcp install --client codex   # if you want Codex peers too
 
 Registers the running `renga` binary as the `renga-peers` MCP server in each selected client's user config. Re-running is idempotent; pass `--force` to overwrite after a renga upgrade. `renga mcp uninstall --client ...` and `renga mcp status --client ...` are the inverse and introspection commands.
 
+For Codex, the default install keeps the client CLI as the primary registration path and only patches the minimum `env_vars` passthrough needed for peer messaging. If you also want renga to preconfigure `check_messages` and `send_message` to auto-approve where Codex supports it, opt in explicitly:
+
+```bash
+renga mcp install --client codex --codex-auto-approve-peer-tools
+```
+
+That flag intentionally does not auto-approve riskier tools such as `send_keys` or pane-control actions.
+
 ### Usage — launch Claude Code with the peer channel
 
 Peer delivery is client-specific:
@@ -323,6 +331,7 @@ _Event monitoring:_
 - **Peer messages don't render as `<channel>` tags** — You probably forgot the `--dangerously-load-development-channels server:renga-peers` flag. Prefer `Alt+P` over typing `claude` directly.
 - **A message sent to Codex seems to do nothing** — Codex is pull-based. The message is queued until Codex calls `check_messages`. Make sure the Codex prompt or workflow checks its inbox at turn start and at reasonable checkpoints during longer work.
 - **Codex auto-nudge does not fire** — The feature is off by default. Run `renga mcp install --client codex` so the MCP registration includes `RENGA_CODEX_AUTO_NUDGE` passthrough, then launch `codex` from a renga pane with `RENGA_CODEX_AUTO_NUDGE=1` in the parent shell environment.
+- **A new Codex pane asks for `check_messages` / `send_message` approval again** — Codex approvals can still behave pane-locally. `renga mcp install --client codex --codex-auto-approve-peer-tools` preconfigures the safe peer-messaging approvals, but a brand-new pane may still need one warm-up approval depending on the Codex version and runtime.
 - **`send_keys` seems to do nothing** — `send_keys` writes raw bytes to the target pane's PTY; it does not grant approval out-of-band. Snapshot first with `inspect_pane(target=..., lines=20)` to confirm the pane is actually waiting for input, and prefer a stable pane `name` over guessing by focus in changing layouts.
 - **`poll_events` returns `events: []` before the timeout you expected** — A `types=[...]` filter only narrows what is returned; a non-matching event can still wake the long-poll and advance `next_since`. Re-issue the call with the returned cursor. If you receive `events_dropped`, re-sync once with `list_panes`.
 - **Upgrading renga?** — Re-run `renga mcp install --client claude --force` and/or `renga mcp install --client codex --force` so each registered client points at your new binary.


### PR DESCRIPTION
## Summary
- keep the default Codex MCP install path client-CLI-led and move the check_messages / send_message approval patch behind --codex-auto-approve-peer-tools
- preserve the Codex auto-nudge stabilization and document pane-local approval / stale nudge caveats in the peer-messaging docs
- add README coverage for the new install flag so users do not have to discover it only from the full docs

## Testing
- cargo test

## Context
- follow-up to #185, which merged before these reviewed commits were split into a new PR