### PR TITLE
Add configurable UI FPS

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,14 @@ pub struct Cli {
     #[arg(long, value_name = "LANG", value_enum, ignore_case = true)]
     pub lang: Option<crate::i18n::UiLang>,
 
+    /// Main event-loop target rate for ordinary rendering / input
+    /// polling. Higher values reduce idle input latency and make
+    /// animations smoother at the cost of more wakeups. Overrides
+    /// `[ui] fps` in config.toml. `0` is accepted here and clamped to
+    /// `1` at runtime to avoid a busy loop.
+    #[arg(long, value_name = "FPS")]
+    pub fps: Option<u16>,
+
     /// Minimum columns each child pane must retain after a vertical
     /// split. Splits that would produce a narrower child are refused.
     /// A value of `0` is clamped to `1` at runtime to avoid degenerate
@@ -1016,6 +1024,12 @@ mod tests {
     }
 
     #[test]
+    fn fps_defaults_to_none() {
+        let cli = Cli::try_parse_from(["renga"]).unwrap();
+        assert_eq!(cli.fps, None);
+    }
+
+    #[test]
     fn parses_lang_auto_ja_en() {
         let cli = Cli::try_parse_from(["renga", "--lang", "auto"]).unwrap();
         assert_eq!(cli.lang, Some(crate::i18n::UiLang::Auto));
@@ -1040,6 +1054,15 @@ mod tests {
     fn rejects_unknown_lang() {
         assert!(Cli::try_parse_from(["renga", "--lang", "zh"]).is_err());
         assert!(Cli::try_parse_from(["renga", "--lang", "banana"]).is_err());
+    }
+
+    #[test]
+    fn parses_fps_override_and_zero() {
+        let cli = Cli::try_parse_from(["renga", "--fps", "60"]).unwrap();
+        assert_eq!(cli.fps, Some(60));
+
+        let cli = Cli::try_parse_from(["renga", "--fps", "0"]).unwrap();
+        assert_eq!(cli.fps, Some(0));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct Config {
 /// Top-level UI settings. Currently only carries the language pick;
 /// future display-affecting options (theme overrides, etc.) can hang
 /// off the same section.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct UiConfig {
     /// UI language for status bar hints and preview error messages.
@@ -33,6 +33,21 @@ pub struct UiConfig {
     /// `[ime] mode` convention is lowercase and we don't want a fat-
     /// finger to fail the whole config parse silently.
     pub lang: crate::i18n::UiLang,
+    /// Main event-loop target rate. This drives the crossterm poll
+    /// timeout used while the TUI is idle, so higher values reduce
+    /// input latency and make animations smoother at the cost of more
+    /// wakeups. `0` is clamped to [`MIN_UI_FPS`] so a bad config or
+    /// CLI override never turns into a busy-spin.
+    pub fps: u16,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            lang: crate::i18n::UiLang::Auto,
+            fps: DEFAULT_UI_FPS,
+        }
+    }
 }
 
 /// IME overlay settings. See Issue #39 for the full mode design;
@@ -88,6 +103,14 @@ impl Default for ImeConfig {
 /// periodic repaint becomes a near-continuous storm that defeats the
 /// point of freezing in the first place.
 pub const MIN_OVERLAY_CATCHUP_MS: u64 = 100;
+
+/// Default main-loop rate used for ordinary event polling.
+pub const DEFAULT_UI_FPS: u16 = 30;
+
+/// Lower bound for user-provided FPS overrides. `0` is treated as a
+/// fat-finger rather than meaning "unlimited", because the latter
+/// would degrade into a busy loop.
+pub const MIN_UI_FPS: u16 = 1;
 
 /// How Ctrl+; behaves in a focused pane.
 ///
@@ -203,6 +226,7 @@ impl Config {
         freeze_panes_on_overlay: Option<bool>,
         overlay_catchup_ms: Option<u64>,
         ui_lang: Option<crate::i18n::UiLang>,
+        ui_fps: Option<u16>,
     ) {
         if let Some(mode) = ime_mode {
             self.ime.mode = mode;
@@ -216,11 +240,17 @@ impl Config {
         if let Some(lang) = ui_lang {
             self.ui.lang = lang;
         }
+        if let Some(fps) = ui_fps {
+            self.ui.fps = fps;
+        }
         // Clamp any non-zero value regardless of origin so the main
         // loop never sees a sub-floor interval.
         if self.ime.overlay_catchup_ms != 0 && self.ime.overlay_catchup_ms < MIN_OVERLAY_CATCHUP_MS
         {
             self.ime.overlay_catchup_ms = MIN_OVERLAY_CATCHUP_MS;
+        }
+        if self.ui.fps < MIN_UI_FPS {
+            self.ui.fps = MIN_UI_FPS;
         }
     }
 }
@@ -330,7 +360,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(Some(ImeMode::Off), None, None, None);
+        cfg.apply_cli_overrides(Some(ImeMode::Off), None, None, None, None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -343,7 +373,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, None, None, None);
+        cfg.apply_cli_overrides(None, None, None, None, None);
         assert_eq!(cfg.ime.mode, ImeMode::Off);
     }
 
@@ -418,11 +448,11 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, Some(false), None, None);
+        cfg.apply_cli_overrides(None, Some(false), None, None, None);
         assert!(!cfg.ime.freeze_panes_on_overlay);
 
         let mut cfg2 = Config::default();
-        cfg2.apply_cli_overrides(None, Some(true), None, None);
+        cfg2.apply_cli_overrides(None, Some(true), None, None, None);
         assert!(cfg2.ime.freeze_panes_on_overlay);
     }
 
@@ -457,19 +487,19 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, None, Some(3000), None);
+        cfg.apply_cli_overrides(None, None, Some(3000), None, None);
         assert_eq!(cfg.ime.overlay_catchup_ms, 3000);
 
         let mut cfg2 = Config::default();
         // Non-zero sub-floor value must be clamped up.
-        cfg2.apply_cli_overrides(None, None, Some(10), None);
+        cfg2.apply_cli_overrides(None, None, Some(10), None, None);
         assert_eq!(cfg2.ime.overlay_catchup_ms, MIN_OVERLAY_CATCHUP_MS);
 
         // Zero must stay zero (means "disabled") even when the default
         // is a non-zero value — an explicit `--ime-overlay-catchup-ms 0`
         // must still give a pure freeze.
         let mut cfg3 = Config::default();
-        cfg3.apply_cli_overrides(None, None, Some(0), None);
+        cfg3.apply_cli_overrides(None, None, Some(0), None, None);
         assert_eq!(cfg3.ime.overlay_catchup_ms, 0);
     }
 
@@ -491,6 +521,12 @@ mod tests {
     fn ui_lang_defaults_to_auto() {
         let cfg = Config::default();
         assert_eq!(cfg.ui.lang, crate::i18n::UiLang::Auto);
+    }
+
+    #[test]
+    fn ui_fps_defaults_to_30() {
+        let cfg = Config::default();
+        assert_eq!(cfg.ui.fps, DEFAULT_UI_FPS);
     }
 
     #[test]
@@ -538,6 +574,35 @@ mod tests {
     }
 
     #[test]
+    fn parses_ui_fps_from_toml() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [ui]
+            fps = 60
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.ui.fps, 60);
+    }
+
+    #[test]
+    fn cli_ui_fps_beats_file_and_clamps_zero() {
+        let mut cfg: Config = toml::from_str(
+            r#"
+            [ui]
+            fps = 45
+            "#,
+        )
+        .unwrap();
+        cfg.apply_cli_overrides(None, None, None, None, Some(60));
+        assert_eq!(cfg.ui.fps, 60);
+
+        let mut cfg2 = Config::default();
+        cfg2.apply_cli_overrides(None, None, None, None, Some(0));
+        assert_eq!(cfg2.ui.fps, MIN_UI_FPS);
+    }
+
+    #[test]
     fn rejects_unknown_ui_lang_value() {
         // An unknown value must bubble up as a parse error instead of
         // silently falling through to a default — otherwise a typo
@@ -564,7 +629,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, None, None, Some(crate::i18n::UiLang::En));
+        cfg.apply_cli_overrides(None, None, None, Some(crate::i18n::UiLang::En), None);
         assert_eq!(cfg.ui.lang, crate::i18n::UiLang::En);
     }
 
@@ -577,7 +642,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        cfg.apply_cli_overrides(None, None, None, None);
+        cfg.apply_cli_overrides(None, None, None, None, None);
         assert_eq!(cfg.ui.lang, crate::i18n::UiLang::En);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,9 @@ fn main() -> Result<()> {
         cli.ime_freeze_panes,
         cli.ime_overlay_catchup_ms,
         cli.lang,
+        cli.fps,
     );
+    let event_poll_timeout = Duration::from_secs_f64(1.0 / f64::from(user_config.ui.fps));
 
     // If a layout was requested and its root node is a single pane
     // with an explicit cwd, pre-load the layout so we can spawn the
@@ -226,7 +228,7 @@ fn main() -> Result<()> {
     }
 
     // Main event loop
-    let result = run_event_loop(&mut terminal, &mut app);
+    let result = run_event_loop(&mut terminal, &mut app, event_poll_timeout);
 
     // Cleanup
     app.shutdown();
@@ -365,6 +367,7 @@ fn run_events(
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut app::App,
+    event_poll_timeout: Duration,
 ) -> Result<()> {
     let mut paste_buffer: Vec<u8> = Vec::new();
 
@@ -449,8 +452,8 @@ fn run_event_loop(
             break;
         }
 
-        // Poll for crossterm events with a short timeout (~30fps)
-        if event::poll(Duration::from_millis(33))? {
+        // Poll for crossterm events at the configured idle rate.
+        if event::poll(event_poll_timeout)? {
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     let consumed = app.handle_key_event(key)?;


### PR DESCRIPTION
## Summary
- add a --fps CLI flag for the main UI event loop
- add [ui] fps config support with a default of 30 fps
- clamp 