### PR TITLE
Build Linux release binary with musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: renga-macos-arm64
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             artifact: renga-linux-x64
 
@@ -35,6 +35,10 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install Linux static-linking toolchain
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-05-11
+
+Patch release. Rebuilds the Linux npm release artifact with the musl
+target so npm-installed `renga` no longer inherits the glibc version
+from GitHub Actions' `ubuntu-latest` image.
+
+### Fixed
+
+- **Linux npm installs no longer fail on distributions older than the
+  release runner's glibc with `GLIBC_2.39 not found`.** The release
+  workflow now builds `renga-linux-x64` for
+  `x86_64-unknown-linux-musl` and installs `musl-tools` only for that
+  matrix entry, keeping the published filename and npm installer
+  contract unchanged. (#235)
+
 ## [1.2.0] — 2026-05-10
 
 First minor release after v1.1.x. Adds soft validation of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,11 @@ name = "renga"
 # unless they are clearly mis-spelled flags. Minor bump under the
 # v1.0 semver policy because the validation surface is new even
 # though no existing field shape changed.
-version = "1.2.0"
+# 1.2.1 rebuilds the Linux npm release artifact with musl so the
+# downloaded binary does not require the glibc version from the
+# release runner (`GLIBC_2.39` on ubuntu-latest at the time of the
+# broken 1.2.0 artifact). Patch bump: packaging-only compatibility fix.
+version = "1.2.1"
 edition = "2021"
 description = "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes.",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary
- build the Linux npm release artifact with the musl target
- install musl-tools for the Linux release job
- bump the release version to 1.2.1 and document the packaging fix

## Reason
The 1.2.0 Linux npm artifact was built on ubuntu-latest and can require GLIBC_2.39 at runtime. Building the Linux release binary with musl avoids that glibc version dependency for npm installs on older Linux distributions. npm cannot republish the existing 1.2.0 package version, so this ships as 1.2.1.

## Testing
- python3 YAML parse for .github/workflows/release.yml
- git diff --check
- local cargo build not run: cargo/rustc are not installed in this environment