### PR TITLE
fix(renga): kill descendant processes on pane close (Closes #214)

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -608,7 +608,25 @@ impl Pane {
     }
 
     /// Kill the PTY child process.
+    ///
+    /// On Windows, `portable-pty`'s `Child::kill` is a bare
+    /// `TerminateProcess` against the immediate shell only — any
+    /// grandchildren (e.g. `claude`/`node.exe` launched from the shell
+    /// via `pending_startup`) survive and keep open handles on the
+    /// pane's working directory. That blocks `git worktree remove` /
+    /// `rmdir` until the renga process itself exits (#214). Walk the
+    /// tree first via `taskkill /F /T` so directory handles in the
+    /// pane's cwd are released as soon as the pane is closed.
     pub fn kill(&mut self) {
+        #[cfg(windows)]
+        if let Some(pid) = self.child.process_id() {
+            let _ = std::process::Command::new("taskkill")
+                .args(["/F", "/T", "/PID", &pid.to_string()])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .stdin(std::process::Stdio::null())
+                .status();
+        }
         let _ = self.child.kill();
         let _ = self.child.wait();
     }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -618,24 +618,27 @@ impl Pane {
     /// tree first via `taskkill /F /T` so directory handles in the
     /// pane's cwd are released as soon as the pane is closed.
     pub fn kill(&mut self) {
-        // Short-circuit on the second pass through an already-killed
-        // pane: `remove_pane_from_layout` calls `kill()` explicitly and
-        // `Drop` calls it again on the same value (#214 review). The
-        // PTY EOF path also flips `exited` before `Pane` is dropped, so
-        // natural exits skip the spawn entirely.
-        if self.exited {
-            return;
+        // `try_wait` distinguishes "child still alive, needs killing"
+        // from "child already exited, just needs reaping" — important
+        // because `pane.exited` only signals PTY EOF was observed, not
+        // that the child has been waited on, so naive short-circuiting
+        // on `exited` would zombie the shell on Unix Drop. The taskkill
+        // / `child.kill()` path is skipped when the process is already
+        // gone so the close+Drop pair doesn't double-spawn taskkill on
+        // Windows (#214 review), but `wait()` always runs to reap.
+        let alive = !matches!(self.child.try_wait(), Ok(Some(_)));
+        if alive {
+            #[cfg(windows)]
+            if let Some(pid) = self.child.process_id() {
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/F", "/T", "/PID", &pid.to_string()])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .stdin(std::process::Stdio::null())
+                    .status();
+            }
+            let _ = self.child.kill();
         }
-        #[cfg(windows)]
-        if let Some(pid) = self.child.process_id() {
-            let _ = std::process::Command::new("taskkill")
-                .args(["/F", "/T", "/PID", &pid.to_string()])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .stdin(std::process::Stdio::null())
-                .status();
-        }
-        let _ = self.child.kill();
         let _ = self.child.wait();
         self.exited = true;
     }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -618,6 +618,14 @@ impl Pane {
     /// tree first via `taskkill /F /T` so directory handles in the
     /// pane's cwd are released as soon as the pane is closed.
     pub fn kill(&mut self) {
+        // Short-circuit on the second pass through an already-killed
+        // pane: `remove_pane_from_layout` calls `kill()` explicitly and
+        // `Drop` calls it again on the same value (#214 review). The
+        // PTY EOF path also flips `exited` before `Pane` is dropped, so
+        // natural exits skip the spawn entirely.
+        if self.exited {
+            return;
+        }
         #[cfg(windows)]
         if let Some(pid) = self.child.process_id() {
             let _ = std::process::Command::new("taskkill")
@@ -629,6 +637,7 @@ impl Pane {
         }
         let _ = self.child.kill();
         let _ = self.child.wait();
+        self.exited = true;
     }
 
     /// Queue a command to be written into the PTY once the shell prompt


### PR DESCRIPTION
## Summary

Close #214 by terminating the entire process tree on `Pane::kill()` on Windows. The original issue posited that the FILES pane retained a directory handle of the closed Claude pane's cwd, but investigation showed the FILES pane has no persistent OS handle (no file watcher, no cached `ReadDir` iterator — `fs::read_dir` results are consumed and dropped within scope, so the underlying `FindFirst` handle is closed by Rust's `Drop for ReadDir`).

The actual cause is **grandchild process retention**. `spawn_claude_pane` launches a shell, which launches `claude` (Node.js / `node.exe`). On Windows, `portable-pty` 0.8.1's `Child::kill` calls `TerminateProcess` only on the immediate shell, leaving the grandchild Node process alive with its CWD still set to the worktree. Until renga itself exits, that surviving process keeps the directory locked and `git worktree remove --force` / `rmdir` fail with `Permission denied` / `Device or resource busy`.

## Changes

- **`src/pane.rs`** — `Pane::kill()` Windows branch now invokes `taskkill /F /T /PID <pid>` first to kill the entire process tree, then proceeds with the existing PTY child kill. Two correctness fixes from Codex review: short-circuit on already-exited panes (avoid double-kill), and always reap the PTY child to avoid Unix zombies on natural exit.
- 3 commits.

## Misdiagnosis acknowledgment

The original issue body's "FILES pane retains directory handle" hypothesis was the Secretary's first-pass guess. Code review of `src/filetree.rs` and surrounding modules (preview, claude_monitor) found no mechanism that holds a persistent OS handle on a worktree path. The grandchild process retention is the actual mechanism, validated by `portable-pty` source inspection and Windows kill semantics.

## Test plan

Automated Windows process-kill testing is impractical in renga's existing suite, so the verification is manual:

1. Start `renga --layout ops`.
2. From a Claude pane, call `mcp__renga-peers__spawn_claude_pane(cwd=<a fresh git worktree>)` to spawn a worker pane.
3. Let the worker do trivial work (e.g. `pwd`), then close it via `mcp__renga-peers__close_pane`.
4. From a separate shell, run `git worktree remove --force <that worktree>`.

Expected before fix: `error: failed to delete '...': Permission denied`.
Expected after fix: removal succeeds immediately.

## Verification

- [x] `cargo test` — 541 passed / 0 failed
- [x] `cargo clippy --all-targets -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Codex self-review 3 rounds (full depth) — all Major resolved (double-kill avoidance + zombie avoidance from rounds 1–2; round 3 approve)
- [x] Codex re-review of the misdiagnosis logic — confirmed FILES pane has no retained handle mechanism; the only adjacent risk (`set_current_dir` in `main.rs`) does not apply to the `--layout ops` + `spawn_claude_pane(cwd=...)` reproduction path.

Closes #214