### PR TITLE
Latch Claude/Codex cosmetic indicators across OSC title rewrites (#209)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "if": "Bash(gh pr create*)",
-            "command": "cmd=$(jq -r '.tool_input.command'); if echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+Shin-sibainu/ccmux'; then echo 'Blocked: PR target is upstream Shin-sibainu/ccmux. Add --repo happy-ryo/ccmux --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi; if ! echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+happy-ryo/ccmux'; then echo 'Blocked: gh pr create without --repo defaults to upstream Shin-sibainu/ccmux. Add --repo happy-ryo/ccmux --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi"
+            "command": "cmd=$(jq -r '.tool_input.command'); if echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+Shin-sibainu/ccmux'; then echo 'Blocked: PR target is upstream Shin-sibainu/ccmux. Add --repo suisya-systems/renga --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi; if ! echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+suisya-systems/renga'; then echo 'Blocked: gh pr create without --repo defaults to upstream Shin-sibainu/ccmux. Add --repo suisya-systems/renga --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi"
           }
         ]
       }

--- a/src/app/codex_peer.rs
+++ b/src/app/codex_peer.rs
@@ -363,8 +363,17 @@ impl App {
     }
 
     pub(crate) fn pane_expects_codex_peer_delivery(&self, ws_index: usize, pane_id: usize) -> bool {
-        if self.peer_client_kinds.get(&pane_id) == Some(&PeerClientKind::Codex) {
-            return true;
+        // Registration is authoritative when present. Without this
+        // short-circuit a Claude-registered pane whose current OSC
+        // title transiently contains the substring "codex" (very
+        // common for orchestration workers debugging Codex-related
+        // issues) would fall through to the title heuristic and be
+        // mis-classified as a Codex recipient — see issue #209's
+        // discussion of the related #208 regression.
+        match self.peer_client_kinds.get(&pane_id) {
+            Some(PeerClientKind::Codex) => return true,
+            Some(PeerClientKind::Claude) => return false,
+            None => {}
         }
         self.workspaces[ws_index]
             .panes

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -48,6 +48,15 @@ pub struct Pane {
     /// current foreground app (e.g. `shell_accepts_command_injection`
     /// gating `Alt+P`).
     pub claude_seen: Arc<AtomicBool>,
+    /// Codex equivalent of `claude_seen`. Latches on the first OSC
+    /// title that mentions "codex" and never resets, so cosmetic
+    /// indicators (border accent, pane label, tab title decoration)
+    /// keep identifying the pane as Codex even when Codex rewrites
+    /// its title to a task-specific summary that drops the literal
+    /// substring. Foreground-app gating (mouse protocol resolution,
+    /// codex_peer detection) still uses the live `is_codex_running()`
+    /// signal — see issue #209 for the cosmetic-vs-foreground split.
+    pub codex_seen: Arc<AtomicBool>,
     /// Cache of the most recently *detected* Claude caret cell on
     /// this pane: `(host_row, host_col)` in vt100 screen coords —
     /// already shifted to land on Claude's inverse-video marker.
@@ -161,6 +170,8 @@ impl Pane {
         let prompt_seen_clone = Arc::clone(&prompt_seen);
         let claude_seen = Arc::new(AtomicBool::new(false));
         let claude_seen_clone = Arc::clone(&claude_seen);
+        let codex_seen = Arc::new(AtomicBool::new(false));
+        let codex_seen_clone = Arc::clone(&codex_seen);
         let mouse_protocol_cache = Arc::new(Mutex::new(None));
         let mouse_protocol_cache_clone = Arc::clone(&mouse_protocol_cache);
         let alternate_scroll_mode = Arc::new(AtomicBool::new(false));
@@ -174,6 +185,7 @@ impl Pane {
                 scrollback_clone,
                 prompt_seen_clone,
                 claude_seen_clone,
+                codex_seen_clone,
                 mouse_protocol_cache_clone,
                 alternate_scroll_mode_clone,
                 id,
@@ -197,6 +209,7 @@ impl Pane {
             pending_startup: None,
             prompt_seen,
             claude_seen,
+            codex_seen,
             claude_caret_cache: Mutex::new(None),
             mouse_protocol_cache,
             alternate_scroll_mode,
@@ -477,9 +490,12 @@ impl Pane {
     }
 
     /// Check if Codex is running in this pane (by current window
-    /// title). Unlike Claude we do not currently need a sticky latch:
-    /// this is used only for UI affordances such as pane labeling and
-    /// border color, not caret placement or command-injection gating.
+    /// title). This is the live signal — it flips back to `false`
+    /// the moment Codex exits or rewrites the title to something
+    /// that doesn't contain "codex". Use this for foreground-app
+    /// gating (mouse protocol resolution, codex_peer fallback) and
+    /// `codex_ever_seen()` for cosmetic indicators that must
+    /// survive Codex's transient task-name title rewrites (#209).
     pub fn is_codex_running(&self) -> bool {
         if let Ok(t) = self.title.lock() {
             title_mentions_client(&t, "codex")
@@ -551,6 +567,21 @@ impl Pane {
     /// signal still get one via `is_claude_running()`.
     pub fn claude_ever_seen(&self) -> bool {
         self.claude_seen.load(Ordering::Relaxed)
+    }
+
+    /// Sticky check: has Codex ever been observed running in this
+    /// pane (by OSC title)? Latches on first match and never resets.
+    /// Mirrors `claude_ever_seen()` and exists for the same reason —
+    /// Codex CLI rewrites its window title to reflect the in-flight
+    /// task, frequently dropping the literal "codex" substring, which
+    /// would otherwise flip the cosmetic indicators (border accent,
+    /// pane label, tab title decoration) off mid-session. See #209.
+    ///
+    /// Foreground-app gating (mouse protocol resolution,
+    /// `pane_expects_codex_peer_delivery` fallback) still calls
+    /// `is_codex_running()` so it sees the honest current state.
+    pub fn codex_ever_seen(&self) -> bool {
+        self.codex_seen.load(Ordering::Relaxed)
     }
 
     /// Whether it is safe to synthesize a shell command line into this
@@ -862,6 +893,7 @@ fn pty_reader_thread(
     scrollback_count: Arc<std::sync::atomic::AtomicUsize>,
     prompt_seen: Arc<AtomicBool>,
     claude_seen: Arc<AtomicBool>,
+    codex_seen: Arc<AtomicBool>,
     mouse_protocol_cache: Arc<Mutex<Option<CachedMouseProtocol>>>,
     alternate_scroll_mode: Arc<AtomicBool>,
     pane_id: usize,
@@ -912,8 +944,12 @@ fn pty_reader_thread(
                     // and the literal "claude" frequently drops out)
                     // do not flip `is_claude_running()` to false and
                     // hide the hardware caret. See `Pane::claude_seen`.
-                    if new_title.to_lowercase().contains("claude") {
+                    let lower = new_title.to_lowercase();
+                    if lower.contains("claude") {
                         claude_seen.store(true, Ordering::Relaxed);
+                    }
+                    if lower.contains("codex") {
+                        codex_seen.store(true, Ordering::Relaxed);
                     }
                     if let Ok(mut t) = title.lock() {
                         *t = new_title;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -678,8 +678,14 @@ fn render_single_pane(
     frame: &mut Frame,
     area: Rect,
 ) {
-    let is_claude = pane.is_claude_running();
-    let is_codex = pane.is_codex_running();
+    // Cosmetic indicators (border accent, pane label) consume the
+    // sticky `*_ever_seen()` latches, not the live title check —
+    // Claude and Codex both rewrite their OSC titles to in-flight
+    // task summaries that frequently drop the literal client name,
+    // which would otherwise flip the indicators off mid-session
+    // even though the client is still interactive. See issue #209.
+    let is_claude = pane.claude_ever_seen();
+    let is_codex = pane.codex_ever_seen();
     let client_accent = if is_claude {
         Some(ACCENT_CLAUDE)
     } else if is_codex {
@@ -1531,7 +1537,7 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
         .ws()
         .panes
         .get(&focused_id)
-        .is_some_and(|p| p.is_claude_running());
+        .is_some_and(|p| p.claude_ever_seen());
 
     let mut right_spans = Vec::new();
 


### PR DESCRIPTION
## Summary
- Switch border accent, pane label, and status-bar tab decoration to the sticky `claude_ever_seen()` / new `codex_ever_seen()` latches so they don't flicker back to "shell" when Claude/Codex rewrite the OSC title to an in-flight task summary that drops the client name (#209).
- Keep `is_claude_running()` / `is_codex_running()` for foreground gating (`shell_accepts_command_injection`, mouse protocol resolution, codex_peer fallback) — those still want the honest live signal.
- Make `pane_expects_codex_peer_delivery` honor a registered Claude pane (return false) before consulting the title heuristic, fixing the related #208 mis-route when a Claude task title transiently mentions "codex".

## Test plan
- [x] `cargo build`
- [x] `cargo test` (519 passed)
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manual repro: spawn claude pane, after task starts emit a non-claude title, verify border + label + tab decoration stay claude-styled.
- [ ] Manual repro: from a raw shell pane, `printf '\x1b]0;claude\x07'` then `printf '\x1b]0;some other task\x07'` — indicators stay on.

Closes #209.