### PR TITLE
release: v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,71 @@ and from v1.0 onward this project adheres to
 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) under the
 rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
-## [Unreleased] — v1.0.0 (planned)
+## [1.1.0] — 2026-05-07
+
+First release after the v1.0 API surface freeze. Two new optional features
+ship without touching the frozen surface, alongside four bug fixes.
+
+### Added
+
+- **`--fps` CLI flag and `[ui] fps` config key** for tuning the main
+  event-loop target rate. Higher values reduce idle input latency at the
+  cost of more wakeups; `0` is accepted and clamped to `1` at runtime to
+  avoid a busy loop. The CLI flag overrides the config key; default
+  behavior is unchanged when neither is set. Adds `--fps` to the frozen
+  CLI surface as a new optional flag and `[ui] fps` to the frozen config
+  schema as a new optional key (#213).
+- **Ctrl+U IME overlay shortcut** that discards the entire composition
+  buffer in one keystroke (multi-line, not just the current line). Footer
+  hint updated; lowercase / Shift / empty-buffer paths covered by tests
+  (#211).
+
+### Fixed
+
+- **Self-targeted peer sends now emit `Event::PeerInbox` instead of being
+  silently dropped.** `handle_peer_send` previously returned `Ok` without
+  emitting the event when `target_id == from_pane`, so JSON-RPC reported
+  `Delivered` while the recipient never observed the message. The
+  self-send guard is removed; cross-tab silence (the actual security
+  boundary) is preserved (#215, #217).
+- **Pane close now walks the descendant process tree on Windows.**
+  `portable-pty`'s `Child::kill` only terminates the immediate shell, so
+  grandchildren (e.g. `claude` / `node.exe` started via
+  `spawn_claude_pane`'s queued startup command) survived close and kept
+  open handles on the pane's working directory, blocking
+  `git worktree remove --force` and `Remove-Item`. `Pane::kill` now
+  invokes `taskkill /F /T /PID <pid>` before delegating to portable-pty,
+  short-circuits when `try_wait()` shows the child has already exited
+  (avoids redundant taskkill from `Drop` after an explicit close), and
+  always calls `wait()` so the child is reaped on every exit pathway —
+  no more zombies on natural Unix exit (#214, #216).
+- **Cosmetic Claude/Codex pane indicators latch across OSC title
+  rewrites.** The per-pane border accent, pane label, and status-bar tab
+  title now key off the sticky `claude_ever_seen()` / `codex_ever_seen()`
+  latches instead of the live title check, since both clients rewrite
+  their OSC 0/2 window titles to in-flight task summaries that frequently
+  drop the literal client name. Foreground-app gating
+  (`shell_accepts_command_injection`, mouse protocol resolution,
+  `codex_peer` fallback) keeps using the live signal where "is the client
+  foreground right now?" is actually needed.
+  `pane_expects_codex_peer_delivery` short-circuits on a registered
+  Claude pane so transient "codex" mentions in a Claude task title cannot
+  mis-route delivery (#209, #210).
+- **Cargo.toml version-history comments and BRANCHING.md no longer
+  reference the legacy `ccmux` binary name.** Comments for 0.9.0,
+  0.10.0, 0.13.0, 0.14.0, 0.16.0, 0.17.0, the interprocess pin comment,
+  the `~/.config/ccmux/.macos_tip_dismissed` path, and the
+  `CCMUX_NO_MACOS_TIP` env var are updated to current `renga` naming.
+  BRANCHING.md "renga と ccmux" is qualified as "upstream ccmux" to
+  disambiguate now that this repo IS renga (#212).
+
+## [1.0.0] — 2026-05-02
+
+API surface freeze release. Defines the v1.0 frozen surface and adopts
+formal semver for all subsequent changes. The Cargo.toml / `npm/package.json`
+version bump was omitted at tag time and is reconciled in 1.1.0; the v1.0.0
+git tag and GitHub Release remain the canonical marker for this surface
+freeze.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "0.18.5"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,28 @@ name = "renga"
 # AI-native terminal for multi-agent coding rather than only as a
 # Claude-only multiplexer. Patch bump because this is packaging /
 # messaging work, not a behavior change in the binary itself.
-version = "0.18.5"
+# 1.0.0 marks the API surface freeze across MCP tools, CLI, IPC
+# protocol, and config / layout / env (#201 / #207). The
+# `set_summary` MCP tool moves from stable-stub to a real per-pane
+# summary store, and `RENGA_TOKEN` / `RENGA_SOCKET` / `RENGA_PANE_ID`
+# / `RENGA_PEER_CLIENT_KIND` are now part of the formal v1.0
+# contract. Major bump under the new semver policy
+# (`docs/semver-policy.md`); the Cargo.toml / npm version bump was
+# omitted at tag time and is being reconciled at v1.1.0.
+# 1.1.0 is the first release after the v1.0 freeze. Adds the
+# `--fps` CLI flag with a `[ui] fps` config key counterpart so users
+# can dial the main event-loop rate (#213, additive optional
+# input), and a Ctrl+U IME overlay shortcut that wipes the entire
+# composition buffer in one keystroke (#211, additive keybinding).
+# Bug fixes: pane close now walks the Windows process tree via
+# `taskkill /F /T` so descendant processes release cwd handles
+# (#214 / #216), self-targeted peer sends emit `Event::PeerInbox`
+# instead of silently dropping (#215 / #217), and the per-pane
+# Claude/Codex cosmetic indicators latch on `*_ever_seen` so they
+# survive OSC title rewrites (#209 / #210). Minor bump under the
+# semver policy because two new optional features ship while the
+# frozen surface remains backward-compatible.
+version = "1.1.0"
 edition = "2021"
 description = "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "0.18.5",
+  "version": "1.1.0",
   "description": "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary
Cut v1.1.0 release. Reconciles version drift (Cargo.toml / npm/package.json were left at 0.18.5 when v1.0.0 was tagged) and bundles 6 commits since v1.0.0.

## SemVer rationale (minor bump)
- **Added (2)**
  - `--fps` CLI flag + `[ui] fps` config key (#213)
  - Ctrl+U IME overlay shortcut (#211)
- **Fixed (4)**
  - Self-send PeerInbox delivery (#217)
  - Windows descendant process kill + zombie reap (#216)
  - OSC title rewrite latch on pane close (#210)
  - Sweep residual ccmux references in `Cargo.toml` / `BRANCHING.md` (#212)

All additions are default-preserving (new optional flag / new config key / new keybinding overlay), matching the `docs/semver-policy.md` §2 minor-bump criteria.

## Diff (1 commit, `883baff`)
- `Cargo.toml`: `0.18.5` → `1.1.0`. Adds version-history comment entries for 1.0.0 / 1.1.0.
- `npm/package.json`: `0.18.5` → `1.1.0`.
- `Cargo.lock`: renga package row only.
- `CHANGELOG.md`: finalize `[Unreleased] — v1.0.0 (planned)` as `[1.0.0] — 2026-05-02`; add `[1.1.0] — 2026-05-07` with Added / Fixed sections.

## Note on v1.0.0 reconciliation
The v1.0.0 git tag and GitHub Release exist, but the Cargo.toml / npm/package.json version bump was missed at tag time, so a `1.0.0` package may not exist on npm. v1.1.0 reconciles the version on both sides; `CHANGELOG.md` documents this.

## Verification
- `cargo check` ✅ (fmt / clippy / test run on CI)
- `.githooks/pre-commit` passed

## Release procedure (post-merge)
After merge:
1. `git tag v1.1.0 && git push origin v1.1.0`
2. `release.yml` builds 4 platforms, publishes the GitHub Release (with `checksums.txt`), and runs npm publish via Trusted Publishing.
3. Manual `gh release create` / `npm publish` are forbidden per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)