### PR TITLE
fix(renga): per-model context_limit — raise Opus to 500K, keep Sonnet/Haiku/fallback at 200K

### DIFF
--- a/src/claude_monitor.rs
+++ b/src/claude_monitor.rs
@@ -78,19 +78,21 @@ impl ClaudeState {
     /// into the JSONL, **without** the `[1m]` suffix even when the
     /// session is running the 1M variant. Opus 4.6 ships with a 1M
     /// context by default for Pro / Max users, so it's treated as 1M
-    /// here. Other models use a 500K baseline so the status-bar usage
-    /// ratio better reflects the actual Claude 4.X context windows
-    /// (especially `[1m]` variants); the explicit `[1m]` / `-1m`
-    /// suffix path catches any future model that does spell it out.
+    /// here. Older Opus uses a 500K baseline so the status-bar usage
+    /// ratio better reflects the practical working window on those
+    /// models. Haiku and Sonnet keep their native 200K window — the
+    /// `[1m]` extended variants are still picked up by the explicit
+    /// `[1m]` / `-1m` suffix path above. Unknown models fall back to
+    /// 200K as the safe default.
     pub fn context_limit(&self) -> u64 {
         match self.model.as_deref() {
             Some(m) if m.contains("[1m]") || m.contains("-1m") => 1_000_000,
             // Opus 4.6+: 1M context is default.
             Some(m) if m.contains("opus-4-6") => 1_000_000,
-            Some(m) if m.contains("haiku") => 500_000,
-            Some(m) if m.contains("sonnet") => 500_000,
+            Some(m) if m.contains("haiku") => 200_000,
+            Some(m) if m.contains("sonnet") => 200_000,
             Some(m) if m.contains("opus") => 500_000,
-            _ => 500_000,
+            _ => 200_000,
         }
     }
 
@@ -619,10 +621,10 @@ mod tests {
         state.model = Some("claude-opus-4-5".to_string());
         assert_eq!(state.context_limit(), 500_000);
 
-        // Sonnet / Haiku also use the 500K baseline.
+        // Sonnet / Haiku keep their native 200K window.
         state.model = Some("claude-sonnet-4-6".to_string());
-        assert_eq!(state.context_limit(), 500_000);
+        assert_eq!(state.context_limit(), 200_000);
         state.model = Some("claude-haiku-4-5".to_string());
-        assert_eq!(state.context_limit(), 500_000);
+        assert_eq!(state.context_limit(), 200_000);
     }
 }

--- a/src/claude_monitor.rs
+++ b/src/claude_monitor.rs
@@ -78,18 +78,19 @@ impl ClaudeState {
     /// into the JSONL, **without** the `[1m]` suffix even when the
     /// session is running the 1M variant. Opus 4.6 ships with a 1M
     /// context by default for Pro / Max users, so it's treated as 1M
-    /// here. Sonnet and Haiku still default to 200K; the explicit
-    /// `[1m]` / `-1m` suffix path catches any future model that does
-    /// spell it out.
+    /// here. Other models use a 500K baseline so the status-bar usage
+    /// ratio better reflects the actual Claude 4.X context windows
+    /// (especially `[1m]` variants); the explicit `[1m]` / `-1m`
+    /// suffix path catches any future model that does spell it out.
     pub fn context_limit(&self) -> u64 {
         match self.model.as_deref() {
             Some(m) if m.contains("[1m]") || m.contains("-1m") => 1_000_000,
             // Opus 4.6+: 1M context is default.
             Some(m) if m.contains("opus-4-6") => 1_000_000,
-            Some(m) if m.contains("haiku") => 200_000,
-            Some(m) if m.contains("sonnet") => 200_000,
-            Some(m) if m.contains("opus") => 200_000,
-            _ => 200_000,
+            Some(m) if m.contains("haiku") => 500_000,
+            Some(m) if m.contains("sonnet") => 500_000,
+            Some(m) if m.contains("opus") => 500_000,
+            _ => 500_000,
         }
     }
 
@@ -614,14 +615,14 @@ mod tests {
         state.model = Some("claude-opus-4-6[1m]".to_string());
         assert_eq!(state.context_limit(), 1_000_000);
 
-        // Older Opus remains 200K.
+        // Older Opus uses the 500K baseline.
         state.model = Some("claude-opus-4-5".to_string());
-        assert_eq!(state.context_limit(), 200_000);
+        assert_eq!(state.context_limit(), 500_000);
 
-        // Sonnet / Haiku default to 200K.
+        // Sonnet / Haiku also use the 500K baseline.
         state.model = Some("claude-sonnet-4-6".to_string());
-        assert_eq!(state.context_limit(), 200_000);
+        assert_eq!(state.context_limit(), 500_000);
         state.model = Some("claude-haiku-4-5".to_string());
-        assert_eq!(state.context_limit(), 200_000);
+        assert_eq!(state.context_limit(), 500_000);
     }
 }


### PR DESCRIPTION
## Summary

Adjust `claude_monitor::context_limit()` per-model so the status-bar token usage ratio reflects the actual Claude 4.X context windows for each tier. Opus moves to a 500K baseline (closer to real Pro/Max usage); Sonnet, Haiku, and the unknown-model fallback stay at their native 200K. The explicit `[1m]` / `-1m` suffix and `opus-4-6` (default 1M) overrides remain unchanged.

## Why

User report: the status-bar token consumption display is judged against a 200K baseline for every model. That doesn't match real usage — Opus runs (especially `[1m]` variants) regularly cross 200K, making the ratio meaningless. Per-model tuning is the minimum change.

## Behavior matrix

| Model match | Before | After |
|---|---|---|
| `[1m]` or `-1m` suffix | 1,000,000 | 1,000,000 (unchanged) |
| `opus-4-6` | 1,000,000 | 1,000,000 (unchanged) |
| `opus` (other) | 200,000 | **500,000** |
| `sonnet` | 200,000 | 200,000 (unchanged) |
| `haiku` | 200,000 | 200,000 (unchanged) |
| fallback (unknown) | 200,000 | 200,000 (unchanged) |

## Verification

- `cargo test claude_monitor` — 8 passed
- Full `cargo test` — 576 passed (no regressions)

## Out of scope

- Per-model context detection for `[1m]` suffix on non-Opus models (separate change if needed)
- Status-bar color thresholds, display format, or status-bar code in `src/ui.rs`
- Version bump / CHANGELOG (small tuning, will ride on next release)

## Test plan

- [ ] CI green across macOS / Ubuntu / Windows / clippy / rustfmt
- [ ] After merge: operator visually confirms the bottom-right token display now treats 500K as 100% for Opus sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
