### PR TITLE
chore: bump version to v1.2.0 (Refs #229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-05-10
+
+First minor release after v1.1.x. Adds soft validation of
+`spawn_claude_pane` `args[]` against the parsed `claude --help` output
+so common flag typos are surfaced at MCP-call time rather than via a
+cryptic Claude startup failure inside the spawned pane. The frozen v1.0
+MCP wire shape is unchanged — input field types, required/optional
+status, and error-code names are all preserved; the new validator only
+adds a soft-fail path on previously-accepted-but-bogus flag spellings.
+
+### Added
+
+- **`spawn_claude_pane` soft-validates flag-like `args[]` entries
+  against the parsed output of `claude --help`.** Help text is fetched
+  once per process and cached for 5 minutes; if the parser fails or
+  `claude --help` is unreachable the validator falls open so a
+  transient `claude` outage cannot block pane spawns. Reserved-flag
+  rejection (`--dangerously-load-development-channels`,
+  `--permission-mode`, `--model` — already required for security
+  routing because renga injects its own values for those) still runs
+  first, so the soft validator never sees a reserved flag. Refs #229.
+  (#230)
+
 ## [1.1.3] — 2026-05-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,19 @@ name = "renga"
 # README.ja, and the docs site keymap tables now call out the WSL
 # caveat next to the Alt+Enter row (#226 / #227). Patch bump: the
 # frozen API surface is unchanged; this is a keyboard-input bug fix.
-version = "1.1.3"
+# 1.2.0 makes `spawn_claude_pane` soft-validate flag-like entries in
+# `args[]` against the parsed output of `claude --help` (#229 / #230).
+# Help text is fetched once per process and cached for 5 minutes; if
+# the parser fails or `claude --help` is unreachable the validator
+# falls open so a transient `claude` outage cannot block pane spawns.
+# Reserved-flag rejection (`--dangerously-load-development-channels`,
+# `--permission-mode`, `--model` — already required for security
+# routing) still runs first. New behavior on an existing MCP tool's
+# input shape, additive: previously-accepted args remain accepted
+# unless they are clearly mis-spelled flags. Minor bump under the
+# v1.0 semver policy because the validation surface is new even
+# though no existing field shape changed.
+version = "1.2.0"
 edition = "2021"
 description = "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes.",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary

Version bump 1.1.3 → 1.2.0 (semver minor) for the soft-validation feature added in #230. After this PR merges, Secretary tags `v1.2.0` and creates the GH release notes.

Refs #229.

## Changes (4 files, +38 -3)

- `Cargo.toml`: workspace + member crate versions 1.1.3 → 1.2.0
- `Cargo.lock`: lockfile sync
- `CHANGELOG.md`: new `## [1.2.0] — 2026-05-10` section summarizing the soft-validation feature (parses `claude --help` once per process, 5-minute TTL allowlist cache, fall-open on parser failure, reserved-flag rejection still runs first)
- `npm/package.json`: npm wrapper lockstep bump 1.1.3 → 1.2.0

## Out of scope

- tag `v1.2.0` and GH release notes — Secretary post-merge action

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — pass
- [ ] CI green
- [ ] After merge: tag v1.2.0 + GH release (Secretary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)