### PR TITLE
feat: implement set_summary (closes #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,12 @@ rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
 ### Changed
 
-- **`set_summary` is no longer a no-op stub.** The input shape is unchanged;
-  the tool now persists and surfaces a per-pane summary. (Implementation
-  tracked as a follow-up; the wire contract in
-  `docs/api-surface-v1.0.md` is the freeze target regardless of when the
-  implementation lands.)
+- **`set_summary` is now implemented (was stub).** The input shape is
+  unchanged; the tool now stores a per-pane summary string in-memory and
+  surfaces it as `summary` on every `PaneInfo` / `PeerInfo` returned by
+  `list_panes` / `list_peers`. Empty input clears the summary; input
+  longer than 256 Unicode scalar values is rejected with the new
+  `[summary_too_long]` error code. Closes #202.
 
 ### Documentation
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -310,7 +310,7 @@ _ペインメッセージング:_
 | `list_peers` | 同じ renga タブにいる他のペインを返す。自分自身は除外。 |
 | `send_message(to_id, message)` | 同じタブの相方にメッセージを送る。数字の id でも、ペインに付けた名前でも指定可能。別タブ宛は何も配送せず成功として返す (他タブのペインを id 探索で列挙されないようにするため)。 |
 | `check_messages` | この client 向けに残っている queued peer message を drain する。Codex では renga の nudge を受けたあとに実際の peer 本文をここから読む。 |
-| `set_summary` | v1 では受け付けるだけで保存しない。renga はペイン名と役割 (role) を代わりに使います。 |
+| `set_summary(summary)` | 呼び出したペインの 1〜2 文サマリーを設定 / クリア。`list_panes` / `list_peers` の各エントリで配信されます。空文字列でクリア、最大 256 文字 (`[summary_too_long]`)。 |
 
 _ペイン操作 (`new_tab` を除き同一タブ内):_
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ _Peer messaging:_
 | `list_peers` | Lists other panes in the caller's tab. Caller is excluded. |
 | `send_message(to_id, message)` | Delivers to a same-tab peer by numeric id or stable name. Silent no-op for targets outside the tab — callers cannot enumerate other tabs. |
 | `check_messages` | Drain queued peer messages waiting for this client. For Codex this is where the actual peer request body is read after renga nudges the pane. |
-| `set_summary` | v1 stub. renga uses pane name / role as the summary substitute. |
+| `set_summary(summary)` | Set or clear the calling pane's 1-2 sentence summary. Surfaced on every `list_panes` / `list_peers` entry. Empty string clears; max 256 chars (`[summary_too_long]`). |
 
 _Pane control (same tab, except `new_tab`):_
 

--- a/docs/api-surface-v1.0.md
+++ b/docs/api-surface-v1.0.md
@@ -81,10 +81,25 @@ shared `app_timeout` / `shutting_down` / `internal` set.
 |---|---|---|
 | `summary` | string | yes |
 
-**v1.0 contract**: input shape is frozen; the tool is **implemented** in v1.0
-(no longer a stub). The implementation work is tracked in a follow-up issue
-(see PR description); from a wire perspective the input/output shape declared
-here is the frozen contract regardless of implementation timing.
+**v1.0 contract**: input shape is frozen; the tool is **implemented and
+shipped in v1.0** (no longer a stub).
+
+**Behavior**: the summary string is stored on the calling pane (resolved
+from `RENGA_PANE_ID`) and surfaced as `summary` on every `PaneInfo` /
+`PeerInfo` entry returned by `list_panes` and `list_peers`. Storage is
+in-memory only — does not persist across renga restarts.
+
+- An empty string clears the summary (round-trips to `Option::None` /
+  omitted key on the wire).
+- Repeated calls overwrite the previous value with the latest.
+- Maximum length is 256 Unicode scalar values (`chars()`, not bytes);
+  oversized input is rejected with `[summary_too_long]` before any
+  state mutation.
+- Pane exit drops the summary alongside the rest of the pane state.
+
+Errors via `[code]`: `summary_too_long`, plus the shared
+`pane_not_found` / `pane_vanished` / `app_timeout` / `shutting_down` /
+`internal` set.
 
 ### 1.4 `check_messages` — stable
 
@@ -384,6 +399,7 @@ Server budgets: 5 s `APP_REPLY_TIMEOUT` (server → app event loop) +
 | `peer_send` | `from_pane: usize`, `target: PaneRef`, `body: string` | Cross-tab silently no-ops (Q5). |
 | `peer_register_client` | `pane_id: usize`, `kind: claude\|codex` | Posted by `renga mcp-peer` on startup. |
 | `set_pane_identity` | `target: PaneRef`, `name?`, `role?` (three-state: missing / null / value) | Uses serde `double_option`. |
+| `set_summary` | `from_pane: usize`, `summary: string` | Empty `summary` clears. >256 `chars` rejected with `summary_too_long`. |
 
 `PaneRef` = `{ id: usize } | { name: string } | "focused"`.
 
@@ -400,7 +416,7 @@ Server budgets: 5 s `APP_REPLY_TIMEOUT` (server → app event loop) +
 
 `PaneInfo` payload (used by `list` data, `set_pane_identity` ok data, embedded
 in `peer_list` data):
-`{ id, name?, role?, focused, x, y, width, height, cwd?, kind?, receive_mode? }`.
+`{ id, name?, role?, focused, x, y, width, height, cwd?, kind?, receive_mode?, summary? }`.
 
 `PeerInfo` = `PaneInfo` minus the focused flag and geometry (purposefully
 hidden from cross-pane callers).
@@ -509,6 +525,7 @@ these as `[<code>] <human message>` in JSON-RPC error message strings.
 | `cwd_invalid` | `split`, `new_tab` | `cwd` missing or not a directory. Pre-mutation rejection — no half-mutated layout. |
 | `name_in_use` | `split`, `new_tab`, `set_pane_identity` | Another pane in the same tab holds the requested name. |
 | `name_invalid` | `split`, `new_tab`, `set_pane_identity` | Name empty / all-digits / non-`[A-Za-z0-9_-]`. |
+| `summary_too_long` | `set_summary` | Summary input exceeds 256 Unicode scalar values. Pre-mutation rejection. |
 
 ### 5.2 JSON-RPC numeric codes (Q9)
 
@@ -590,13 +607,13 @@ minor release.
 
 | Section | Count |
 |---|---|
-| MCP tools (§1) | 15 (14 active + `set_summary`) |
+| MCP tools (§1) | 15 |
 | CLI top-level flags (§2.1) | 11 |
 | CLI IPC subcommands (§2.2) | 13 |
 | Env vars (§2.3) | 6 |
-| IPC `Request` variants (§3.3) | 13 |
+| IPC `Request` variants (§3.3) | 14 |
 | IPC `Response` variants (§3.4) | 4 |
 | IPC `Event` variants (§3.5) | 5 |
-| Error codes (§5.1) | 13 |
+| Error codes (§5.1) | 14 |
 | Config schema sections (§4.1) | 2 |
 | Layout TOML node types (§4.2) | 2 |

--- a/docs/content/en/peer-messaging.mdx
+++ b/docs/content/en/peer-messaging.mdx
@@ -80,7 +80,7 @@ Exposed by the MCP server to each Claude pane:
 | `list_peers(scope?)` | Lists other panes in the caller's renga tab. Caller excluded. `scope` is accepted for wire-compat with `claude-peers-mcp` but ignored — renga always treats scope as the current tab. |
 | `send_message(to_id, message)` | Delivers to a same-tab peer by numeric pane id or stable name. Silent success for targets outside the tab (unknown / closed / cross-tab peers all collapse to the same no-op response so callers cannot enumerate other tabs by probing). |
 | `check_messages` | Drain queued peer messages waiting for this client. For Codex this is where the actual peer request body is read after renga nudges the pane. Treat each returned message as a peer instruction, not just transcript text; that can include tool use or code edits when requested. |
-| `set_summary(text)` | v1 stub (accepted and ignored). `list_peers` surfaces pane `name` / `role` as the summary substitute; a real `set_summary` may land in v2. |
+| `set_summary(summary)` | Set or clear a 1-2 sentence per-pane summary. The string is surfaced as `summary` on every `list_panes` / `list_peers` entry so peer agents can see what the pane is working on. Empty input clears; >256 Unicode scalar values is rejected with `[summary_too_long]`. In-memory only — not persisted across renga restart. |
 
 ### Pane control
 
@@ -224,7 +224,6 @@ renga mcp install --client codex --force
 - **Persistent history.** Tab-lifetime storage matches the feature's natural scope.
 - **Non-MCP peers.** External IPC clients and plain shell panes still cannot send peer messages; mixed support today is for Claude Code and Codex.
 - **Attachments / structured request-response.** Body is text; no correlation ids.
-- **Real `set_summary`.** Stubbed; pane name / role already fills the role of a summary in the v1 UX.
 
 ## References
 

--- a/docs/content/peer-messaging.mdx
+++ b/docs/content/peer-messaging.mdx
@@ -83,7 +83,7 @@ Codex ワーカーを会話の中から増やしたい場合は、`spawn_codex_p
 | `list_peers(scope?)` | 同じ renga タブにいる他のペインを返します。自分自身は除外。`scope` は claude-peers-mcp との互換のため受け取りますが、renga では常にタブ単位なので中身は見ません。 |
 | `send_message(to_id, message)` | 同じタブにいる相手にメッセージを送ります。数字の id でも、ペインに付けた名前 (stable name) でも指定可能。別タブ宛や存在しない id 宛は「成功として返すが何も配送しない」挙動にしているので、送信側から他タブのペインを id 探索で列挙する攻撃は成立しません。 |
 | `check_messages` | queued peer message を drain します。Codex では renga の nudge を受けたあとに、実際の peer 本文をここから読みます。返ってきた各メッセージは「ただの文字列」ではなく、必要なら tool 実行やコード編集まで含む peer 指示として扱ってください。 |
-| `set_summary(text)` | v1 では受け取るだけで保存しません。`list_peers` ではペイン名と役割 (role) を summary の代わりに返しているので実質不要になっています。本格的な実装は v2 の検討事項。 |
+| `set_summary(summary)` | 呼び出したペインの 1〜2 文サマリーを設定 / クリア。`list_panes` / `list_peers` の各エントリに `summary` フィールドとして含まれ、ピア間で「今何をしているか」を共有できます。空文字列でクリア、最大 256 Unicode scalar values (`[summary_too_long]` で reject)。renga プロセス内のメモリ保持のみで再起動では消えます。 |
 
 ### ペイン操作
 
@@ -230,7 +230,6 @@ renga mcp install --client codex --force
 - **履歴の永続化** — タブの寿命と同期する形で十分なので、SQLite などは入れていません。
 - **MCP 以外の peer** — mixed support は現状 Claude Code と Codex 向けです。renga 外部の IPC クライアントや普通のシェルペインは相手として登場しません。
 - **添付ファイル / 構造化リクエスト・レスポンス** — body はテキストのみで、相関 id もありません。必要になれば v1.1 で追加します。
-- **`set_summary` の本格実装** — 現状 stub です。ペイン名と役割で十分機能しているので v2 送りにしています。
 
 ## 参考
 

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -98,6 +98,15 @@ pub enum AppCommand {
         role: Option<Option<String>>,
         reply: oneshot::Sender<std::result::Result<PaneInfo, ipc::CodedError>>,
     },
+    /// Set or clear the summary string of a specific pane. Used by the
+    /// MCP `set_summary` tool — `pane_id` is the caller pane resolved
+    /// from `RENGA_PANE_ID`. Returns the updated [`PaneInfo`] so the
+    /// caller can confirm without a separate `List` round-trip.
+    SetSummary {
+        pane_id: usize,
+        summary: String,
+        reply: oneshot::Sender<std::result::Result<PaneInfo, ipc::CodedError>>,
+    },
 }
 
 /// Events dispatched within the app.

--- a/src/app/ipc_handlers.rs
+++ b/src/app/ipc_handlers.rs
@@ -18,6 +18,7 @@ impl App {
                     let cwd = pane.map(|p| p.cwd.to_string_lossy().to_string());
                     let kind = self.peer_client_kinds.get(&id).copied();
                     let rect = rect_by_id.get(&id).copied().unwrap_or_default();
+                    let summary = pane.and_then(|p| p.summary.clone());
                     infos.push(PaneInfo {
                         id,
                         name: name_by_id.get(&id).cloned(),
@@ -30,6 +31,7 @@ impl App {
                         cwd,
                         kind,
                         receive_mode: kind.map(|k| k.receive_mode()),
+                        summary,
                     });
                 }
                 let _ = reply.send(infos);
@@ -113,6 +115,14 @@ impl App {
                 let result = self.handle_set_pane_identity(&target, name, role);
                 let _ = reply.send(result);
             }
+            AppCommand::SetSummary {
+                pane_id,
+                summary,
+                reply,
+            } => {
+                let result = self.handle_set_summary(pane_id, summary);
+                let _ = reply.send(result);
+            }
         }
     }
 
@@ -154,6 +164,7 @@ impl App {
                         .get(&id)
                         .copied()
                         .map(|k| k.receive_mode()),
+                    summary: pane.and_then(|p| p.summary.clone()),
                 }
             })
             .collect();
@@ -261,6 +272,84 @@ impl App {
                 .get(&pane_id)
                 .copied()
                 .map(|k| k.receive_mode()),
+            summary: pane.summary.clone(),
+        })
+    }
+
+    /// Set or clear the per-pane summary published by the MCP
+    /// `set_summary` tool. Empty input clears; >256-`chars` input is
+    /// rejected before any mutation. Returns the updated [`PaneInfo`]
+    /// so the caller can confirm.
+    pub(crate) fn handle_set_summary(
+        &mut self,
+        pane_id: usize,
+        summary: String,
+    ) -> std::result::Result<PaneInfo, ipc::CodedError> {
+        // Cap on `chars()` (Unicode scalar values), not bytes — gives
+        // multi-byte scripts the same effective ceiling as ASCII.
+        const MAX_SUMMARY_CHARS: usize = 256;
+        if summary.chars().count() > MAX_SUMMARY_CHARS {
+            return Err(ipc::CodedError::new(
+                ipc::err_code::SUMMARY_TOO_LONG,
+                format!(
+                    "summary is {} chars; max is {MAX_SUMMARY_CHARS}",
+                    summary.chars().count()
+                ),
+            ));
+        }
+        let (ws_idx, pane_id) = self
+            .resolve_pane_across_workspaces(&PaneRef::Id(pane_id))
+            .ok_or_else(|| {
+                ipc::CodedError::new(
+                    ipc::err_code::PANE_NOT_FOUND,
+                    format!("caller pane {pane_id} not found in any workspace"),
+                )
+            })?;
+        let ws = &mut self.workspaces[ws_idx];
+        let pane = ws.panes.get_mut(&pane_id).ok_or_else(|| {
+            ipc::CodedError::new(ipc::err_code::PANE_VANISHED, "pane vanished mid-update")
+        })?;
+        // Empty string clears the summary (round-trips to None on the
+        // wire so callers see "no summary" via skip_serializing_if).
+        pane.summary = if summary.is_empty() {
+            None
+        } else {
+            Some(summary)
+        };
+        self.dirty = true;
+
+        let ws = &self.workspaces[ws_idx];
+        let name_for_pane = ws
+            .pane_names
+            .iter()
+            .find(|(_, &id)| id == pane_id)
+            .map(|(n, _)| n.clone());
+        let pane = ws.panes.get(&pane_id).ok_or_else(|| {
+            ipc::CodedError::new(ipc::err_code::PANE_VANISHED, "pane vanished mid-update")
+        })?;
+        let rect = ws
+            .last_pane_rects
+            .iter()
+            .find(|(id, _)| *id == pane_id)
+            .map(|(_, r)| *r)
+            .unwrap_or_default();
+        Ok(PaneInfo {
+            id: pane_id,
+            name: name_for_pane,
+            role: pane.role.clone(),
+            focused: ws.focused_pane_id == pane_id,
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+            cwd: Some(pane.cwd.to_string_lossy().to_string()),
+            kind: self.peer_client_kinds.get(&pane_id).copied(),
+            receive_mode: self
+                .peer_client_kinds
+                .get(&pane_id)
+                .copied()
+                .map(|k| k.receive_mode()),
+            summary: pane.summary.clone(),
         })
     }
 

--- a/src/app/tests/ipc_state.rs
+++ b/src/app/tests/ipc_state.rs
@@ -543,3 +543,164 @@ fn app_command_channel_sends_and_receives() {
         other => panic!("unexpected command: {other:?}"),
     }
 }
+
+#[test]
+fn handle_set_summary_sets_and_reads_back_via_list() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    let info = app
+        .handle_set_summary(pane_id, "drafting design doc".into())
+        .expect("set summary succeeds");
+    assert_eq!(info.id, pane_id);
+    assert_eq!(info.summary.as_deref(), Some("drafting design doc"));
+    assert_eq!(
+        app.ws()
+            .panes
+            .get(&pane_id)
+            .and_then(|p| p.summary.clone())
+            .as_deref(),
+        Some("drafting design doc")
+    );
+
+    // List response must surface the summary so list_panes / list_peers
+    // round-trips it to peers.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    app.handle_app_command(AppCommand::List { reply: reply_tx });
+    let infos = reply_rx.recv().expect("list reply");
+    let entry = infos
+        .iter()
+        .find(|p| p.id == pane_id)
+        .expect("pane in list");
+    assert_eq!(entry.summary.as_deref(), Some("drafting design doc"));
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_overwrites_previous_value() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    app.handle_set_summary(pane_id, "first".into()).unwrap();
+    let info = app
+        .handle_set_summary(pane_id, "second".into())
+        .expect("overwrite succeeds");
+    assert_eq!(info.summary.as_deref(), Some("second"));
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_empty_clears() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    app.handle_set_summary(pane_id, "before".into()).unwrap();
+    let info = app
+        .handle_set_summary(pane_id, String::new())
+        .expect("clear succeeds");
+    assert!(info.summary.is_none());
+    assert!(app.ws().panes.get(&pane_id).unwrap().summary.is_none());
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_rejects_oversized_input() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    // 257 ASCII chars (one over the cap).
+    let too_long = "x".repeat(257);
+    let err = app
+        .handle_set_summary(pane_id, too_long)
+        .expect_err("oversized summary must be rejected");
+    assert_eq!(err.code, Some(ipc::err_code::SUMMARY_TOO_LONG));
+    // Pre-call state is preserved (no partial write).
+    assert!(app.ws().panes.get(&pane_id).unwrap().summary.is_none());
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_accepts_exactly_max_length() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    // 256 chars is on the boundary — must succeed.
+    let at_cap = "x".repeat(256);
+    let info = app
+        .handle_set_summary(pane_id, at_cap.clone())
+        .expect("exactly-cap summary must be accepted");
+    assert_eq!(info.summary.as_deref(), Some(at_cap.as_str()));
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_caps_on_chars_not_bytes() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    // 256 multi-byte Japanese chars is well over 256 bytes (UTF-8 = 3
+    // bytes per char). Must still be accepted because the cap is on
+    // chars(), not byte length.
+    let multibyte = "あ".repeat(256);
+    assert!(multibyte.len() > 256, "precondition: more bytes than chars");
+    let info = app
+        .handle_set_summary(pane_id, multibyte.clone())
+        .expect("256 multi-byte chars must be accepted");
+    assert_eq!(info.summary.as_deref(), Some(multibyte.as_str()));
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_repeated_calls_are_stable() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+
+    // Hammer the handler back-to-back to check that nothing leaks
+    // (mutation order, lock state, etc.).
+    for i in 0..5 {
+        let info = app
+            .handle_set_summary(pane_id, format!("iter-{i}"))
+            .expect("set succeeds");
+        assert_eq!(info.summary.as_deref(), Some(format!("iter-{i}").as_str()));
+    }
+    app.shutdown();
+}
+
+#[test]
+fn handle_set_summary_unknown_pane_is_rejected() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let err = app
+        .handle_set_summary(9999, "x".into())
+        .expect_err("unknown pane must fail");
+    assert_eq!(err.code, Some(ipc::err_code::PANE_NOT_FOUND));
+    app.shutdown();
+}
+
+#[test]
+fn handle_peer_list_surfaces_summary() {
+    // Two panes; only the second has a summary set. handle_peer_list
+    // (called from the *first* pane's perspective) must include the
+    // second pane's summary on its PeerInfo entry.
+    let mut app = App::new(40, 80).expect("App::new");
+    let a_id = app.ws().focused_pane_id;
+    let b_id = app
+        .handle_split(
+            &ipc::PaneRef::Focused,
+            ipc::Direction::Vertical,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("split");
+    app.handle_set_summary(b_id, "running tests".into())
+        .expect("set on b");
+
+    let peers = app.handle_peer_list(a_id).expect("peer list from a");
+    let b_entry = peers.iter().find(|p| p.id == b_id).expect("b in peers");
+    assert_eq!(b_entry.summary.as_deref(), Some("running tests"));
+    // a is not in its own peer list, but spot-check that no spurious
+    // summary appears on the empty side either.
+    assert!(peers.iter().all(|p| p.id != a_id));
+    app.shutdown();
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -208,6 +208,20 @@ pub enum Request {
         )]
         role: Option<Option<String>>,
     },
+    /// Set or clear the per-pane summary string. The summary is
+    /// surfaced on `PaneInfo.summary` / `PeerInfo.summary` so other
+    /// peer agents can read what this pane is working on.
+    ///
+    /// Wire contract:
+    /// - `summary == ""` clears the existing value (round-trips to
+    ///   `Option::None` on the server side).
+    /// - Strings longer than 256 Unicode scalar values (`chars()`)
+    ///   are rejected with `summary_too_long` before any state
+    ///   mutation. The cap is in `chars`, not bytes, so multi-byte
+    ///   scripts get the same effective ceiling as ASCII.
+    /// - `from_pane` is the caller's own pane id, taken from
+    ///   `RENGA_PANE_ID` by the MCP peer subprocess.
+    SetSummary { from_pane: usize, summary: String },
 }
 
 /// Serde helper for the "missing / null / value" three-state pattern
@@ -306,6 +320,12 @@ pub struct PeerInfo {
     pub kind: Option<PeerClientKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub receive_mode: Option<PeerReceiveMode>,
+    /// Optional pane-authored summary set via the MCP `set_summary`
+    /// tool. Absent until the pane calls the tool; cleared when the
+    /// pane sets it to an empty string. In-memory only — does not
+    /// survive renga restart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 /// One entry in the `List` response payload.
@@ -344,6 +364,9 @@ pub struct PaneInfo {
     pub kind: Option<PeerClientKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub receive_mode: Option<PeerReceiveMode>,
+    /// Optional pane-authored summary; see [`PeerInfo::summary`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 /// Server reply to one [`Request`].
@@ -444,6 +467,10 @@ pub mod err_code {
     /// since digit strings are interpreted as numeric ids by
     /// `PaneRef::Name` resolution).
     pub const NAME_INVALID: &str = "name_invalid";
+    /// `SetSummary` was passed a `summary` string longer than the
+    /// per-pane cap (256 Unicode scalar values). The caller should
+    /// either truncate the summary or send an empty string to clear.
+    pub const SUMMARY_TOO_LONG: &str = "summary_too_long";
 }
 
 /// App-side error carrying a free-form message plus an optional
@@ -835,6 +862,7 @@ mod tests {
             cwd: None,
             kind: None,
             receive_mode: None,
+            summary: None,
         };
         let s = serde_json::to_string(&info).unwrap();
         assert!(!s.contains("role"), "unexpected role field: {s}");
@@ -854,6 +882,7 @@ mod tests {
             cwd: Some("/home/user/project".into()),
             kind: Some(PeerClientKind::Claude),
             receive_mode: Some(PeerReceiveMode::Push),
+            summary: None,
         };
         let parsed: PaneInfo =
             serde_json::from_str(&serde_json::to_string(&info).unwrap()).unwrap();
@@ -874,6 +903,7 @@ mod tests {
             cwd: None,
             kind: None,
             receive_mode: None,
+            summary: None,
         };
         let s = serde_json::to_string(&info).unwrap();
         assert!(s.contains("\"x\":3"), "missing x: {s}");
@@ -1127,6 +1157,78 @@ mod tests {
         };
         let parsed: Event = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn set_summary_request_roundtrips() {
+        let r = Request::SetSummary {
+            from_pane: 7,
+            summary: "drafting design doc".into(),
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn set_summary_empty_string_roundtrips() {
+        // Empty string is the documented "clear" form; must survive
+        // the wire as-is so the App handler can detect it.
+        let r = Request::SetSummary {
+            from_pane: 1,
+            summary: String::new(),
+        };
+        assert_eq!(roundtrip(&r), r);
+    }
+
+    #[test]
+    fn pane_info_omits_summary_when_none() {
+        // additive serde: clients on old protocol must not see a new
+        // `summary: null` key — `skip_serializing_if = Option::is_none`
+        // guarantees omission.
+        let info = PaneInfo {
+            id: 1,
+            name: None,
+            role: None,
+            focused: false,
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+            cwd: None,
+            kind: None,
+            receive_mode: None,
+            summary: None,
+        };
+        let s = serde_json::to_string(&info).unwrap();
+        assert!(!s.contains("summary"), "must omit summary key: {s}");
+    }
+
+    #[test]
+    fn pane_info_includes_summary_when_set() {
+        let info = PaneInfo {
+            id: 1,
+            name: None,
+            role: None,
+            focused: false,
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+            cwd: None,
+            kind: None,
+            receive_mode: None,
+            summary: Some("hello".into()),
+        };
+        let s = serde_json::to_string(&info).unwrap();
+        assert!(s.contains("\"summary\":\"hello\""), "{s}");
+    }
+
+    #[test]
+    fn pane_info_deserializes_legacy_payload_without_summary() {
+        // Old servers that don't emit `summary` must still deserialize.
+        // Guards the additive-change promise from semver-policy.md.
+        let raw = r#"{"id":1,"focused":false,"x":0,"y":0,"width":0,"height":0}"#;
+        let info: PaneInfo = serde_json::from_str(raw).unwrap();
+        assert!(info.summary.is_none());
     }
 
     #[test]

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -555,6 +555,31 @@ fn dispatch_request(req: Request, command_tx: &Sender<AppCommand>) -> Response {
                 reply,
             })
         }
+        Request::SetSummary { from_pane, summary } => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if command_tx
+                .send(AppCommand::SetSummary {
+                    pane_id: from_pane,
+                    summary,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return Response::err_coded(err_code::SHUTTING_DOWN, "app shutting down");
+            }
+            match reply_rx.recv_timeout(APP_REPLY_TIMEOUT) {
+                Ok(Ok(pane)) => match serde_json::to_value(&pane) {
+                    Ok(v) => Response::ok_value(serde_json::json!({ "pane": v })),
+                    Err(e) => {
+                        Response::err_coded(err_code::INTERNAL, format!("serialize pane: {e}"))
+                    }
+                },
+                Ok(Err(err)) => err.into_response(),
+                Err(e) => {
+                    Response::err_coded(err_code::APP_TIMEOUT, format!("app did not respond: {e}"))
+                }
+            }
+        }
         Request::SetPaneIdentity { target, name, role } => {
             let (reply_tx, reply_rx) = oneshot::channel();
             if command_tx

--- a/src/mcp_peer/mod.rs
+++ b/src/mcp_peer/mod.rs
@@ -353,7 +353,7 @@ running in the same renga tab can see you and send you messages.\n\n\
 Peer messaging tools:\n\
 - list_peers: Discover other peer-enabled agent instances in the same renga tab.\n\
 - send_message: Send a message to another instance by peer ID or name.\n\
-- set_summary: (stub in v1) Set a 1-2 sentence summary of what you're working on.\n\
+- set_summary: Set a 1-2 sentence summary of what you're working on; surfaced on list_panes / list_peers for other peers.\n\
 - check_messages: Drain any queued peer messages still waiting for this client.\n\n\
 Pane control tools (all scoped to the current renga tab, except new_tab which is the one \
 cross-tab tool):\n\
@@ -434,7 +434,7 @@ fn tools_spec() -> Value {
         },
         {
             "name": "set_summary",
-            "description": "Stub in v1 — accepted and dropped. renga uses pane name/role as the summary substitute. Kept on the tool list so the same claude-peers-mcp skill / prompt works here.",
+            "description": "Set a 1-2 sentence summary of what this pane is currently working on. Surfaced on every PaneInfo / PeerInfo entry returned by list_panes and list_peers so other peer agents can see it. An empty string clears the summary. Max 256 chars (rejected with [summary_too_long]).",
             "inputSchema": {
                 "type": "object",
                 "properties": { "summary": { "type": "string" } },
@@ -932,10 +932,7 @@ fn handle_tools_call(id: &Value, params: &Value, ctx: &PeerCtx) -> Result<Value>
     Ok(match name {
         "list_peers" => handle_list_peers(id, ctx),
         "send_message" => handle_send_message(id, &args, ctx),
-        "set_summary" => ok_response(
-            id,
-            tool_text_result("Summary accepted (v1 stub: renga displays pane name / role)."),
-        ),
+        "set_summary" => handle_set_summary(id, &args, ctx),
         "check_messages" => handle_check_messages(id, ctx),
         "list_panes" => handle_list_panes(id, ctx),
         "spawn_pane" => handle_spawn_pane(id, &args, ctx),
@@ -1685,6 +1682,55 @@ fn handle_set_pane_identity(id: &Value, args: &Value, ctx: &PeerCtx) -> Value {
                 "renga refused set_pane_identity: {}",
                 fmt_code(&message, &code)
             ),
+        ),
+        Ok(other) => err_response(id, -32603, &format!("unexpected renga response: {other:?}")),
+        Err(e) => err_response(id, -32603, &format!("renga call failed: {e}")),
+    }
+}
+
+// ── set_summary (per-pane summary string) ────────────────────
+
+fn handle_set_summary(id: &Value, args: &Value, ctx: &PeerCtx) -> Value {
+    // The schema requires `summary` as a string. Reject anything else
+    // (number, null, etc.) explicitly so callers get a clear error
+    // rather than silently coercing.
+    let summary = match args.get("summary") {
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => {
+            return err_response(
+                id,
+                -32602,
+                &format!("`summary` must be a string; got {}", other),
+            );
+        }
+        None => {
+            return err_response(id, -32602, "set_summary requires a `summary` argument");
+        }
+    };
+
+    let (caller_pane, endpoint) = match require_connected(ctx, id, "set summary") {
+        Ok(t) => t,
+        Err(resp) => return resp,
+    };
+    match client::send_request(
+        endpoint,
+        &Request::SetSummary {
+            from_pane: caller_pane,
+            summary: summary.clone(),
+        },
+    ) {
+        Ok(Response::Ok { .. }) => {
+            let msg = if summary.is_empty() {
+                "Summary cleared.".to_string()
+            } else {
+                format!("Summary set: {summary}")
+            };
+            ok_response(id, tool_text_result(&msg))
+        }
+        Ok(Response::Err { message, code }) => err_response(
+            id,
+            -32603,
+            &format!("renga refused set_summary: {}", fmt_code(&message, &code)),
         ),
         Ok(other) => err_response(id, -32603, &format!("unexpected renga response: {other:?}")),
         Err(e) => err_response(id, -32603, &format!("renga call failed: {e}")),
@@ -2443,6 +2489,7 @@ mod tests {
                 cwd: None,
                 kind: Some(PeerClientKind::Claude),
                 receive_mode: Some(ipc::PeerReceiveMode::Push),
+                summary: None,
             },
             PaneInfo {
                 id: 2,
@@ -2456,6 +2503,7 @@ mod tests {
                 cwd: None,
                 kind: Some(PeerClientKind::Codex),
                 receive_mode: Some(ipc::PeerReceiveMode::Pull),
+                summary: None,
             },
         ];
         let text = format_pane_list(&panes);

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -77,6 +77,11 @@ pub struct Pane {
     /// `Workspace.pane_names` as the unique IPC key), `role` may repeat
     /// and may be absent. Surfaced via `renga list`.
     pub role: Option<String>,
+    /// Optional 1-2 sentence per-pane summary set by the pane's MCP
+    /// `set_summary` tool. In-memory only; cleared when the pane exits.
+    /// Surfaced via `list_panes` / `list_peers` so peer agents can see
+    /// what other panes are working on.
+    pub summary: Option<String>,
     /// Set once the App has published a `PaneExited` event for this
     /// pane. Guards the multiple exit pathways (explicit close, tab
     /// close, natural shell exit) so subscribers see exactly one event.
@@ -202,6 +207,7 @@ impl Pane {
             alternate_scroll_mode,
             codex_transcript_overlay_hint,
             role: None,
+            summary: None,
             exit_event_emitted: false,
         };
 


### PR DESCRIPTION
## Summary
- Replace the v1 stub `set_summary` MCP tool with a real per-pane summary store. Summaries are surfaced as a new optional `summary` field on every `PaneInfo` / `PeerInfo` returned by `list_panes` / `list_peers`, and discarded when the pane exits.
- Add `Request::SetSummary { from_pane, summary }` and `AppCommand::SetSummary` plumbing, with the 256-Unicode-scalar-value cap enforced before any state mutation.
- Add the `summary_too_long` error code to `err_code` and document it in `docs/api-surface-v1.0.md` §1.3 / §5.1.

## Wire compatibility
Additive change. `summary` uses `#[serde(skip_serializing_if = "Option::is_none")]` so older clients never see a new key, and a legacy `PaneInfo` payload with no `summary` deserializes unchanged (covered by `pane_info_deserializes_legacy_payload_without_summary`).

## Behavior
- Empty string clears the summary (round-trips to `None` / omitted on the wire).
- Repeated calls overwrite with the latest value.
- Strings longer than 256 Unicode scalar values are rejected with `[summary_too_long]` before any mutation. The cap is in `chars()`, not bytes, so multi-byte scripts get the same effective ceiling as ASCII.
- Storage is in-memory only — does not survive renga restart.

## Tests
- 9 unit tests on `App::handle_set_summary` (set→list, overwrite, empty clear, 256/257 boundary, chars-vs-bytes via `あ`×256, repeated stability, unknown pane, peer_list propagation).
- 3 serde tests on `Request::SetSummary` and `PaneInfo.summary` (roundtrip, empty round-trip, omit-when-None, legacy-payload deserialization).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (533 passed) all green.

## Test plan
- [ ] Smoke-check with `claude` in a renga pane: call `set_summary("hello")`, then `list_peers` from a sibling pane and confirm `summary: hello` appears.
- [ ] Empty-string clear: `set_summary("")` then verify the field is omitted on the wire.
- [ ] 257-char input rejected with `[summary_too_long]`.
- [ ] Pane exit drops the summary (kill pane, list, confirm gone).

Closes #202.