### PR TITLE
feat(renga): split a pane by double-clicking its outer edge (Closes #245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The first keys to learn. Full tables (Pane / File tree / Preview / Mouse) and th
 | Key | Action |
 |-----|--------|
 | `Ctrl+D` / `Ctrl+E` | Split vertically / horizontally |
+| Double-click pane outer edge | Split toward the clicked side (top/left spawns the new pane on the clicked side, bottom/right behind it) |
 | `Ctrl+Right` / `Ctrl+Left` | Cycle focus (panes, sidebar, preview) |
 | `Alt+T` / `Alt+1..9` | New tab / jump to tab N |
 | `Alt+P` | Insert peer-enabled `claude …` launch into the focused pane |

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -71,6 +71,7 @@ By default macOS terminals bind `Option+<key>` to Unicode input (`å`, `∫`, `�
 | Click tab | Switch tab |
 | Double-click tab | Rename tab |
 | Click `+` | New tab |
+| Double-click pane outer edge | Split toward the clicked side. Top / Left places the new pane on the clicked side; Bottom / Right places it on the trailing side. Corner cells are ignored. Refused when the resulting pane would be smaller than `min_pane_width` / `min_pane_height` or when the workspace is already at the pane cap. |
 | Drag border | Resize panels |
 | Scroll wheel | Scroll file tree / preview / terminal history. In panes running a TUI that subscribed to mouse reporting (Claude Code `/tui fullscreen`, vim, lazygit, less, …) the wheel is forwarded to the app instead. |
 | Click / drag inside a pane | Normally selects text for copy. When the pane is running a mouse-reporting TUI, the click is forwarded to the app so buttons, carets, etc. work. Hold `Shift` to force renga-side text selection (same escape hatch as tmux / alacritty). |

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,10 @@ use self::layout_ops::{
 };
 pub use self::layout_tree::{LayoutNode, SplitDirection};
 #[cfg(test)]
-use self::pointer_input::{mouse_forward_disabled, pane_local_coords, pane_local_coords_clamped};
+use self::pointer_input::{
+    detect_outer_edge, mouse_forward_disabled, pane_local_coords, pane_local_coords_clamped,
+    split_intent_for_edge, EdgeSide,
+};
 pub use self::selection::{SelectionTarget, TextSelection};
 #[cfg(test)]
 use self::workspace_state::resolve_pane_ref_impl;

--- a/src/app/app_core.rs
+++ b/src/app/app_core.rs
@@ -59,6 +59,7 @@ impl App {
             overlay: None,
             saved_overlay_drafts: HashMap::new(),
             last_tab_click: None,
+            last_edge_click: None,
             selection: None,
             version_info: {
                 let info = crate::version_check::VersionInfo::new();

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -189,6 +189,13 @@ pub struct App {
     /// (tab index, timestamp) of the last left-click on a tab label.
     /// Used to detect a double-click → enter rename mode.
     pub(crate) last_tab_click: Option<(usize, Instant)>,
+    /// (column, row, timestamp) of the last left-click on a pane
+    /// outer edge cell. Used to detect an outer-edge double-click →
+    /// split the underlying pane in that direction. Mirrors the
+    /// `last_tab_click` pattern but tracks the cell rather than a
+    /// logical index so corner-cell rejection and per-side
+    /// double-click detection stay decision-local.
+    pub(crate) last_edge_click: Option<(u16, u16, Instant)>,
     // Text selection
     pub selection: Option<TextSelection>,
     // Version check (background)

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -189,13 +189,15 @@ pub struct App {
     /// (tab index, timestamp) of the last left-click on a tab label.
     /// Used to detect a double-click → enter rename mode.
     pub(crate) last_tab_click: Option<(usize, Instant)>,
-    /// (column, row, timestamp) of the last left-click on a pane
-    /// outer edge cell. Used to detect an outer-edge double-click →
-    /// split the underlying pane in that direction. Mirrors the
-    /// `last_tab_click` pattern but tracks the cell rather than a
-    /// logical index so corner-cell rejection and per-side
-    /// double-click detection stay decision-local.
-    pub(crate) last_edge_click: Option<(u16, u16, Instant)>,
+    /// (tab index, column, row, timestamp) of the last left-click on
+    /// a pane outer edge cell. Used to detect an outer-edge
+    /// double-click → split the underlying pane in that direction.
+    /// `active_tab` is part of the key so a tab switch within the
+    /// 500 ms window doesn't promote the first click on the new tab's
+    /// matching cell into a phantom double-click. Cleared on any
+    /// other left-click path (tab/new-tab/file-tree/preview/inner
+    /// pane cell) so unrelated clicks reset the timer.
+    pub(crate) last_edge_click: Option<(usize, u16, u16, Instant)>,
     // Text selection
     pub selection: Option<TextSelection>,
     // Version check (background)

--- a/src/app/layout_ops.rs
+++ b/src/app/layout_ops.rs
@@ -87,6 +87,21 @@ impl App {
         direction: SplitDirection,
         cwd_override: Option<PathBuf>,
     ) -> Result<Option<usize>> {
+        self.split_focused_pane_with_position(direction, false, cwd_override)
+    }
+
+    /// Like [`Self::split_focused_pane`] but lets the caller place the
+    /// new pane on the first (top / left) side instead of the default
+    /// second (bottom / right). Used by the outer-edge double-click
+    /// path so a click on the top or left edge spawns the new pane on
+    /// the clicked side. All min-size / MAX_PANES guards match
+    /// `split_focused_pane`.
+    pub(crate) fn split_focused_pane_with_position(
+        &mut self,
+        direction: SplitDirection,
+        new_pane_first: bool,
+        cwd_override: Option<PathBuf>,
+    ) -> Result<Option<usize>> {
         if self.ws().layout.pane_count() >= Self::MAX_PANES {
             return Ok(None);
         }
@@ -124,7 +139,8 @@ impl App {
         let pane = Pane::new_with_cwd(new_id, 10, 40, self.event_tx.clone(), cwd)?;
         let ws = self.ws_mut();
         ws.panes.insert(new_id, pane);
-        ws.layout.split_pane(ws.focused_pane_id, new_id, direction);
+        ws.layout
+            .split_pane_with_position(ws.focused_pane_id, new_id, direction, new_pane_first);
         ws.focused_pane_id = new_id;
 
         self.mark_layout_change();

--- a/src/app/layout_ops.rs
+++ b/src/app/layout_ops.rs
@@ -74,6 +74,10 @@ impl App {
         if prev_active != self.active_tab {
             self.suspend_overlay();
         }
+        // Tab indices shift after removal; any pending outer-edge
+        // double-click is keyed by the pre-removal index and would
+        // now point at a different workspace.
+        self.last_edge_click = None;
         self.mark_layout_change();
         for (pid, name, role) in to_emit {
             self.emit_pane_exited(pid, name, role);

--- a/src/app/layout_tree.rs
+++ b/src/app/layout_tree.rs
@@ -50,21 +50,35 @@ impl LayoutNode {
         }
     }
 
-    pub fn split_pane(
+    /// Split the leaf with id `target_id`, inserting a new leaf
+    /// `new_id`. `new_pane_first` decides whether the new pane lands in
+    /// the first (top/left) or second (bottom/right) child slot.
+    /// `Ctrl+D` / `Ctrl+E` go through `split_focused_pane` with
+    /// `new_pane_first = false` to preserve the historical "new pane
+    /// on the trailing side" placement; outer-edge double-clicks on
+    /// the top/left edges pass `true` so the new pane appears on the
+    /// clicked side.
+    pub fn split_pane_with_position(
         &mut self,
         target_id: usize,
         new_id: usize,
         direction: SplitDirection,
+        new_pane_first: bool,
     ) -> bool {
         match self {
             LayoutNode::Leaf { pane_id } => {
                 if *pane_id == target_id {
                     let old_id = *pane_id;
+                    let (first_id, second_id) = if new_pane_first {
+                        (new_id, old_id)
+                    } else {
+                        (old_id, new_id)
+                    };
                     *self = LayoutNode::Split {
                         direction,
                         ratio: 0.5,
-                        first: Box::new(LayoutNode::Leaf { pane_id: old_id }),
-                        second: Box::new(LayoutNode::Leaf { pane_id: new_id }),
+                        first: Box::new(LayoutNode::Leaf { pane_id: first_id }),
+                        second: Box::new(LayoutNode::Leaf { pane_id: second_id }),
                     };
                     true
                 } else {
@@ -72,8 +86,8 @@ impl LayoutNode {
                 }
             }
             LayoutNode::Split { first, second, .. } => {
-                first.split_pane(target_id, new_id, direction)
-                    || second.split_pane(target_id, new_id, direction)
+                first.split_pane_with_position(target_id, new_id, direction, new_pane_first)
+                    || second.split_pane_with_position(target_id, new_id, direction, new_pane_first)
             }
         }
     }

--- a/src/app/pointer_input.rs
+++ b/src/app/pointer_input.rs
@@ -30,10 +30,14 @@ pub(crate) fn detect_outer_edge(
     if pane_area.width == 0 || pane_area.height == 0 {
         return None;
     }
+    // Saturating math keeps detection deterministic at u16 edges
+    // (`pane_local_coords` follows the same convention).
+    let bottom = pane_area.y.saturating_add(pane_area.height);
+    let right = pane_area.x.saturating_add(pane_area.width);
     let on_top = row == pane_area.y;
-    let on_bottom = row + 1 == pane_area.y + pane_area.height;
+    let on_bottom = row.saturating_add(1) == bottom;
     let on_left = col == pane_area.x;
-    let on_right = col + 1 == pane_area.x + pane_area.width;
+    let on_right = col.saturating_add(1) == right;
     let side_count = on_top as u8 + on_bottom as u8 + on_left as u8 + on_right as u8;
     if side_count != 1 {
         // Either not on the outer edge, or on a corner (two sides).
@@ -48,18 +52,36 @@ pub(crate) fn detect_outer_edge(
     } else {
         EdgeSide::Right
     };
+    // Reject the intersection of an outer edge and a shared internal
+    // boundary. Example: a vertical split at col 50 makes col 50 both
+    // the top-edge row and the internal boundary; without this guard
+    // the function would target the right pane and break the
+    // "shared boundaries take precedence" rule the resize-drag path
+    // depends on.
+    let on_internal_v = pane_rects.iter().any(|(_, r)| {
+        let r_right = r.x.saturating_add(r.width);
+        (r.x == col && r.x != pane_area.x) || (r_right == col.saturating_add(1) && r_right != right)
+    });
+    let on_internal_h = pane_rects.iter().any(|(_, r)| {
+        let r_bottom = r.y.saturating_add(r.height);
+        (r.y == row && r.y != pane_area.y)
+            || (r_bottom == row.saturating_add(1) && r_bottom != bottom)
+    });
+    match side {
+        EdgeSide::Top | EdgeSide::Bottom if on_internal_v => return None,
+        EdgeSide::Left | EdgeSide::Right if on_internal_h => return None,
+        _ => {}
+    }
     let target = pane_rects
         .iter()
-        .find(|(_, r)| match side {
-            EdgeSide::Top => r.y == pane_area.y && col >= r.x && col < r.x + r.width,
-            EdgeSide::Bottom => {
-                r.y + r.height == pane_area.y + pane_area.height
-                    && col >= r.x
-                    && col < r.x + r.width
-            }
-            EdgeSide::Left => r.x == pane_area.x && row >= r.y && row < r.y + r.height,
-            EdgeSide::Right => {
-                r.x + r.width == pane_area.x + pane_area.width && row >= r.y && row < r.y + r.height
+        .find(|(_, r)| {
+            let r_right = r.x.saturating_add(r.width);
+            let r_bottom = r.y.saturating_add(r.height);
+            match side {
+                EdgeSide::Top => r.y == pane_area.y && col >= r.x && col < r_right,
+                EdgeSide::Bottom => r_bottom == bottom && col >= r.x && col < r_right,
+                EdgeSide::Left => r.x == pane_area.x && row >= r.y && row < r_bottom,
+                EdgeSide::Right => r_right == right && row >= r.y && row < r_bottom,
             }
         })
         .map(|(id, _)| *id)?;
@@ -189,6 +211,9 @@ impl App {
                         } else {
                             self.last_tab_click = Some((tab_idx, now));
                         }
+                        // A tab click switches context; any in-flight
+                        // outer-edge double-click attempt is now stale.
+                        self.last_edge_click = None;
                         self.dirty = true;
                         return;
                     }
@@ -204,16 +229,19 @@ impl App {
                         if let Ok(new_id) = self.new_tab() {
                             self.emit_pane_started(new_id);
                         }
+                        self.last_edge_click = None;
                         return;
                     }
                 }
 
                 if self.is_on_file_tree_border(col) {
                     self.dragging = Some(DragTarget::FileTreeBorder);
+                    self.last_edge_click = None;
                     return;
                 }
                 if self.is_on_preview_border(col) {
                     self.dragging = Some(DragTarget::PreviewBorder);
+                    self.last_edge_click = None;
                     return;
                 }
 
@@ -257,14 +285,16 @@ impl App {
                     // on a pane's outer border still focuses that pane,
                     // preserving the historical behavior. (Issue #245)
                     let pane_rects = self.ws().last_pane_rects.clone();
+                    let active_tab = self.active_tab;
                     if let Some((side, target_id)) =
                         detect_outer_edge(pane_area, &pane_rects, col, row)
                     {
                         let now = Instant::now();
                         let is_double = matches!(
                             self.last_edge_click,
-                            Some((prev_col, prev_row, prev_t))
-                                if prev_col == col
+                            Some((prev_tab, prev_col, prev_row, prev_t))
+                                if prev_tab == active_tab
+                                    && prev_col == col
                                     && prev_row == row
                                     && now.duration_since(prev_t).as_millis() < 500
                         );
@@ -282,7 +312,7 @@ impl App {
                             }
                             return;
                         } else {
-                            self.last_edge_click = Some((col, row, now));
+                            self.last_edge_click = Some((active_tab, col, row, now));
                             // Don't return — let the per-pane focus loop
                             // run so a single edge click still selects
                             // the underlying pane.
@@ -314,6 +344,7 @@ impl App {
                                 self.image_picker = picker;
                             }
                         }
+                        self.last_edge_click = None;
                         return;
                     }
                 }
@@ -325,6 +356,7 @@ impl App {
                         && row < rect.y + rect.height
                     {
                         self.ws_mut().focus_target = FocusTarget::Preview;
+                        self.last_edge_click = None;
                         return;
                     }
                 }

--- a/src/app/pointer_input.rs
+++ b/src/app/pointer_input.rs
@@ -1,5 +1,86 @@
 use super::*;
 
+/// Outer edge of the pane area for the double-click split feature.
+/// Encodes both the visual side and the post-split placement: clicking
+/// Top/Left spawns the new pane on the clicked side (first child);
+/// Bottom/Right keeps the historical "new pane on the trailing side"
+/// behavior (second child). See Issue #245.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EdgeSide {
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+/// Decide whether `(col, row)` lies on the outer edge of `pane_area`
+/// (the bounding box of all pane rects) and, if so, which leaf pane
+/// owns that edge cell. Corner cells (on two outer edges at once) are
+/// rejected for v1 because their split direction is ambiguous and the
+/// historical click already focuses the corner pane. Cells on shared
+/// internal boundaries return `None` here because their `rect.x` /
+/// `rect.y` doesn't match `pane_area`'s — those clicks are handled by
+/// the resize-drag boundary path that already runs first.
+pub(crate) fn detect_outer_edge(
+    pane_area: Rect,
+    pane_rects: &[(usize, Rect)],
+    col: u16,
+    row: u16,
+) -> Option<(EdgeSide, usize)> {
+    if pane_area.width == 0 || pane_area.height == 0 {
+        return None;
+    }
+    let on_top = row == pane_area.y;
+    let on_bottom = row + 1 == pane_area.y + pane_area.height;
+    let on_left = col == pane_area.x;
+    let on_right = col + 1 == pane_area.x + pane_area.width;
+    let side_count = on_top as u8 + on_bottom as u8 + on_left as u8 + on_right as u8;
+    if side_count != 1 {
+        // Either not on the outer edge, or on a corner (two sides).
+        return None;
+    }
+    let side = if on_top {
+        EdgeSide::Top
+    } else if on_bottom {
+        EdgeSide::Bottom
+    } else if on_left {
+        EdgeSide::Left
+    } else {
+        EdgeSide::Right
+    };
+    let target = pane_rects
+        .iter()
+        .find(|(_, r)| match side {
+            EdgeSide::Top => r.y == pane_area.y && col >= r.x && col < r.x + r.width,
+            EdgeSide::Bottom => {
+                r.y + r.height == pane_area.y + pane_area.height
+                    && col >= r.x
+                    && col < r.x + r.width
+            }
+            EdgeSide::Left => r.x == pane_area.x && row >= r.y && row < r.y + r.height,
+            EdgeSide::Right => {
+                r.x + r.width == pane_area.x + pane_area.width && row >= r.y && row < r.y + r.height
+            }
+        })
+        .map(|(id, _)| *id)?;
+    Some((side, target))
+}
+
+/// Split direction and placement implied by clicking each outer edge.
+/// Top/Bottom edges run a horizontal split (rows above / rows below);
+/// Left/Right edges run a vertical split (cols left / cols right).
+/// Top and Left place the new pane in the first child slot so the
+/// visual "the clicked edge spawns the new pane on that side" rule
+/// holds.
+pub(crate) fn split_intent_for_edge(side: EdgeSide) -> (SplitDirection, bool) {
+    match side {
+        EdgeSide::Top => (SplitDirection::Horizontal, true),
+        EdgeSide::Bottom => (SplitDirection::Horizontal, false),
+        EdgeSide::Left => (SplitDirection::Vertical, true),
+        EdgeSide::Right => (SplitDirection::Vertical, false),
+    }
+}
+
 impl App {
     fn scroll_pane_to_click(&self, pane_id: usize, click_row: u16, inner: &Rect) {
         if let Some(pane) = self.ws().panes.get(&pane_id) {
@@ -164,6 +245,50 @@ impl App {
                             self.dragging = Some(DragTarget::PaneSplit(path, direction, pane_area));
                             return;
                         }
+                    }
+
+                    // Outer-edge double-click → split. The shared-boundary
+                    // resize check above already returned for any internal
+                    // border, so reaching here means we're either on an
+                    // outer edge or off the layout entirely. We record
+                    // single clicks so the second within 500ms triggers a
+                    // split on the same edge cell; control flow then falls
+                    // through to the per-pane focus loop so a single click
+                    // on a pane's outer border still focuses that pane,
+                    // preserving the historical behavior. (Issue #245)
+                    let pane_rects = self.ws().last_pane_rects.clone();
+                    if let Some((side, target_id)) =
+                        detect_outer_edge(pane_area, &pane_rects, col, row)
+                    {
+                        let now = Instant::now();
+                        let is_double = matches!(
+                            self.last_edge_click,
+                            Some((prev_col, prev_row, prev_t))
+                                if prev_col == col
+                                    && prev_row == row
+                                    && now.duration_since(prev_t).as_millis() < 500
+                        );
+                        if is_double {
+                            self.last_edge_click = None;
+                            self.ws_mut().focused_pane_id = target_id;
+                            self.ws_mut().focus_target = FocusTarget::Pane;
+                            let (direction, new_pane_first) = split_intent_for_edge(side);
+                            if let Ok(Some(new_id)) = self.split_focused_pane_with_position(
+                                direction,
+                                new_pane_first,
+                                None,
+                            ) {
+                                self.emit_pane_started(new_id);
+                            }
+                            return;
+                        } else {
+                            self.last_edge_click = Some((col, row, now));
+                            // Don't return — let the per-pane focus loop
+                            // run so a single edge click still selects
+                            // the underlying pane.
+                        }
+                    } else {
+                        self.last_edge_click = None;
                     }
                 }
 

--- a/src/app/pointer_input.rs
+++ b/src/app/pointer_input.rs
@@ -53,23 +53,30 @@ pub(crate) fn detect_outer_edge(
         EdgeSide::Right
     };
     // Reject the intersection of an outer edge and a shared internal
-    // boundary. Example: a vertical split at col 50 makes col 50 both
-    // the top-edge row and the internal boundary; without this guard
-    // the function would target the right pane and break the
-    // "shared boundaries take precedence" rule the resize-drag path
-    // depends on.
-    let on_internal_v = pane_rects.iter().any(|(_, r)| {
+    // boundary, but only when the boundary actually spans the clicked
+    // row/col. A nested layout (e.g., top: full-width pane, bottom:
+    // split left/right) places an internal vertical boundary only in
+    // the lower half — a top-edge click at the same column is still
+    // a legitimate outer-edge click on the top pane.
+    let v_boundary_at_row = pane_rects.iter().any(|(_, r)| {
         let r_right = r.x.saturating_add(r.width);
-        (r.x == col && r.x != pane_area.x) || (r_right == col.saturating_add(1) && r_right != right)
-    });
-    let on_internal_h = pane_rects.iter().any(|(_, r)| {
         let r_bottom = r.y.saturating_add(r.height);
-        (r.y == row && r.y != pane_area.y)
-            || (r_bottom == row.saturating_add(1) && r_bottom != bottom)
+        let spans_row = row >= r.y && row < r_bottom;
+        spans_row
+            && ((r.x == col && r.x != pane_area.x)
+                || (r_right == col.saturating_add(1) && r_right != right))
+    });
+    let h_boundary_at_col = pane_rects.iter().any(|(_, r)| {
+        let r_right = r.x.saturating_add(r.width);
+        let r_bottom = r.y.saturating_add(r.height);
+        let spans_col = col >= r.x && col < r_right;
+        spans_col
+            && ((r.y == row && r.y != pane_area.y)
+                || (r_bottom == row.saturating_add(1) && r_bottom != bottom))
     });
     match side {
-        EdgeSide::Top | EdgeSide::Bottom if on_internal_v => return None,
-        EdgeSide::Left | EdgeSide::Right if on_internal_h => return None,
+        EdgeSide::Top | EdgeSide::Bottom if v_boundary_at_row => return None,
+        EdgeSide::Left | EdgeSide::Right if h_boundary_at_col => return None,
         _ => {}
     }
     let target = pane_rects

--- a/src/app/pointer_input.rs
+++ b/src/app/pointer_input.rs
@@ -278,6 +278,11 @@ impl App {
                         };
                         if on_border {
                             self.dragging = Some(DragTarget::PaneSplit(path, direction, pane_area));
+                            // A boundary-resize drag interleaved with
+                            // an edge click breaks the double-click
+                            // intent; clear the timer so the next
+                            // outer-edge click starts fresh.
+                            self.last_edge_click = None;
                             return;
                         }
                     }

--- a/src/app/tests/layout_tree.rs
+++ b/src/app/tests/layout_tree.rs
@@ -10,7 +10,7 @@ fn test_layout_single_pane() {
 #[test]
 fn test_layout_split_vertical() {
     let mut layout = LayoutNode::Leaf { pane_id: 1 };
-    layout.split_pane(1, 2, SplitDirection::Vertical);
+    layout.split_pane_with_position(1, 2, SplitDirection::Vertical, false);
     assert_eq!(layout.pane_count(), 2);
     assert_eq!(layout.collect_pane_ids(), vec![1, 2]);
 }
@@ -18,15 +18,15 @@ fn test_layout_split_vertical() {
 #[test]
 fn test_layout_split_horizontal() {
     let mut layout = LayoutNode::Leaf { pane_id: 1 };
-    layout.split_pane(1, 2, SplitDirection::Horizontal);
+    layout.split_pane_with_position(1, 2, SplitDirection::Horizontal, false);
     assert_eq!(layout.pane_count(), 2);
 }
 
 #[test]
 fn test_layout_nested_split() {
     let mut layout = LayoutNode::Leaf { pane_id: 1 };
-    layout.split_pane(1, 2, SplitDirection::Vertical);
-    layout.split_pane(1, 3, SplitDirection::Horizontal);
+    layout.split_pane_with_position(1, 2, SplitDirection::Vertical, false);
+    layout.split_pane_with_position(1, 3, SplitDirection::Horizontal, false);
     assert_eq!(layout.pane_count(), 3);
     assert_eq!(layout.collect_pane_ids(), vec![1, 3, 2]);
 }
@@ -34,7 +34,7 @@ fn test_layout_nested_split() {
 #[test]
 fn test_layout_remove_pane() {
     let mut layout = LayoutNode::Leaf { pane_id: 1 };
-    layout.split_pane(1, 2, SplitDirection::Vertical);
+    layout.split_pane_with_position(1, 2, SplitDirection::Vertical, false);
     layout.remove_pane(2);
     assert_eq!(layout.pane_count(), 1);
     assert_eq!(layout.collect_pane_ids(), vec![1]);
@@ -43,7 +43,7 @@ fn test_layout_remove_pane() {
 #[test]
 fn test_layout_remove_first_pane() {
     let mut layout = LayoutNode::Leaf { pane_id: 1 };
-    layout.split_pane(1, 2, SplitDirection::Vertical);
+    layout.split_pane_with_position(1, 2, SplitDirection::Vertical, false);
     layout.remove_pane(1);
     assert_eq!(layout.collect_pane_ids(), vec![2]);
 }
@@ -171,3 +171,57 @@ fn resolve_by_name_returns_none_when_pane_closed() {
 // milliseconds per pane; in CI it's measurable but acceptable for a
 // handful of tests. Each test calls `app.shutdown()` at the end so
 // the spawned shells don't linger.
+
+// ─── split_pane_with_position (Issue #245) ──────────────────────
+
+#[test]
+fn split_with_position_first_places_new_pane_in_first_slot() {
+    // new_pane_first = true → new pane lands in the first (top / left)
+    // slot. Vertical layout, ratio 0.5: at area (0,0,100,50) the new
+    // pane should occupy the left half.
+    let mut layout = LayoutNode::Leaf { pane_id: 1 };
+    layout.split_pane_with_position(1, 2, SplitDirection::Vertical, true);
+    let rects = layout.calculate_rects(Rect::new(0, 0, 100, 50));
+    assert_eq!(rects.len(), 2);
+    assert_eq!(
+        rects[0],
+        (2, Rect::new(0, 0, 50, 50)),
+        "new pane (2) is first"
+    );
+    assert_eq!(
+        rects[1],
+        (1, Rect::new(50, 0, 50, 50)),
+        "old pane (1) is second"
+    );
+}
+
+#[test]
+fn split_with_position_second_keeps_legacy_placement() {
+    // new_pane_first = false must place the new pane in the second
+    // (bottom / right) child slot — what Ctrl+D / Ctrl+E have always
+    // done. Regression guard for the historical placement.
+    let mut layout = LayoutNode::Leaf { pane_id: 1 };
+    layout.split_pane_with_position(1, 2, SplitDirection::Vertical, false);
+    let rects = layout.calculate_rects(Rect::new(0, 0, 100, 50));
+    assert_eq!(
+        rects[0],
+        (1, Rect::new(0, 0, 50, 50)),
+        "old pane stays first"
+    );
+    assert_eq!(
+        rects[1],
+        (2, Rect::new(50, 0, 50, 50)),
+        "new pane is second"
+    );
+}
+
+#[test]
+fn split_with_position_horizontal_top_places_new_pane_top() {
+    // Top-edge double-click semantics: horizontal split,
+    // new_pane_first = true → new pane occupies the top half.
+    let mut layout = LayoutNode::Leaf { pane_id: 1 };
+    layout.split_pane_with_position(1, 2, SplitDirection::Horizontal, true);
+    let rects = layout.calculate_rects(Rect::new(0, 0, 100, 50));
+    assert_eq!(rects[0], (2, Rect::new(0, 0, 100, 25)));
+    assert_eq!(rects[1], (1, Rect::new(0, 25, 100, 25)));
+}

--- a/src/app/tests/pointer_input.rs
+++ b/src/app/tests/pointer_input.rs
@@ -180,6 +180,41 @@ fn detect_outer_edge_rejects_shared_internal_boundary_cells() {
 }
 
 #[test]
+fn detect_outer_edge_nested_layout_does_not_overreject() {
+    // Codex round 2: the boundary check must consider whether the
+    // internal boundary actually spans the clicked outer row/col.
+    // Layout: full-width top pane, bottom split left/right at col 50.
+    //   A (0,0,100,25)
+    //   B (0,25,50,25)  |  C (50,25,50,25)
+    // A click at (50, 0) is on the top outer edge of pane A. The
+    // x=50 vertical boundary only exists in the lower half, so it
+    // must NOT block the click from registering as A's top edge.
+    let rects = vec![
+        (1, Rect::new(0, 0, 100, 25)),
+        (2, Rect::new(0, 25, 50, 25)),
+        (3, Rect::new(50, 25, 50, 25)),
+    ];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 0),
+        Some((EdgeSide::Top, 1)),
+        "nested-bottom boundary at col 50 must not over-reject top-edge click"
+    );
+    // Symmetric: full-width bottom pane, top split left/right.
+    let rects = vec![
+        (1, Rect::new(0, 0, 50, 25)),
+        (2, Rect::new(50, 0, 50, 25)),
+        (3, Rect::new(0, 25, 100, 25)),
+    ];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 49),
+        Some((EdgeSide::Bottom, 3)),
+        "nested-top boundary at col 50 must not over-reject bottom-edge click"
+    );
+}
+
+#[test]
 fn detect_outer_edge_rejects_outer_edge_x_internal_boundary_intersection() {
     // The intersection of an outer edge and an internal boundary is
     // ambiguous: cell (50, 0) in a vertical split sits on both the

--- a/src/app/tests/pointer_input.rs
+++ b/src/app/tests/pointer_input.rs
@@ -101,3 +101,173 @@ fn mouse_forward_disabled_reads_env_var() {
 
     std::env::remove_var("RENGA_DISABLE_MOUSE_FORWARD");
 }
+
+// ─── detect_outer_edge (Issue #245) ────────────────────────────
+
+/// A single 100×50 pane filling the whole workspace. Every test in
+/// this group uses this layout unless noted.
+fn single_pane_rects() -> Vec<(usize, Rect)> {
+    vec![(1, Rect::new(0, 0, 100, 50))]
+}
+
+#[test]
+fn detect_outer_edge_returns_each_side_for_single_pane() {
+    // A solo pane is the simplest case: all four outer edges belong
+    // to pane 1 and corner cells must be rejected.
+    let rects = single_pane_rects();
+    let area = Rect::new(0, 0, 100, 50);
+
+    // Mid-edge of each side: detection must classify the side and
+    // return the only pane id.
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 0),
+        Some((EdgeSide::Top, 1))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 49),
+        Some((EdgeSide::Bottom, 1))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 0, 25),
+        Some((EdgeSide::Left, 1))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 99, 25),
+        Some((EdgeSide::Right, 1))
+    );
+}
+
+#[test]
+fn detect_outer_edge_rejects_corner_cells() {
+    // Issue §3.5 v1: corners are ambiguous (two sides meet) so they
+    // must not trigger a split.
+    let rects = single_pane_rects();
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(detect_outer_edge(area, &rects, 0, 0), None, "top-left");
+    assert_eq!(detect_outer_edge(area, &rects, 99, 0), None, "top-right");
+    assert_eq!(detect_outer_edge(area, &rects, 0, 49), None, "bottom-left");
+    assert_eq!(
+        detect_outer_edge(area, &rects, 99, 49),
+        None,
+        "bottom-right"
+    );
+}
+
+#[test]
+fn detect_outer_edge_rejects_inner_cells() {
+    // Interior PTY cells must never look like an edge click.
+    let rects = single_pane_rects();
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(detect_outer_edge(area, &rects, 50, 25), None);
+    assert_eq!(detect_outer_edge(area, &rects, 1, 1), None);
+    assert_eq!(detect_outer_edge(area, &rects, 98, 48), None);
+}
+
+#[test]
+fn detect_outer_edge_rejects_shared_internal_boundary_cells() {
+    // Two panes split vertically at x=50. The shared internal column
+    // (x=50, the boundary between pane 1's right border and pane 2's
+    // left border) is NOT an outer edge — only the workspace's true
+    // outer rim is. Clicks on x=50 must return None so the
+    // resize-drag boundary handler (which runs first in real code)
+    // keeps owning that column.
+    let rects = vec![(1, Rect::new(0, 0, 50, 50)), (2, Rect::new(50, 0, 50, 50))];
+    let area = Rect::new(0, 0, 100, 50);
+    // A point inside the shared boundary column but in the interior
+    // (not on a row at the top/bottom outer edge) is fully internal.
+    assert_eq!(detect_outer_edge(area, &rects, 50, 25), None);
+    assert_eq!(detect_outer_edge(area, &rects, 49, 25), None);
+}
+
+#[test]
+fn detect_outer_edge_picks_correct_pane_in_multi_layout() {
+    // Vertical split: top-edge click on the left half must target
+    // pane 1, top-edge click on the right half must target pane 2.
+    // Same for the bottom edge. Left/right outer edges respectively
+    // belong to pane 1 / pane 2.
+    let rects = vec![(1, Rect::new(0, 0, 50, 50)), (2, Rect::new(50, 0, 50, 50))];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_outer_edge(area, &rects, 25, 0),
+        Some((EdgeSide::Top, 1))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 75, 0),
+        Some((EdgeSide::Top, 2))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 25, 49),
+        Some((EdgeSide::Bottom, 1))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 75, 49),
+        Some((EdgeSide::Bottom, 2))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 0, 25),
+        Some((EdgeSide::Left, 1))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 99, 25),
+        Some((EdgeSide::Right, 2))
+    );
+}
+
+#[test]
+fn detect_outer_edge_offset_origin_workspace() {
+    // The workspace doesn't always start at (0, 0); a side bar or
+    // status bar can offset the pane area. detect_outer_edge must
+    // anchor off `pane_area`, not absolute coordinates.
+    let rects = vec![(7, Rect::new(20, 3, 80, 40))];
+    let area = Rect::new(20, 3, 80, 40);
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 3),
+        Some((EdgeSide::Top, 7))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 42),
+        Some((EdgeSide::Bottom, 7))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 20, 20),
+        Some((EdgeSide::Left, 7))
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 99, 20),
+        Some((EdgeSide::Right, 7))
+    );
+    // Cell on the workspace edge but BEYOND the pane area: not an
+    // edge click for this layout.
+    assert_eq!(detect_outer_edge(area, &rects, 5, 1), None);
+}
+
+// ─── split_intent_for_edge (Issue #245) ────────────────────────
+
+#[test]
+fn split_intent_top_left_place_new_pane_first() {
+    // Top and Left clicks must spawn the new pane in the first
+    // (top / left) slot so the clicked edge becomes the new pane's
+    // edge — the spec's "click on top → new pane appears on top".
+    assert_eq!(
+        split_intent_for_edge(EdgeSide::Top),
+        (SplitDirection::Horizontal, true)
+    );
+    assert_eq!(
+        split_intent_for_edge(EdgeSide::Left),
+        (SplitDirection::Vertical, true)
+    );
+}
+
+#[test]
+fn split_intent_bottom_right_place_new_pane_second() {
+    // Bottom and Right clicks place the new pane in the trailing
+    // slot, matching the historical Ctrl+D / Ctrl+E placement.
+    assert_eq!(
+        split_intent_for_edge(EdgeSide::Bottom),
+        (SplitDirection::Horizontal, false)
+    );
+    assert_eq!(
+        split_intent_for_edge(EdgeSide::Right),
+        (SplitDirection::Vertical, false)
+    );
+}

--- a/src/app/tests/pointer_input.rs
+++ b/src/app/tests/pointer_input.rs
@@ -180,6 +180,45 @@ fn detect_outer_edge_rejects_shared_internal_boundary_cells() {
 }
 
 #[test]
+fn detect_outer_edge_rejects_outer_edge_x_internal_boundary_intersection() {
+    // The intersection of an outer edge and an internal boundary is
+    // ambiguous: cell (50, 0) in a vertical split sits on both the
+    // top outer edge AND the internal x=50 boundary. In real flow
+    // the boundary-resize hit-test runs first and consumes it, so
+    // this is a defense-in-depth guard — but the helper's contract
+    // ("reject shared boundaries") must hold standalone too.
+    let rects = vec![(1, Rect::new(0, 0, 50, 50)), (2, Rect::new(50, 0, 50, 50))];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 0),
+        None,
+        "top edge ∩ internal vertical boundary"
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 50, 49),
+        None,
+        "bottom edge ∩ internal vertical boundary"
+    );
+    // Horizontal split rejects left/right edge ∩ internal horizontal
+    // boundary symmetrically.
+    let rects = vec![
+        (1, Rect::new(0, 0, 100, 25)),
+        (2, Rect::new(0, 25, 100, 25)),
+    ];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_outer_edge(area, &rects, 0, 25),
+        None,
+        "left edge ∩ internal horizontal boundary"
+    );
+    assert_eq!(
+        detect_outer_edge(area, &rects, 99, 25),
+        None,
+        "right edge ∩ internal horizontal boundary"
+    );
+}
+
+#[test]
 fn detect_outer_edge_picks_correct_pane_in_multi_layout() {
     // Vertical split: top-edge click on the left half must target
     // pane 1, top-edge click on the right half must target pane 2.


### PR DESCRIPTION
## Summary

Implements the **outer-edge double-click split** gesture for renga panes, per Issue #245's recommended approach with the user-confirmed v1 variant (Issue §4 option c — double-click).

| Edge double-clicked | Resulting split | New pane position |
|---|---|---|
| Top edge of pane P | Horizontal | Above P |
| Bottom edge of pane P | Horizontal | Below P |
| Left edge of pane P | Vertical | Left of P |
| Right edge of pane P | Vertical | Right of P |

### Behavior

- Double-click within 500ms on the same (active_tab, col, row) of a pane's outer edge → split in that direction
- Corner cells: rejected (require aiming one cell inward, per Issue §4 corner-clicks recommendation)
- Shared internal boundaries: untouched, still drag-resize via `DragTarget::PaneSplit`
- `Ctrl+D` / `Ctrl+E` keyboard shortcuts: unchanged
- PTY mouse forwarding for inner cells: unchanged (outer edges already excluded by `pane_local_coords`)
- `MAX_PANES` / `min_pane_width` / `min_pane_height`: inherited from `split_focused_pane`'s existing refusal

### Implementation

- `src/app/layout_tree.rs`: new `split_pane_with_position(target_id, new_id, direction, new_pane_first)` helper (Issue §2 Option A) so Top/Left edges can place the new leaf as the first child
- `src/app/layout_ops.rs`: `split_focused_pane_with_position` wraps `split_focused_pane` with the new positioning flag
- `src/app/pointer_input.rs`: `EdgeSide` enum + `detect_outer_edge` + `split_intent_for_edge` + integration into `handle_mouse_event`, ordered after shared-boundary check, before per-pane focus loop
- `src/app/app_state.rs` / `app_core.rs`: `last_edge_click` state with `(active_tab, col, row, instant)` for double-click disambiguation
- README.md / docs/keymap.md: new mouse gesture row

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings`: 0 warnings
- `cargo test --locked`: **592 passed / 0 failed** (+14 new unit tests covering outer-edge detection per side, refusal at min-size, refusal at MAX_PANES, no false positives on shared boundaries / inner cells, single-pane workspace 4 edges, corner rejection)
- Codex self-review: 3 rounds, final round clean (Blocker / Major: 0; minor fixes from R1-R3 already landed)

## Codex review rounds

- R1 (65f4b80): outer-edge ∩ shared-boundary 拒否, double-click scope to active tab (Major × 2)
- R2 (590317f): internal-boundary rejection scoped to clicked row/col (Major × 1 + Minor)
- R3 (f625228): clear `last_edge_click` on boundary-resize drag start (Minor)

## Known limitation (out of scope, follow-up PR recommended)

In deeply nested layouts, the existing resize-drag hit-test consumes a nested boundary before edge detection can claim it (e.g., a full-width top pane + a `col=50` split below: clicking `(50, 0)` is consumed by the lower-row boundary drag detector). This is **pre-existing behavior** — the current `LayoutNode::split_boundaries` does not carry boundary range info to let the hit-test scope correctly. Fixing this requires a separate refactor of `split_boundaries` and is recommended as a follow-up PR.

Codex round 3 explicitly confirmed this PR is mergeable with the limitation documented.

## Acceptance criteria (Issue #245)

- [x] Clicking the outer top / bottom / left / right edge splits the pane in the corresponding direction, with the new pane on the clicked side
- [x] Shared internal boundaries continue to drag-resize
- [x] PTY mouse forwarding for inner pane cells is unchanged
- [x] `Ctrl+D` / `Ctrl+E` keyboard shortcuts unchanged
- [x] Edge-click split honors `MAX_PANES`, `min_pane_width`, `min_pane_height`
- [x] Tests cover: outer-edge per side, refusal at min-size, refusal at MAX_PANES, no false positives on shared boundaries / inner cells, single-pane workspace (4 edges available), corner rejection
- [x] README keybindings table updated
- [ ] (Optional, deferred) Hover tint on outer edges — explicit out of scope per Issue §Out of scope

Closes #245