### PR TITLE
fix(renga): route bracketed-paste to IME overlay when open

### DIFF
--- a/src/app/keyboard_input.rs
+++ b/src/app/keyboard_input.rs
@@ -354,6 +354,23 @@ impl App {
 
     // ─── PTY forwarding ───────────────────────────────────
 
+    /// Route a terminal-level paste payload (bracketed-paste from the
+    /// host terminal — typically Ctrl+V on WSL2 / Windows Terminal /
+    /// WezTerm / iTerm2) to the right destination. When the IME
+    /// composition overlay is open, the paste belongs to the overlay
+    /// buffer; otherwise it forwards to the focused pane's PTY via
+    /// `forward_paste_to_pty`. Centralizing the routing here keeps
+    /// `main.rs` from having to reach into overlay internals.
+    pub fn handle_paste(&mut self, text: &str) -> Result<bool> {
+        if let Some(overlay) = self.overlay.as_mut() {
+            overlay.insert_str(text);
+            self.dirty = true;
+            return Ok(true);
+        }
+        self.forward_paste_to_pty(text)?;
+        Ok(false)
+    }
+
     /// Forward pasted text to PTY, wrapping in bracketed paste only if
     /// the PTY application has enabled the mode (e.g. Claude Code, modern
     /// readline). Sending bracketed paste to a shell that hasn't opted in

--- a/src/app/tests/overlay.rs
+++ b/src/app/tests/overlay.rs
@@ -618,6 +618,33 @@ fn handle_paste_truncates_at_buffer_cap() {
 }
 
 #[test]
+fn handle_paste_normalizes_crlf_from_windows_clipboard() {
+    // The actual user environment is WSL2, where Ctrl+V pastes text
+    // copied from Windows applications — clipboard payloads use CRLF
+    // line endings. wrap_overlay_buffer (ui.rs) only recognizes \n
+    // as a hard newline, so a stray \r would render as a zero-width
+    // control glyph and offset the rendered cursor from the buffer
+    // cursor by one char per pasted line. Normalize at intake.
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_a = app.ws().focused_pane_id;
+    app.overlay = Some(crate::input::overlay::OverlayState::new(pane_a));
+
+    app.handle_paste("first\r\nsecond\rthird")
+        .expect("handle_paste");
+
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert_eq!(
+        overlay.buffer, "first\nsecond\nthird",
+        "CRLF and bare CR must collapse to \\n"
+    );
+    assert_eq!(overlay.cursor, "first\nsecond\nthird".chars().count());
+    assert!(
+        !overlay.buffer.contains('\r'),
+        "no carriage returns should survive normalization"
+    );
+}
+
+#[test]
 fn handle_paste_falls_through_to_pty_when_overlay_closed() {
     // Behavior preservation guard: with no overlay open the paste
     // path must still reach the focused pane's PTY (and return false

--- a/src/app/tests/overlay.rs
+++ b/src/app/tests/overlay.rs
@@ -545,3 +545,90 @@ fn freeze_panes_does_not_suppress_without_overlay() {
 
     assert!(app.dirty, "PtyOutput must dirty when overlay is closed");
 }
+
+#[test]
+fn handle_paste_routes_to_overlay_when_open() {
+    // The user-visible bug: on WSL2, terminal-level Ctrl+V emits a
+    // bracketed-paste sequence which crossterm surfaces as
+    // Event::Paste. Without overlay-aware routing the text leaked to
+    // the back pane's PTY even though the IME composition overlay
+    // was holding focus. handle_paste must intercept and deliver the
+    // payload into the overlay buffer instead.
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_a = app.ws().focused_pane_id;
+    let mut state = crate::input::overlay::OverlayState::new(pane_a);
+    state.insert_char('a');
+    app.overlay = Some(state);
+    app.dirty = false;
+
+    let routed_to_overlay = app.handle_paste("bcd").expect("handle_paste");
+
+    assert!(routed_to_overlay, "overlay-open paste must report routed");
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert_eq!(overlay.buffer, "abcd");
+    assert_eq!(overlay.cursor, 4);
+    assert!(app.dirty, "overlay paste must mark dirty for redraw");
+}
+
+#[test]
+fn handle_paste_inserts_at_cursor_position() {
+    // The cursor isn't always at the buffer end (the user may have
+    // arrowed back to fix earlier composition). Pasted text must
+    // splice in at the cursor and advance it past the inserted run.
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_a = app.ws().focused_pane_id;
+    let mut state = crate::input::overlay::OverlayState::new(pane_a);
+    for ch in "ab".chars() {
+        state.insert_char(ch);
+    }
+    state.cursor = 1;
+    app.overlay = Some(state);
+
+    app.handle_paste("XY").expect("handle_paste");
+
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert_eq!(overlay.buffer, "aXYb");
+    assert_eq!(overlay.cursor, 3, "cursor advances past inserted run");
+}
+
+#[test]
+fn handle_paste_truncates_at_buffer_cap() {
+    // The overlay caps the composition buffer at 4096 chars to
+    // bound memory on a stuck key. Pasted text must follow the same
+    // cap by truncating the tail; dropping the entire paste would
+    // be far worse UX than a clipped paste.
+    let mut app = App::new(40, 80).expect("App::new");
+    let pane_a = app.ws().focused_pane_id;
+    let mut state = crate::input::overlay::OverlayState::new(pane_a);
+    for _ in 0..4090 {
+        state.insert_char('x');
+    }
+    app.overlay = Some(state);
+
+    app.handle_paste("0123456789abcdef").expect("handle_paste");
+
+    let overlay = app.overlay.as_ref().expect("overlay still open");
+    assert_eq!(overlay.buffer.chars().count(), 4096);
+    assert_eq!(overlay.cursor, 4096);
+    assert!(
+        overlay.buffer.ends_with("xxxxxx012345"),
+        "tail of buffer must reflect the truncated paste prefix, got {:?}",
+        &overlay.buffer[overlay.buffer.len().saturating_sub(20)..]
+    );
+}
+
+#[test]
+fn handle_paste_falls_through_to_pty_when_overlay_closed() {
+    // Behavior preservation guard: with no overlay open the paste
+    // path must still reach the focused pane's PTY (and return false
+    // so main.rs keeps applying the post-PTY-paste cooldown).
+    let mut app = App::new(40, 80).expect("App::new");
+    assert!(app.overlay.is_none());
+
+    let routed_to_overlay = app.handle_paste("hello").expect("handle_paste");
+
+    assert!(
+        !routed_to_overlay,
+        "no overlay → paste must report PTY-routed"
+    );
+}

--- a/src/input/overlay.rs
+++ b/src/input/overlay.rs
@@ -83,9 +83,13 @@ impl OverlayState {
         if current_len >= MAX_BUFFER_CHARS {
             return;
         }
-        let normalized = normalize_paste_line_endings(s);
         let remaining = MAX_BUFFER_CHARS - current_len;
-        let to_insert: String = normalized.chars().take(remaining).collect();
+        // Stream the normalized chars and stop once we hit the cap so a
+        // megabyte-class paste doesn't allocate megabytes upfront just
+        // to throw most of it away. `take(remaining)` short-circuits
+        // the `\r`/`\n` state machine the moment we've collected
+        // enough.
+        let to_insert: String = normalize_paste_line_endings(s).take(remaining).collect();
         if to_insert.is_empty() {
             return;
         }
@@ -283,29 +287,25 @@ const CLAUDE_INPUT_WALK_MAX: u16 = 20;
 /// `wrap_overlay_buffer` in `ui.rs`), so leaving carriage returns
 /// in-band would render as zero-width control glyphs and desync the
 /// rendered cursor from the buffer cursor on Windows-clipboard
-/// pastes via WSL2.
-fn normalize_paste_line_endings(s: &str) -> String {
-    if !s.contains('\r') {
-        return s.to_owned();
-    }
-    let mut out = String::with_capacity(s.len());
+/// pastes via WSL2. Returns an iterator so the caller can `take()`
+/// up to the buffer cap without allocating the full normalized
+/// string for a paste that will be truncated anyway.
+fn normalize_paste_line_endings(s: &str) -> impl Iterator<Item = char> + '_ {
     let mut prev_cr = false;
-    for ch in s.chars() {
-        match ch {
-            '\r' => {
-                out.push('\n');
-                prev_cr = true;
-            }
-            '\n' if prev_cr => {
-                prev_cr = false;
-            }
-            _ => {
-                out.push(ch);
-                prev_cr = false;
-            }
+    s.chars().filter_map(move |ch| match ch {
+        '\r' => {
+            prev_cr = true;
+            Some('\n')
         }
-    }
-    out
+        '\n' if prev_cr => {
+            prev_cr = false;
+            None
+        }
+        _ => {
+            prev_cr = false;
+            Some(ch)
+        }
+    })
 }
 
 pub(crate) fn snapshot_visible_input(pane: &crate::pane::Pane) -> Option<VisibleInputSnapshot> {

--- a/src/input/overlay.rs
+++ b/src/input/overlay.rs
@@ -58,6 +58,40 @@ impl OverlayState {
         self.cursor += 1;
     }
 
+    /// Insert `s` at the overlay cursor and advance the cursor by the
+    /// number of inserted chars. Used for routing terminal-level
+    /// bracketed-paste payloads (Ctrl+V on WSL2 / Windows Terminal /
+    /// WezTerm) into the composition buffer instead of the underlying
+    /// pane. Honors the same 4096-char cap as `insert_char` by
+    /// truncating the tail rather than rejecting the whole paste — a
+    /// dropped paste is harder to recover from than a clipped one.
+    pub fn insert_str(&mut self, s: &str) {
+        const MAX_BUFFER_CHARS: usize = 4096;
+
+        if s.is_empty() {
+            return;
+        }
+        let current_len = self.buffer.chars().count();
+        if current_len >= MAX_BUFFER_CHARS {
+            return;
+        }
+        let remaining = MAX_BUFFER_CHARS - current_len;
+        let to_insert: String = s.chars().take(remaining).collect();
+        if to_insert.is_empty() {
+            return;
+        }
+        let inserted_chars = to_insert.chars().count();
+
+        let byte_idx = self
+            .buffer
+            .char_indices()
+            .nth(self.cursor)
+            .map(|(i, _)| i)
+            .unwrap_or(self.buffer.len());
+        self.buffer.insert_str(byte_idx, &to_insert);
+        self.cursor += inserted_chars;
+    }
+
     /// Clear the entire composition buffer and reset the cursor.
     pub fn clear(&mut self) {
         self.buffer.clear();

--- a/src/input/overlay.rs
+++ b/src/input/overlay.rs
@@ -62,9 +62,17 @@ impl OverlayState {
     /// number of inserted chars. Used for routing terminal-level
     /// bracketed-paste payloads (Ctrl+V on WSL2 / Windows Terminal /
     /// WezTerm) into the composition buffer instead of the underlying
-    /// pane. Honors the same 4096-char cap as `insert_char` by
-    /// truncating the tail rather than rejecting the whole paste — a
-    /// dropped paste is harder to recover from than a clipped one.
+    /// pane. Honors the same 4096-char cap that `handle_overlay_key`
+    /// applies to typed input, by truncating the tail rather than
+    /// rejecting the whole paste — a dropped paste is harder to
+    /// recover from than a clipped one.
+    ///
+    /// Line endings are normalized to `\n` so a Windows-clipboard
+    /// paste (the WSL2 user's primary path) doesn't leave bare `\r`
+    /// bytes in the buffer. The overlay's wrap/render path treats
+    /// only `\n` as a hard newline, and `\r` is a width-zero control
+    /// char — without normalization the host clipboard's CRLF would
+    /// desync the rendered cursor from the buffer cursor.
     pub fn insert_str(&mut self, s: &str) {
         const MAX_BUFFER_CHARS: usize = 4096;
 
@@ -75,8 +83,9 @@ impl OverlayState {
         if current_len >= MAX_BUFFER_CHARS {
             return;
         }
+        let normalized = normalize_paste_line_endings(s);
         let remaining = MAX_BUFFER_CHARS - current_len;
-        let to_insert: String = s.chars().take(remaining).collect();
+        let to_insert: String = normalized.chars().take(remaining).collect();
         if to_insert.is_empty() {
             return;
         }
@@ -268,6 +277,36 @@ const CLAUDE_PROMPT_GLYPHS: &[&str] = &[
 ];
 const CLAUDE_PROMPT_SCAN_COLS: u16 = 8;
 const CLAUDE_INPUT_WALK_MAX: u16 = 20;
+
+/// Collapse `\r\n` and bare `\r` into `\n` for paste payloads. The
+/// overlay buffer treats `\n` as the only line break (see
+/// `wrap_overlay_buffer` in `ui.rs`), so leaving carriage returns
+/// in-band would render as zero-width control glyphs and desync the
+/// rendered cursor from the buffer cursor on Windows-clipboard
+/// pastes via WSL2.
+fn normalize_paste_line_endings(s: &str) -> String {
+    if !s.contains('\r') {
+        return s.to_owned();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut prev_cr = false;
+    for ch in s.chars() {
+        match ch {
+            '\r' => {
+                out.push('\n');
+                prev_cr = true;
+            }
+            '\n' if prev_cr => {
+                prev_cr = false;
+            }
+            _ => {
+                out.push(ch);
+                prev_cr = false;
+            }
+        }
+    }
+    out
+}
 
 pub(crate) fn snapshot_visible_input(pane: &crate::pane::Pane) -> Option<VisibleInputSnapshot> {
     let parser = pane.parser.lock().ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,8 +487,10 @@ fn run_event_loop(
                 }
                 Event::Key(_) => {}
                 Event::Paste(text) => {
-                    app.forward_paste_to_pty(&text)?;
-                    app.paste_cooldown = 5;
+                    let routed_to_overlay = app.handle_paste(&text)?;
+                    if !routed_to_overlay {
+                        app.paste_cooldown = 5;
+                    }
                     app.dirty = true;
                 }
                 Event::Mouse(mouse) => {


### PR DESCRIPTION
## Summary

When the IME Overlay is open, bracketed-paste content is now routed to the overlay's composition buffer instead of being forwarded to the background PTY.

- `src/main.rs`: `Event::Paste(text)` now flows through `app.handle_paste(&text)`. Pastes routed to the overlay skip the `paste_cooldown` flag because no PTY echo round-trip is involved.
- `src/app/keyboard_input.rs`: new `App::handle_paste(text) -> Result<bool>` returns true when the overlay is open and consumed the paste, false otherwise.
- `src/input/overlay.rs`: new `OverlayState::insert_str` splices at the cursor with a 4096-char cap. CRLF normalization (`normalize_paste_line_endings`) is implemented as an iterator + `take(remaining).collect()` so the allocation stays bounded for large clipboard payloads.
- `src/app/tests/overlay.rs`: 5 new tests covering overlay-open routing, mid-cursor insertion, the 4096-char truncation cap, CRLF normalization, and PTY fall-through when the overlay is closed.

## Why

Reported on WSL2 + Windows Terminal: while the IME Overlay was open, pressing Ctrl+V pasted into the background Claude Code input field rather than the overlay. Code path inspection (crossterm 0.29 `event/sys/unix/parse.rs:813` `parse_csi_bracketed_paste`, `#[cfg(feature = \"bracketed-paste\")]`) confirmed `Event::Paste` is emitted only by the Unix backend, so the bug surfaces wherever a terminal sends `\x1b[200~...\x1b[201~` to a Linux/macOS renga binary. Windows native renga.exe is unaffected because the Windows backend has no bracketed-paste parser and pastes arrive as per-character `Event::Key`.

## Per-environment behavior matrix

| Environment | Ctrl+V interpretation | Path | Before | After |
|---|---|---|---|---|
| **Windows native (Windows Terminal, renga.exe)** | paste (default) | conpty injects paste as `Event::Key(Char(c))` per-character. crossterm Windows backend has no bracketed-paste parser. | Overlay buffer (already correct via per-char key handler) | Unchanged |
| **Windows native (conhost)** | console-API paste | Same per-character key event path | Overlay buffer | Unchanged |
| **WSL2 (Windows Terminal)** | paste (default) | bracketed-paste -> `Event::Paste` (Linux backend) | Background PTY (the reported bug) | **Overlay buffer** |
| **WSL2 (WezTerm-Win, custom paste binding)** | user-bound paste | `Event::Paste` when bound to paste; `Event::Key` for raw Ctrl+V | Custom: background PTY / Raw: swallowed by overlay | Custom: **overlay buffer** / Raw: unchanged |
| **Linux native (GNOME Terminal / Konsole / Alacritty / WezTerm / Kitty defaults)** | pass-through (paste is Ctrl+Shift+V) | `Event::Key(Char('v')+CONTROL)` | Swallowed by overlay | Unchanged |
| **Linux native -- Ctrl+Shift+V (default paste)** | paste | bracketed-paste -> `Event::Paste` | Background PTY | **Overlay buffer** |
| **macOS (iTerm2 / Terminal.app / WezTerm / Alacritty / Kitty defaults)** | pass-through (paste is Cmd+V) | `Event::Key(Char('v')+CONTROL)` | Swallowed by overlay | Unchanged |
| **macOS -- Cmd+V (default paste)** | paste | bracketed-paste -> `Event::Paste` | Background PTY (verified empirically with this PR's reporter) | **Overlay buffer** |

In short, the fix corrects the routing on every environment that ships paste through bracketed-paste sequences (WSL2 / Linux native via Ctrl+Shift+V / macOS via Cmd+V). Windows native renga.exe is outside the bug's reach and is not touched by the change.

## Out of scope (existing behavior preserved)

- Raw Ctrl+V (`\x16`) inside the overlay continues to be swallowed by the overlay. Adding a clipboard-read fallback there would require a new dependency (e.g. `arboard`) and is left for a follow-up.

## Test plan

- [x] `cargo build`: clean.
- [x] `cargo clippy --all-targets`: no warnings.
- [x] `cargo fmt --check`: clean.
- [x] `cargo test`: 561 passed; 0 failed (5 new tests included).
- [x] Codex self-review at full depth, three rounds: zero Blocker / Major / Minor / Nit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)