### PR TITLE
feat(overlay): Ctrl+U clears IME composition buffer

### DIFF
--- a/src/app/tests/overlay.rs
+++ b/src/app/tests/overlay.rs
@@ -109,6 +109,68 @@ fn hotkey_mode_bootstraps_visible_claude_input_into_overlay() {
 }
 
 #[test]
+fn ctrl_u_clears_overlay_buffer() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+    let mut state = crate::input::overlay::OverlayState::new(pane_id);
+    for ch in "hello\nworld".chars() {
+        state.insert_char(ch);
+    }
+    app.overlay = Some(state);
+
+    let ctrl_u = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
+    let consumed = crate::input::overlay::handle_overlay_key(&mut app, ctrl_u)
+        .expect("handle_overlay_key Ctrl+U");
+
+    assert!(consumed, "Ctrl+U must be consumed by the overlay handler");
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert!(overlay.buffer.is_empty(), "Ctrl+U should clear the buffer");
+    assert_eq!(overlay.cursor, 0, "cursor should reset to 0 after clear");
+}
+
+#[test]
+fn ctrl_shift_u_also_clears_overlay_buffer() {
+    // Some terminals report Ctrl+U with the Shift bit still set
+    // when the user happens to be holding Shift, and the handler
+    // treats both 'u' and 'U' as the same chord — verify that path.
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+    let mut state = crate::input::overlay::OverlayState::new(pane_id);
+    for ch in "draft".chars() {
+        state.insert_char(ch);
+    }
+    app.overlay = Some(state);
+
+    let ctrl_shift_u = KeyEvent::new(
+        KeyCode::Char('U'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    );
+    let consumed = crate::input::overlay::handle_overlay_key(&mut app, ctrl_shift_u)
+        .expect("handle_overlay_key Ctrl+Shift+U");
+
+    assert!(consumed);
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert!(overlay.buffer.is_empty());
+    assert_eq!(overlay.cursor, 0);
+}
+
+#[test]
+fn ctrl_u_on_empty_overlay_is_a_noop() {
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_id = app.ws().focused_pane_id;
+    app.overlay = Some(crate::input::overlay::OverlayState::new(pane_id));
+
+    let ctrl_u = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
+    let consumed = crate::input::overlay::handle_overlay_key(&mut app, ctrl_u)
+        .expect("handle_overlay_key Ctrl+U on empty");
+
+    assert!(consumed, "Ctrl+U must always be consumed by the overlay");
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert!(overlay.buffer.is_empty());
+    assert_eq!(overlay.cursor, 0);
+}
+
+#[test]
 fn hotkey_mode_skips_visible_input_bootstrap_for_codex_peer() {
     let mut app = App::new(40, 80).expect("App::new");
     let pane_id = app.ws().focused_pane_id;

--- a/src/input/overlay.rs
+++ b/src/input/overlay.rs
@@ -58,6 +58,12 @@ impl OverlayState {
         self.cursor += 1;
     }
 
+    /// Clear the entire composition buffer and reset the cursor.
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+        self.cursor = 0;
+    }
+
     /// Backspace: remove the char left of the cursor.
     pub fn backspace(&mut self) {
         if self.cursor == 0 {
@@ -570,6 +576,19 @@ pub(crate) fn handle_overlay_key(app: &mut App, key: KeyEvent) -> Result<bool> {
             }
         }
         KeyCode::Char(c) => {
+            // Ctrl+U clears the entire draft (not just the current
+            // line). The binding is borrowed from readline's
+            // "discard" muscle memory but the semantics here are
+            // whole-buffer. Handled before the generic Ctrl/Alt
+            // swallow below so the chord actually reaches us.
+            if key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT)
+                && (c == 'u' || c == 'U')
+            {
+                overlay.clear();
+                app.dirty = true;
+                return Ok(true);
+            }
             if key
                 .modifiers
                 .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -264,7 +264,7 @@ fn render_ime_overlay(app: &mut App, frame: &mut Frame, area: Rect) {
         ),
     ]);
     let hint = Line::from(Span::styled(
-        " Alt+Enter send \u{00b7} Enter newline \u{00b7} Esc cancel ",
+        " Alt+Enter send \u{00b7} Enter newline \u{00b7} Ctrl+U clear \u{00b7} Esc cancel ",
         Style::default().fg(TEXT_DIM),
     ));
     let block = Block::default()


### PR DESCRIPTION
## Summary
- Add a `Ctrl+U` shortcut in the IME composition overlay that wipes the entire draft buffer and resets the cursor, so users can discard a half-typed message without holding Backspace.
- Surface the new chord in the overlay's footer hint (` Alt+Enter send · Enter newline · Ctrl+U clear · Esc cancel `).
- Cover the lowercase chord, the `Ctrl+Shift+U` variant (some terminals leave the Shift bit on), and the empty-buffer no-op.

The semantics are whole-buffer (not readline's line-scoped "discard"), which is what users actually want for a multi-line draft. Reviewed by codex; comment was tightened to avoid implying line-scoped behavior, and the two extra tests were added on its suggestion.

## Test plan
- [x] `cargo test overlay` — 52/52 pass, including the new `ctrl_u_clears_overlay_buffer`, `ctrl_shift_u_also_clears_overlay_buffer`, and `ctrl_u_on_empty_overlay_is_a_noop`.
- [x] `cargo fmt --all`
- [x] Manual: open the overlay (Ctrl+;), type a multi-line draft, press Ctrl+U, confirm buffer clears and overlay stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)