### PR TITLE
chore: update npm package description tagline

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@suisya-systems/renga",
   "version": "1.1.0",
-  "description": "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace",
+  "description": "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes.",
   "bin": {
     "renga": "bin/cli.js"
   },


### PR DESCRIPTION
## Summary
- Update the first-line tagline shown on the npm package page (`npm/package.json` `description` field) to: "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes."

## Test plan
- [x] No code change; metadata-only update. No publish performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)