### PR TITLE
fix(renga): deliver self-send PeerInbox instead of dropping silently (Closes #215)

### DIFF
--- a/src/app/codex_peer.rs
+++ b/src/app/codex_peer.rs
@@ -200,9 +200,10 @@ impl App {
     /// Route `body` from `from_pane` to `target` when both share a
     /// workspace. Cross-tab targets are silently dropped so the MCP
     /// server cannot enumerate panes in other tabs by probing ids.
-    /// Self-sends are also a no-op — the spike binary proved the
-    /// loopback rendering already; in production self-send is always
-    /// a mistake.
+    /// Self-sends loop back to the sender pane: tooling like
+    /// claude-org-ja's peer_notify resolves "secretary" from a shell
+    /// running inside the secretary pane, and a silent drop there
+    /// breaks the notification round-trip (see renga#215).
     pub(crate) fn handle_peer_send(
         &mut self,
         from_pane: usize,
@@ -221,7 +222,7 @@ impl App {
             Some(pair) => pair,
             None => return Ok(()),
         };
-        if sender_ws != target_ws || target_id == from_pane {
+        if sender_ws != target_ws {
             return Ok(());
         }
         self.materialize_unfocused_codex_peer_notification();

--- a/src/app/tests/codex_peer.rs
+++ b/src/app/tests/codex_peer.rs
@@ -134,6 +134,46 @@ fn handle_peer_send_emits_peer_inbox_to_sibling_in_same_tab() {
 }
 
 #[test]
+fn handle_peer_send_loops_back_to_sender_pane() {
+    // Regression for renga#215: when the resolved target is the
+    // sender pane itself (e.g. claude-org-ja's peer_notify resolving
+    // "secretary" from a shell inside the secretary pane), the
+    // handler must still emit PeerInbox so the local check_messages
+    // loop picks it up. Prior to the fix the self-send was silently
+    // dropped while JSON-RPC reported Delivered.
+    let mut app = App::new(40, 80).expect("App::new");
+    let (_sub_id, rx) = app.event_bus.subscribe();
+    let sender_id = app.ws().focused_pane_id;
+    while rx.try_recv().is_ok() {}
+
+    app.handle_peer_send(
+        sender_id,
+        &ipc::PaneRef::Id(sender_id),
+        "self ping".to_string(),
+    )
+    .expect("self send");
+
+    let mut found = false;
+    while let Ok(ev) = rx.try_recv() {
+        if let ipc::Event::PeerInbox {
+            target_pane,
+            from_pane,
+            body,
+            ..
+        } = ev
+        {
+            assert_eq!(target_pane, sender_id);
+            assert_eq!(from_pane, sender_id);
+            assert_eq!(body, "self ping");
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "expected PeerInbox event for self-send (renga#215)");
+    app.shutdown();
+}
+
+#[test]
 fn handle_peer_send_silently_drops_cross_tab_target() {
     // Cross-tab delivery is a silent no-op by design — callers
     // cannot enumerate panes in other tabs by probing ids. A


### PR DESCRIPTION
## Summary

- `handle_peer_send` returned `Ok` without emitting `Event::PeerInbox` whenever the resolved target pane equaled the sender pane, so JSON-RPC reported `Delivered` while the message was silently dropped.
- This broke claude-org-ja's `peer_notify` when invoked from a shell inside the recipient pane (e.g. Secretary's bash sending to `"secretary"`): the same call sent to a different pane (e.g. `dispatcher`) worked, only self-send was silently swallowed.
- Drop the self-send guard so the inbox event loops back to the sender pane. Cross-tab silence (the actual security boundary) is preserved.

## Test plan

- [x] `cargo test` — 542 passed (new regression `handle_peer_send_loops_back_to_sender_pane` in `src/app/tests/codex_peer.rs`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Codex self-review (full depth, 1 round): no Blocker / Major / Minor / Nit
- [ ] Manual end-to-end: claude-org-ja `tools/pr_watch.py` invoking `peer_notify("secretary", ...)` from Secretary's bash subprocess delivers a `<channel source="renga-peers">` message to the Secretary Claude pane (pending renga rebuild + session restart on the user's side).

Closes #215