### PR TITLE
Fix WSL clipboard bridging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
 ## [Unreleased]
 
+## [1.2.3] — 2026-05-14
+
+Patch release. Fixes clipboard copy on WSL when the normal Linux
+clipboard backend is unavailable and when pane-local applications such
+as Claude Code emit OSC 52 clipboard sequences that the host terminal
+does not accept directly. The frozen v1.0 API surface (MCP wire shape,
+CLI flags, config keys, env vars) is unchanged.
+
+### Fixed
+
+- **Text selected with the mouse in renga now reaches the Windows
+  clipboard on WSL even when the regular clipboard backend fails.**
+  renga retries stale clipboard handles, then falls back to `clip.exe`
+  under WSL so selected pane / preview text is still pasteable in
+  renga, sibling panes, and Windows applications.
+- **OSC 52 copy requests emitted by pane applications are bridged to
+  renga's clipboard path.** Claude Code's terminal-copy path now works
+  inside renga even when the outer terminal refuses OSC 52 directly:
+  renga decodes BEL- and ST-terminated OSC 52 payloads, tolerates PTY
+  chunk boundaries, and forwards the decoded text through the same
+  WSL-aware clipboard fallback.
+
 ## [1.2.2] — 2026-05-13
 
 Patch release. Reorganizes the README into a ~200-line landing-style

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,12 @@ name = "renga"
 # config keys, env vars) is unchanged — README/docs reorg is content
 # only, and the per-model context_limit change is a presentation tweak
 # to the status-bar ratio, not a new public field.
-version = "1.2.2"
+# 1.2.3 fixes clipboard copy on WSL by falling back to `clip.exe` when
+# the regular clipboard backend is unavailable and by bridging OSC 52
+# clipboard requests emitted by pane-local applications such as Claude
+# Code into renga's clipboard path. Patch bump: clipboard transport
+# compatibility fix; the frozen v1.0 API surface is unchanged.
+version = "1.2.3"
 edition = "2021"
 description = "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes.",
   "bin": {
     "renga": "bin/cli.js"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::Write;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, Instant};
 

--- a/src/app/app_core.rs
+++ b/src/app/app_core.rs
@@ -272,14 +272,50 @@ impl App {
 
     /// Copy text to clipboard, reusing the handle if available.
     pub(crate) fn copy_to_clipboard(&mut self, text: &str) {
-        if self.clipboard.is_none() {
-            self.clipboard = arboard::Clipboard::new().ok();
-        }
         if let Some(ref mut cb) = self.clipboard {
-            let _ = cb.set_text(text);
+            if cb.set_text(text).is_ok() {
+                return;
+            }
+            self.clipboard = None;
+        }
+
+        self.clipboard = arboard::Clipboard::new().ok();
+        if let Some(ref mut cb) = self.clipboard {
+            if cb.set_text(text).is_ok() {
+                return;
+            }
+        }
+
+        if running_under_wsl() {
+            let _ = copy_to_windows_clipboard(text);
         }
     }
+}
 
+fn running_under_wsl() -> bool {
+    std::env::var_os("WSL_INTEROP").is_some()
+        || std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|release| release.to_ascii_lowercase().contains("microsoft"))
+            .unwrap_or(false)
+}
+
+fn copy_to_windows_clipboard(text: &str) -> std::io::Result<()> {
+    let mut child = Command::new("clip.exe")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(text.as_bytes())?;
+    }
+
+    child.wait()?;
+    Ok(())
+}
+
+impl App {
     /// Recompute pane rectangles and apply sizes to every PTY in the
     /// active workspace. Returns `true` if any pane was actually
     /// resized (so callers can decide whether to enter the post-resize

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -113,6 +113,8 @@ pub enum AppCommand {
 pub enum AppEvent {
     /// PTY output received for a pane.
     PtyOutput(#[allow(dead_code)] usize),
+    /// A pane emitted OSC 52 with clipboard text.
+    ClipboardCopy(String),
     /// PTY process exited for a pane.
     PtyEof(usize),
     /// Shell changed working directory (pane_id, new path).

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -72,6 +72,9 @@ impl App {
                     }
                 }
                 AppEvent::PtyOutput(_) => {}
+                AppEvent::ClipboardCopy(text) => {
+                    self.copy_to_clipboard(&text);
+                }
             }
         }
         if had_events {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -941,6 +941,7 @@ fn pty_reader_thread(
     const TAIL_CAP: usize = 256;
     let mut tail: Vec<u8> = Vec::with_capacity(TAIL_CAP * 2);
     let mut control_tail: Vec<u8> = Vec::with_capacity(64);
+    let mut osc52_tail: Vec<u8> = Vec::with_capacity(4096);
 
     let mut buf = [0u8; 4096];
     loop {
@@ -1015,6 +1016,13 @@ fn pty_reader_thread(
                 if let Some(enabled) = detect_alternate_scroll_toggle(&control_tail) {
                     alternate_scroll_mode.store(enabled, Ordering::Relaxed);
                 }
+                osc52_tail.extend_from_slice(data);
+                for text in drain_osc52_copies(&mut osc52_tail) {
+                    let _ = event_tx.send(AppEvent::ClipboardCopy(text));
+                }
+                if osc52_tail.len() > 1_048_576 {
+                    osc52_tail.clear();
+                }
 
                 let mut parser = parser.lock().unwrap_or_else(|e| e.into_inner());
                 parser.process(data);
@@ -1038,6 +1046,125 @@ fn pty_reader_thread(
             }
         }
     }
+}
+
+fn drain_osc52_copies(buf: &mut Vec<u8>) -> Vec<String> {
+    const PREFIX: &[u8] = b"\x1b]52;";
+    let mut copies = Vec::new();
+    let mut search_from = 0;
+
+    loop {
+        let Some(start_rel) = find_subslice(&buf[search_from..], PREFIX) else {
+            keep_possible_prefix_suffix(buf, PREFIX);
+            break;
+        };
+        let start = search_from + start_rel;
+        let payload_start = start + PREFIX.len();
+        let Some((term_start, term_end)) = find_osc_terminator(buf, payload_start) else {
+            if start > 0 {
+                buf.drain(..start);
+            }
+            break;
+        };
+
+        if let Some(text) = decode_osc52_body(&buf[payload_start..term_start]) {
+            copies.push(text);
+        }
+        buf.drain(..term_end);
+        search_from = 0;
+    }
+
+    copies
+}
+
+fn decode_osc52_body(body: &[u8]) -> Option<String> {
+    let sep = body.iter().position(|&b| b == b';')?;
+    let payload = &body[sep + 1..];
+    if payload == b"?" {
+        return None;
+    }
+    let bytes = decode_base64(payload)?;
+    String::from_utf8(bytes).ok()
+}
+
+fn find_osc_terminator(buf: &[u8], from: usize) -> Option<(usize, usize)> {
+    let mut i = from;
+    while i < buf.len() {
+        if buf[i] == b'\x07' {
+            return Some((i, i + 1));
+        }
+        if buf[i] == b'\x1b' && buf.get(i + 1) == Some(&b'\\') {
+            return Some((i, i + 2));
+        }
+        i += 1;
+    }
+    None
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn keep_possible_prefix_suffix(buf: &mut Vec<u8>, prefix: &[u8]) {
+    let keep = prefix.len().saturating_sub(1);
+    if buf.len() <= keep {
+        return;
+    }
+    let start = buf.len() - keep;
+    let suffix = buf[start..].to_vec();
+    buf.clear();
+    buf.extend_from_slice(&suffix);
+}
+
+fn decode_base64(input: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut quartet = [0u8; 4];
+    let mut n = 0;
+
+    for &b in input {
+        if b.is_ascii_whitespace() {
+            continue;
+        }
+        quartet[n] = match b {
+            b'A'..=b'Z' => b - b'A',
+            b'a'..=b'z' => b - b'a' + 26,
+            b'0'..=b'9' => b - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            b'=' => 64,
+            _ => return None,
+        };
+        n += 1;
+        if n == 4 {
+            push_base64_quartet(&mut out, quartet)?;
+            n = 0;
+        }
+    }
+
+    if n > 0 {
+        for slot in quartet.iter_mut().skip(n) {
+            *slot = 64;
+        }
+        push_base64_quartet(&mut out, quartet)?;
+    }
+
+    Some(out)
+}
+
+fn push_base64_quartet(out: &mut Vec<u8>, q: [u8; 4]) -> Option<()> {
+    if q[0] == 64 || q[1] == 64 {
+        return None;
+    }
+    out.push((q[0] << 2) | (q[1] >> 4));
+    if q[2] != 64 {
+        out.push((q[1] << 4) | (q[2] >> 2));
+    }
+    if q[3] != 64 {
+        out.push((q[2] << 6) | q[3]);
+    }
+    Some(())
 }
 
 /// Extract path from OSC 7 escape sequence: \x1b]7;file://HOST/PATH(\x07|\x1b\\)
@@ -1234,6 +1361,29 @@ fn detect_shell_unix() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn drain_osc52_copies_decodes_bel_terminated_payload() {
+        let mut buf = b"\x1b]52;c;aGVsbG8=\x07".to_vec();
+        assert_eq!(drain_osc52_copies(&mut buf), vec!["hello"]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drain_osc52_copies_decodes_st_terminated_payload() {
+        let mut buf = b"\x1b]52;c;44GT44KT44Gr44Gh44Gv\x1b\\".to_vec();
+        assert_eq!(drain_osc52_copies(&mut buf), vec!["こんにちは"]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drain_osc52_copies_handles_split_sequence() {
+        let mut buf = b"\x1b]52;c;aGVs".to_vec();
+        assert!(drain_osc52_copies(&mut buf).is_empty());
+        buf.extend_from_slice(b"bG8=\x07");
+        assert_eq!(drain_osc52_copies(&mut buf), vec!["hello"]);
+        assert!(buf.is_empty());
+    }
 
     #[test]
     fn wheel_report_sgr_up_matches_xterm_format() {


### PR DESCRIPTION
## Summary
- fall back to clip.exe for renga selection copies on WSL when arboard is unavailable
- bridge pane-emitted OSC 52 clipboard payloads through renga's clipboard path
- bump release metadata to v1.2.3 and document the fix

## Tests
- cargo fmt --check
- cargo check
- cargo test