### PR TITLE
feat: extend click-to-split to shared internal boundaries (Closes #247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The first keys to learn. Full tables (Pane / File tree / Preview / Mouse) and th
 |-----|--------|
 | `Ctrl+D` / `Ctrl+E` | Split vertically / horizontally |
 | Double-click pane outer edge | Split toward the clicked side (top/left spawns the new pane on the clicked side, bottom/right behind it) |
+| Double-click shared border | Split the adjacent pane, dropping the new pane on the border between the two siblings (drag still resizes) |
 | `Ctrl+Right` / `Ctrl+Left` | Cycle focus (panes, sidebar, preview) |
 | `Alt+T` / `Alt+1..9` | New tab / jump to tab N |
 | `Alt+P` | Insert peer-enabled `claude …` launch into the focused pane |

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -72,6 +72,7 @@ By default macOS terminals bind `Option+<key>` to Unicode input (`å`, `∫`, `�
 | Double-click tab | Rename tab |
 | Click `+` | New tab |
 | Double-click pane outer edge | Split toward the clicked side. Top / Left places the new pane on the clicked side; Bottom / Right places it on the trailing side. Corner cells are ignored. Refused when the resulting pane would be smaller than `min_pane_width` / `min_pane_height` or when the workspace is already at the pane cap. |
+| Double-click shared border | Split the pane on the leading side of the divider, dropping the new pane right on the border (between the two siblings). A vertical divider splits the left pane to the right; a horizontal divider splits the top pane downward. Junction cells where two dividers cross are ignored. Same `min_pane_width` / `min_pane_height` / pane-cap refusals as above. |
 | Drag border | Resize panels |
 | Scroll wheel | Scroll file tree / preview / terminal history. In panes running a TUI that subscribed to mouse reporting (Claude Code `/tui fullscreen`, vim, lazygit, less, …) the wheel is forwarded to the app instead. |
 | Click / drag inside a pane | Normally selects text for copy. When the pane is running a mouse-reporting TUI, the click is forwarded to the app so buttons, carets, etc. work. Hold `Shift` to force renga-side text selection (same escape hatch as tmux / alacritty). |

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,8 +38,8 @@ use self::layout_ops::{
 pub use self::layout_tree::{LayoutNode, SplitDirection};
 #[cfg(test)]
 use self::pointer_input::{
-    detect_outer_edge, mouse_forward_disabled, pane_local_coords, pane_local_coords_clamped,
-    split_intent_for_edge, EdgeSide,
+    detect_outer_edge, detect_shared_boundary, mouse_forward_disabled, pane_local_coords,
+    pane_local_coords_clamped, split_intent_for_edge, EdgeSide,
 };
 pub use self::selection::{SelectionTarget, TextSelection};
 #[cfg(test)]

--- a/src/app/app_core.rs
+++ b/src/app/app_core.rs
@@ -60,6 +60,7 @@ impl App {
             saved_overlay_drafts: HashMap::new(),
             last_tab_click: None,
             last_edge_click: None,
+            last_boundary_click: None,
             selection: None,
             version_info: {
                 let info = crate::version_check::VersionInfo::new();

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -198,6 +198,14 @@ pub struct App {
     /// other left-click path (tab/new-tab/file-tree/preview/inner
     /// pane cell) so unrelated clicks reset the timer.
     pub(crate) last_edge_click: Option<(usize, u16, u16, Instant)>,
+    /// (tab index, column, row, timestamp) of the last left-click that
+    /// landed on a shared internal split boundary. Mirrors
+    /// [`Self::last_edge_click`] but for the divider between sibling
+    /// panes: a second click on the same divider cell within 500 ms
+    /// double-clicks it and splits the adjacent pane (Issue #247),
+    /// while a single click still falls through to the resize-drag.
+    /// Cleared on the same unrelated click paths as `last_edge_click`.
+    pub(crate) last_boundary_click: Option<(usize, u16, u16, Instant)>,
     // Text selection
     pub selection: Option<TextSelection>,
     // Version check (background)

--- a/src/app/layout_ops.rs
+++ b/src/app/layout_ops.rs
@@ -74,10 +74,11 @@ impl App {
         if prev_active != self.active_tab {
             self.suspend_overlay();
         }
-        // Tab indices shift after removal; any pending outer-edge
-        // double-click is keyed by the pre-removal index and would
-        // now point at a different workspace.
+        // Tab indices shift after removal; any pending outer-edge or
+        // boundary double-click is keyed by the pre-removal index and
+        // would now point at a different workspace.
         self.last_edge_click = None;
+        self.last_boundary_click = None;
         self.mark_layout_change();
         for (pid, name, role) in to_emit {
             self.emit_pane_exited(pid, name, role);

--- a/src/app/layout_tree.rs
+++ b/src/app/layout_tree.rs
@@ -7,6 +7,24 @@ pub enum SplitDirection {
     Horizontal,
 }
 
+/// One internal split divider, used for resize / hover hit-testing.
+/// `position` is the screen column (for a `Vertical` split) or row (for
+/// a `Horizontal` split) the divider sits on; `path` identifies the
+/// owning `Split` node for [`LayoutNode::update_ratio`]. `span` is the
+/// divider's perpendicular extent — `(start, end)` half-open rows for a
+/// `Vertical` split, columns for a `Horizontal` one. Before #247 the
+/// hit-test assumed every divider spanned the whole pane area, so a
+/// nested divider (e.g. a left/right split living only in the bottom
+/// half) wrongly claimed clicks that shared its column but fell in the
+/// unrelated top pane. Carrying `span` closes that gap.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SplitBoundary {
+    pub position: u16,
+    pub direction: SplitDirection,
+    pub path: Vec<bool>,
+    pub span: (u16, u16),
+}
+
 /// Binary tree node for pane layout.
 #[derive(Debug)]
 pub enum LayoutNode {
@@ -117,9 +135,11 @@ impl LayoutNode {
         }
     }
 
-    /// Find the split boundary position and direction for hit testing.
-    /// Returns a list of (boundary_position, direction, depth) for each Split node.
-    pub fn split_boundaries(&self, area: Rect) -> Vec<(u16, SplitDirection, Vec<bool>)> {
+    /// Find every internal split divider for hit testing. Each
+    /// [`SplitBoundary`] carries its screen position, direction, tree
+    /// path, and perpendicular span (the rows/cols it actually
+    /// occupies, so nested dividers don't over-claim — see #247).
+    pub fn split_boundaries(&self, area: Rect) -> Vec<SplitBoundary> {
         let mut result = Vec::new();
         self.collect_boundaries(area, &mut Vec::new(), &mut result);
         result
@@ -129,7 +149,7 @@ impl LayoutNode {
         &self,
         area: Rect,
         path: &mut Vec<bool>, // false=first, true=second
-        result: &mut Vec<(u16, SplitDirection, Vec<bool>)>,
+        result: &mut Vec<SplitBoundary>,
     ) {
         if let LayoutNode::Split {
             direction,
@@ -145,7 +165,19 @@ impl LayoutNode {
                 SplitDirection::Vertical => first_area.x + first_area.width,
                 SplitDirection::Horizontal => first_area.y + first_area.height,
             };
-            result.push((boundary, *direction, path.clone()));
+            // The divider runs perpendicular to the split: a vertical
+            // split's divider spans this node's rows, a horizontal
+            // split's spans its columns.
+            let span = match direction {
+                SplitDirection::Vertical => (area.y, area.y.saturating_add(area.height)),
+                SplitDirection::Horizontal => (area.x, area.x.saturating_add(area.width)),
+            };
+            result.push(SplitBoundary {
+                position: boundary,
+                direction: *direction,
+                path: path.clone(),
+                span,
+            });
 
             path.push(false);
             first.collect_boundaries(first_area, path, result);

--- a/src/app/layout_tree.rs
+++ b/src/app/layout_tree.rs
@@ -23,6 +23,12 @@ pub struct SplitBoundary {
     pub direction: SplitDirection,
     pub path: Vec<bool>,
     pub span: (u16, u16),
+    /// The owning `Split` node's own rendered rect. Resize-drag ratios
+    /// must be measured against this sub-region, not the whole pane
+    /// area — otherwise a divider nested inside one half of the layout
+    /// jumps when dragged (the ratio would be taken relative to the
+    /// full width/height instead of the node's slice).
+    pub area: Rect,
 }
 
 /// Binary tree node for pane layout.
@@ -177,6 +183,7 @@ impl LayoutNode {
                 direction: *direction,
                 path: path.clone(),
                 span,
+                area,
             });
 
             path.push(false);

--- a/src/app/pointer_input.rs
+++ b/src/app/pointer_input.rs
@@ -110,6 +110,61 @@ pub(crate) fn split_intent_for_edge(side: EdgeSide) -> (SplitDirection, bool) {
     }
 }
 
+/// Decide how a double-click on the shared internal boundary at
+/// `(col, row)` should split. Returns `(direction, target_leaf,
+/// new_pane_first)` so the caller can run `split_focused_pane_with_
+/// position` against `target_leaf`; the new pane lands right on the
+/// clicked divider, between the two siblings it separated.
+///
+/// Detection is purely geometric (off `pane_rects`), so it works for
+/// boundaries at any nesting depth — the leaf whose trailing edge
+/// abuts the divider at the clicked row/col is the split target. A
+/// vertical divider splits its left leaf to the right; a horizontal
+/// divider splits its top leaf downward. Junction cells where a
+/// vertical and a horizontal divider cross are ambiguous (which way to
+/// split?) and return `None`, mirroring the corner-cell rejection in
+/// [`detect_outer_edge`]. Cells on the workspace's outer rim are not
+/// shared boundaries and return `None` — those belong to the
+/// outer-edge double-click path (#245).
+pub(crate) fn detect_shared_boundary(
+    pane_area: Rect,
+    pane_rects: &[(usize, Rect)],
+    col: u16,
+    row: u16,
+) -> Option<(SplitDirection, usize, bool)> {
+    if pane_area.width == 0 || pane_area.height == 0 {
+        return None;
+    }
+    let outer_right = pane_area.x.saturating_add(pane_area.width);
+    let outer_bottom = pane_area.y.saturating_add(pane_area.height);
+
+    // A vertical divider sits between a leaf's right border column
+    // (`r_right - 1`) and its right neighbor's left border column
+    // (`r_right`); the resize hit-test treats both as on the divider.
+    // Require `r_right < outer_right` so the workspace's own right rim
+    // (an outer edge, not a shared boundary) is excluded.
+    let vertical = pane_rects.iter().find_map(|(id, r)| {
+        let r_right = r.x.saturating_add(r.width);
+        let on_col = col == r_right.saturating_sub(1) || col == r_right;
+        let spans_row = row >= r.y && row < r.y.saturating_add(r.height);
+        (on_col && spans_row && r_right < outer_right).then_some(*id)
+    });
+    let horizontal = pane_rects.iter().find_map(|(id, r)| {
+        let r_bottom = r.y.saturating_add(r.height);
+        let on_row = row == r_bottom.saturating_sub(1) || row == r_bottom;
+        let spans_col = col >= r.x && col < r.x.saturating_add(r.width);
+        (on_row && spans_col && r_bottom < outer_bottom).then_some(*id)
+    });
+
+    match (vertical, horizontal) {
+        // Crossing dividers: ambiguous, leave it to the resize-drag.
+        (Some(_), Some(_)) => None,
+        (Some(id), None) => Some((SplitDirection::Vertical, id, false)),
+        (None, Some(id)) => Some((SplitDirection::Horizontal, id, false)),
+        (None, None) => None,
+    }
+}
+
 impl App {
     fn scroll_pane_to_click(&self, pane_id: usize, click_row: u16, inner: &Rect) {
         if let Some(pane) = self.ws().panes.get(&pane_id) {
@@ -125,6 +180,51 @@ impl App {
             let mut parser = pane.parser.lock().unwrap_or_else(|e| e.into_inner());
             parser.screen_mut().set_scrollback(target_scroll);
         }
+    }
+
+    /// Bounding box of all pane rects in the active tab — the area the
+    /// layout tree was rendered into. `None` when there are no panes
+    /// yet (before the first frame).
+    fn pane_area(&self) -> Option<Rect> {
+        let rects = &self.ws().last_pane_rects;
+        if rects.is_empty() {
+            return None;
+        }
+        let min_x = rects.iter().map(|(_, r)| r.x).min().unwrap_or(0);
+        let min_y = rects.iter().map(|(_, r)| r.y).min().unwrap_or(0);
+        let max_x = rects.iter().map(|(_, r)| r.x + r.width).max().unwrap_or(0);
+        let max_y = rects.iter().map(|(_, r)| r.y + r.height).max().unwrap_or(0);
+        Some(Rect::new(min_x, min_y, max_x - min_x, max_y - min_y))
+    }
+
+    /// If `(col, row)` lands on a shared internal split divider, return
+    /// the [`DragTarget::PaneSplit`] that would resize it. Honors each
+    /// divider's perpendicular span so a nested divider only claims the
+    /// rows/cols it actually occupies (the gap #246 left open). Shared
+    /// by the resize-drag setup, the double-click classifier, and the
+    /// hover tint so all three agree on what counts as "on a boundary".
+    fn boundary_drag_target(&self, col: u16, row: u16) -> Option<DragTarget> {
+        let pane_area = self.pane_area()?;
+        for b in self.ws().layout.split_boundaries(pane_area) {
+            let on_border = match b.direction {
+                SplitDirection::Vertical => {
+                    col >= b.position.saturating_sub(1)
+                        && col <= b.position
+                        && row >= b.span.0
+                        && row < b.span.1
+                }
+                SplitDirection::Horizontal => {
+                    row >= b.position.saturating_sub(1)
+                        && row <= b.position
+                        && col >= b.span.0
+                        && col < b.span.1
+                }
+            };
+            if on_border {
+                return Some(DragTarget::PaneSplit(b.path, b.direction, pane_area));
+            }
+        }
+        None
     }
 
     fn is_on_file_tree_border(&self, col: u16) -> bool {
@@ -219,8 +319,10 @@ impl App {
                             self.last_tab_click = Some((tab_idx, now));
                         }
                         // A tab click switches context; any in-flight
-                        // outer-edge double-click attempt is now stale.
+                        // outer-edge or boundary double-click attempt is
+                        // now stale.
                         self.last_edge_click = None;
+                        self.last_boundary_click = None;
                         self.dirty = true;
                         return;
                     }
@@ -237,6 +339,7 @@ impl App {
                             self.emit_pane_started(new_id);
                         }
                         self.last_edge_click = None;
+                        self.last_boundary_click = None;
                         return;
                     }
                 }
@@ -244,47 +347,64 @@ impl App {
                 if self.is_on_file_tree_border(col) {
                     self.dragging = Some(DragTarget::FileTreeBorder);
                     self.last_edge_click = None;
+                    self.last_boundary_click = None;
                     return;
                 }
                 if self.is_on_preview_border(col) {
                     self.dragging = Some(DragTarget::PreviewBorder);
                     self.last_edge_click = None;
+                    self.last_boundary_click = None;
                     return;
                 }
 
-                if let Some(pane_area) = self.ws().last_pane_rects.first().map(|_| {
-                    let rects = &self.ws().last_pane_rects;
-                    let min_x = rects.iter().map(|(_, r)| r.x).min().unwrap_or(0);
-                    let min_y = rects.iter().map(|(_, r)| r.y).min().unwrap_or(0);
-                    let max_x = rects.iter().map(|(_, r)| r.x + r.width).max().unwrap_or(0);
-                    let max_y = rects.iter().map(|(_, r)| r.y + r.height).max().unwrap_or(0);
-                    Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
-                }) {
-                    let boundaries = self.ws().layout.split_boundaries(pane_area);
-                    for (boundary, direction, path) in boundaries {
-                        let on_border = match direction {
-                            SplitDirection::Vertical => {
-                                col >= boundary.saturating_sub(1)
-                                    && col <= boundary
-                                    && row >= pane_area.y
-                                    && row < pane_area.y + pane_area.height
+                if let Some(pane_area) = self.pane_area() {
+                    let active_tab = self.active_tab;
+
+                    // Shared internal boundary: classify click vs drag.
+                    // A second click on the same divider cell within
+                    // 500 ms double-clicks it → split the adjacent pane
+                    // and drop the new leaf right on the divider. A
+                    // first (single) click instead arms the timer and
+                    // sets up the resize-drag, so a plain click that
+                    // never moves is a no-op and a click-drag still
+                    // resizes — the historical behavior. (Issue #247)
+                    if let Some(DragTarget::PaneSplit(path, direction, area)) =
+                        self.boundary_drag_target(col, row)
+                    {
+                        let now = Instant::now();
+                        let is_double = matches!(
+                            self.last_boundary_click,
+                            Some((prev_tab, prev_col, prev_row, prev_t))
+                                if prev_tab == active_tab
+                                    && prev_col == col
+                                    && prev_row == row
+                                    && now.duration_since(prev_t).as_millis() < 500
+                        );
+                        // A boundary click breaks any in-flight
+                        // outer-edge double-click intent.
+                        self.last_edge_click = None;
+                        if is_double {
+                            self.last_boundary_click = None;
+                            let pane_rects = self.ws().last_pane_rects.clone();
+                            if let Some((dir, target_id, new_pane_first)) =
+                                detect_shared_boundary(pane_area, &pane_rects, col, row)
+                            {
+                                self.ws_mut().focused_pane_id = target_id;
+                                self.ws_mut().focus_target = FocusTarget::Pane;
+                                if let Ok(Some(new_id)) =
+                                    self.split_focused_pane_with_position(dir, new_pane_first, None)
+                                {
+                                    self.emit_pane_started(new_id);
+                                }
+                                return;
                             }
-                            SplitDirection::Horizontal => {
-                                row >= boundary.saturating_sub(1)
-                                    && row <= boundary
-                                    && col >= pane_area.x
-                                    && col < pane_area.x + pane_area.width
-                            }
-                        };
-                        if on_border {
-                            self.dragging = Some(DragTarget::PaneSplit(path, direction, pane_area));
-                            // A boundary-resize drag interleaved with
-                            // an edge click breaks the double-click
-                            // intent; clear the timer so the next
-                            // outer-edge click starts fresh.
-                            self.last_edge_click = None;
-                            return;
+                            // Ambiguous junction cell — fall through to
+                            // the resize-drag instead of splitting.
+                        } else {
+                            self.last_boundary_click = Some((active_tab, col, row, now));
                         }
+                        self.dragging = Some(DragTarget::PaneSplit(path, direction, area));
+                        return;
                     }
 
                     // Outer-edge double-click → split. The shared-boundary
@@ -297,7 +417,6 @@ impl App {
                     // on a pane's outer border still focuses that pane,
                     // preserving the historical behavior. (Issue #245)
                     let pane_rects = self.ws().last_pane_rects.clone();
-                    let active_tab = self.active_tab;
                     if let Some((side, target_id)) =
                         detect_outer_edge(pane_area, &pane_rects, col, row)
                     {
@@ -329,8 +448,13 @@ impl App {
                             // run so a single edge click still selects
                             // the underlying pane.
                         }
+                        // An outer-edge click is never a boundary click;
+                        // reset the boundary timer so the two paths
+                        // can't cross-trigger.
+                        self.last_boundary_click = None;
                     } else {
                         self.last_edge_click = None;
+                        self.last_boundary_click = None;
                     }
                 }
 
@@ -357,6 +481,7 @@ impl App {
                             }
                         }
                         self.last_edge_click = None;
+                        self.last_boundary_click = None;
                         return;
                     }
                 }
@@ -369,6 +494,7 @@ impl App {
                     {
                         self.ws_mut().focus_target = FocusTarget::Preview;
                         self.last_edge_click = None;
+                        self.last_boundary_click = None;
                         return;
                     }
                 }
@@ -642,13 +768,18 @@ impl App {
             }
             MouseEventKind::Moved => {
                 let col = mouse.column;
+                let row = mouse.row;
                 let old_hover = self.hover_border.clone();
                 if self.is_on_file_tree_border(col) {
                     self.hover_border = Some(DragTarget::FileTreeBorder);
                 } else if self.is_on_preview_border(col) {
                     self.hover_border = Some(DragTarget::PreviewBorder);
                 } else {
-                    self.hover_border = None;
+                    // Tint the shared internal divider under the cursor
+                    // so it reads as draggable / double-clickable, the
+                    // same affordance the file-tree and preview borders
+                    // already get. (Issue #247)
+                    self.hover_border = self.boundary_drag_target(col, row);
                 }
                 if self.hover_border != old_hover {
                     self.dirty = true;

--- a/src/app/pointer_input.rs
+++ b/src/app/pointer_input.rs
@@ -221,7 +221,11 @@ impl App {
                 }
             };
             if on_border {
-                return Some(DragTarget::PaneSplit(b.path, b.direction, pane_area));
+                // Store the split node's own rect (not `pane_area`) so
+                // the resize-drag ratio is measured against the region
+                // the divider actually slices — nested dividers would
+                // otherwise jump when dragged.
+                return Some(DragTarget::PaneSplit(b.path, b.direction, b.area));
             }
         }
         None
@@ -591,6 +595,12 @@ impl App {
                                 }
                             };
                             self.ws_mut().layout.update_ratio(path, new_ratio);
+                            // An actual resize-drag invalidates the
+                            // pending double-click: the next click on
+                            // this cell should arm a fresh timer, not
+                            // promote a just-resized divider into a
+                            // phantom double-click split.
+                            self.last_boundary_click = None;
                         }
                         DragTarget::Scrollbar(pane_id, inner) => {
                             self.scroll_pane_to_click(*pane_id, row, inner);

--- a/src/app/tests/layout_tree.rs
+++ b/src/app/tests/layout_tree.rs
@@ -225,3 +225,65 @@ fn split_with_position_horizontal_top_places_new_pane_top() {
     assert_eq!(rects[0], (2, Rect::new(0, 0, 100, 25)));
     assert_eq!(rects[1], (1, Rect::new(0, 25, 100, 25)));
 }
+
+// ─── split_boundaries span (Issue #247) ─────────────────────────
+
+#[test]
+fn split_boundaries_flat_vertical_spans_full_height() {
+    // A single top-level vertical split: the divider sits at x = 50
+    // and spans every row of the area.
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Vertical,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Leaf { pane_id: 1 }),
+        second: Box::new(LayoutNode::Leaf { pane_id: 2 }),
+    };
+    let bounds = layout.split_boundaries(Rect::new(0, 0, 100, 50));
+    assert_eq!(bounds.len(), 1);
+    assert_eq!(bounds[0].position, 50);
+    assert_eq!(bounds[0].direction, SplitDirection::Vertical);
+    assert_eq!(bounds[0].span, (0, 50), "vertical divider spans all rows");
+    assert!(bounds[0].path.is_empty());
+}
+
+#[test]
+fn split_boundaries_nested_divider_spans_only_its_subregion() {
+    // Top-level HORIZONTAL split: full-width top pane (1) over a
+    // bottom subtree that is itself a VERTICAL split (2 | 3).
+    //   1 → (0,0,100,25)
+    //   2 → (0,25,50,25)   3 → (50,25,50,25)
+    // The nested vertical divider at x = 50 must report a span of
+    // rows 25..50 — NOT the whole 0..50 height. Before #247 the
+    // hit-test assumed full height, so a click at (50, 10) — inside
+    // the top pane — wrongly registered as a boundary press.
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Leaf { pane_id: 1 }),
+        second: Box::new(LayoutNode::Split {
+            direction: SplitDirection::Vertical,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf { pane_id: 2 }),
+            second: Box::new(LayoutNode::Leaf { pane_id: 3 }),
+        }),
+    };
+    let bounds = layout.split_boundaries(Rect::new(0, 0, 100, 50));
+    assert_eq!(bounds.len(), 2);
+
+    let top = bounds.iter().find(|b| b.path.is_empty()).expect("root");
+    assert_eq!(top.direction, SplitDirection::Horizontal);
+    assert_eq!(top.position, 25);
+    assert_eq!(top.span, (0, 100), "horizontal divider spans all cols");
+
+    let nested = bounds
+        .iter()
+        .find(|b| b.path == vec![true])
+        .expect("nested vertical divider");
+    assert_eq!(nested.direction, SplitDirection::Vertical);
+    assert_eq!(nested.position, 50);
+    assert_eq!(
+        nested.span,
+        (25, 50),
+        "nested divider must span only the bottom subregion"
+    );
+}

--- a/src/app/tests/pointer_input.rs
+++ b/src/app/tests/pointer_input.rs
@@ -588,3 +588,96 @@ fn boundary_drag_resizes_and_does_not_split() {
     }
     app.shutdown();
 }
+
+#[test]
+fn boundary_drag_then_click_does_not_phantom_split() {
+    // After a resize-drag, the pending double-click candidate must be
+    // dropped — otherwise a click on the same cell within 500 ms would
+    // be misread as a double-click and split. (Codex review, #247)
+    let (mut app, _a_id, _b_id) = two_pane_vertical_app();
+
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        50,
+        20,
+    ));
+    // Drag in place (boundary stays at x=50), then release.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        50,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        50,
+        20,
+    ));
+    // A follow-up click on the same divider cell must arm a fresh
+    // timer, not split.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        50,
+        20,
+    ));
+
+    assert_eq!(
+        app.ws().layout.pane_count(),
+        2,
+        "a click after a drag must not phantom-split"
+    );
+    app.shutdown();
+}
+
+#[test]
+fn boundary_drag_ratio_is_relative_to_nested_subregion() {
+    // Layout [A | [B | C]] over a 100×40 area: a top-level vertical
+    // split at x=50, and a nested vertical split (B|C) inside the
+    // right half, with its divider at x=75. Dragging the NESTED
+    // divider must measure the ratio against the right half's own rect
+    // (x∈[50,100)), not the whole pane area — so a drag to x=80 yields
+    // (80-50)/50 = 0.60, not the buggy 80/100 = 0.80. (Codex review)
+    let mut app = App::new(40, 100).expect("App::new");
+    app.split_focused_pane_with_position(SplitDirection::Vertical, false, None)
+        .expect("split A|B")
+        .expect("not refused");
+    app.split_focused_pane_with_position(SplitDirection::Vertical, false, None)
+        .expect("split B|C")
+        .expect("not refused");
+    assert_eq!(app.ws().layout.pane_count(), 3);
+
+    let area = Rect::new(0, 0, 100, 40);
+    app.ws_mut().last_pane_rects = app.ws().layout.calculate_rects(area);
+
+    // The nested divider is at x=75; drag it to x=80.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        75,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        80,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        80,
+        20,
+    ));
+
+    assert_eq!(app.ws().layout.pane_count(), 3, "drag must not split");
+    // Walk to the nested split's ratio.
+    if let LayoutNode::Split { second, .. } = &app.ws().layout {
+        if let LayoutNode::Split { ratio, .. } = second.as_ref() {
+            assert!(
+                (*ratio - 0.60).abs() < 0.01,
+                "nested drag should resize relative to the right half, got {ratio}"
+            );
+        } else {
+            panic!("right child should be the nested split");
+        }
+    } else {
+        panic!("root should be a split");
+    }
+    app.shutdown();
+}

--- a/src/app/tests/pointer_input.rs
+++ b/src/app/tests/pointer_input.rs
@@ -345,3 +345,246 @@ fn split_intent_bottom_right_place_new_pane_second() {
         (SplitDirection::Vertical, false)
     );
 }
+
+// ─── detect_shared_boundary (Issue #247) ────────────────────────
+
+#[test]
+fn detect_shared_boundary_vertical_targets_left_leaf() {
+    // [1 | 2] split vertically at x = 50. The divider occupies the
+    // two columns {49, 50}. A double-click anywhere on it splits the
+    // LEFT leaf (1) to its right, so the new pane lands between 1 and
+    // 2. Direction is Vertical, new_pane_first = false.
+    let rects = vec![(1, Rect::new(0, 0, 50, 50)), (2, Rect::new(50, 0, 50, 50))];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 50, 25),
+        Some((SplitDirection::Vertical, 1, false))
+    );
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 49, 25),
+        Some((SplitDirection::Vertical, 1, false)),
+        "the left border column of the divider counts too"
+    );
+}
+
+#[test]
+fn detect_shared_boundary_horizontal_targets_top_leaf() {
+    // [1 / 2] split horizontally at y = 25. The divider occupies rows
+    // {24, 25}. A double-click splits the TOP leaf (1) downward.
+    let rects = vec![
+        (1, Rect::new(0, 0, 100, 25)),
+        (2, Rect::new(0, 25, 100, 25)),
+    ];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 50, 25),
+        Some((SplitDirection::Horizontal, 1, false))
+    );
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 50, 24),
+        Some((SplitDirection::Horizontal, 1, false))
+    );
+}
+
+#[test]
+fn detect_shared_boundary_rejects_outer_rim() {
+    // The workspace's own outer edges are NOT shared boundaries —
+    // those belong to the outer-edge double-click path (#245).
+    let rects = vec![(1, Rect::new(0, 0, 50, 50)), (2, Rect::new(50, 0, 50, 50))];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 0, 25),
+        None,
+        "left rim"
+    );
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 99, 25),
+        None,
+        "right rim"
+    );
+    assert_eq!(detect_shared_boundary(area, &rects, 25, 0), None, "top rim");
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 25, 49),
+        None,
+        "bottom rim"
+    );
+}
+
+#[test]
+fn detect_shared_boundary_nested_hit_test_respects_span() {
+    // Full-width top pane (1) over a bottom left/right split (2 | 3):
+    //   1 → (0,0,100,25)
+    //   2 → (0,25,50,25)   3 → (50,25,50,25)
+    // The nested vertical divider lives only in the bottom half.
+    let rects = vec![
+        (1, Rect::new(0, 0, 100, 25)),
+        (2, Rect::new(0, 25, 50, 25)),
+        (3, Rect::new(50, 25, 50, 25)),
+    ];
+    let area = Rect::new(0, 0, 100, 50);
+    // Click at column 50 but in the TOP pane's rows: not a boundary.
+    // (This is exactly the gap #246 left open and #247 closes.)
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 50, 10),
+        None,
+        "col 50 inside the top pane is not a divider"
+    );
+    // Click at column 50 in the BOTTOM rows: splits the bottom-left
+    // leaf (2) to its right.
+    assert_eq!(
+        detect_shared_boundary(area, &rects, 50, 40),
+        Some((SplitDirection::Vertical, 2, false))
+    );
+}
+
+#[test]
+fn detect_shared_boundary_rejects_ambiguous_junction() {
+    // Where a vertical and a horizontal divider cross, the split
+    // direction is ambiguous, so the helper declines (like a corner
+    // cell) and the click stays a resize-drag.
+    //   1 → (0,0,100,25) full-width top
+    //   2 → (0,25,50,25)   3 → (50,25,50,25)
+    // Cell (50, 25) sits on both pane 1's bottom edge (horizontal
+    // divider) and the 2|3 vertical divider.
+    let rects = vec![
+        (1, Rect::new(0, 0, 100, 25)),
+        (2, Rect::new(0, 25, 50, 25)),
+        (3, Rect::new(50, 25, 50, 25)),
+    ];
+    let area = Rect::new(0, 0, 100, 50);
+    assert_eq!(detect_shared_boundary(area, &rects, 50, 25), None);
+}
+
+// ─── handle_mouse_event boundary click vs drag (Issue #247) ─────
+//
+// These drive the real event handler, which spawns PTYs on split, so
+// each test calls `app.shutdown()` at the end. A two-pane vertical
+// layout is set up by hand: split the focused pane, then publish the
+// rects the renderer would have produced into `last_pane_rects` so the
+// pointer code can hit-test against them.
+
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+fn boundary_mouse(kind: MouseEventKind, col: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column: col,
+        row,
+        modifiers: KeyModifiers::empty(),
+    }
+}
+
+/// Build an app whose active tab holds `[A | B]` split vertically over
+/// a 100×40 area, with `last_pane_rects` published. Returns
+/// `(app, a_id, b_id)`; the divider sits at column 50.
+fn two_pane_vertical_app() -> (App, usize, usize) {
+    let mut app = App::new(40, 100).expect("App::new");
+    let a_id = app.ws().focused_pane_id;
+    app.split_focused_pane_with_position(SplitDirection::Vertical, false, None)
+        .expect("split succeeds")
+        .expect("split not refused");
+    let b_id = app.ws().focused_pane_id;
+    assert_ne!(a_id, b_id);
+    let area = Rect::new(0, 0, 100, 40);
+    let rects = app.ws().layout.calculate_rects(area);
+    app.ws_mut().last_pane_rects = rects;
+    (app, a_id, b_id)
+}
+
+#[test]
+fn boundary_double_click_splits_between_siblings() {
+    let (mut app, a_id, b_id) = two_pane_vertical_app();
+    assert_eq!(app.ws().layout.pane_count(), 2);
+
+    // First click on the divider arms the timer (and sets up a
+    // resize-drag); the release cancels the drag without resizing.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        50,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        50,
+        20,
+    ));
+    assert_eq!(
+        app.ws().layout.pane_count(),
+        2,
+        "a single click must not split"
+    );
+
+    // Second click within 500 ms → double-click → split the left
+    // sibling, dropping the new leaf between A and B.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        50,
+        20,
+    ));
+    let new_id = app.ws().focused_pane_id;
+    assert_eq!(app.ws().layout.pane_count(), 3, "double-click splits");
+    assert_eq!(
+        app.ws().layout.collect_pane_ids(),
+        vec![a_id, new_id, b_id],
+        "new leaf is inserted between the two siblings"
+    );
+    app.shutdown();
+}
+
+#[test]
+fn boundary_single_click_is_noop() {
+    let (mut app, a_id, b_id) = two_pane_vertical_app();
+    let ids_before = app.ws().layout.collect_pane_ids();
+
+    // A lone down/up on the divider (no second click, no drag) must
+    // leave the layout untouched.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        50,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        50,
+        20,
+    ));
+
+    assert_eq!(app.ws().layout.pane_count(), 2);
+    assert_eq!(app.ws().layout.collect_pane_ids(), ids_before);
+    assert_eq!(ids_before, vec![a_id, b_id]);
+    app.shutdown();
+}
+
+#[test]
+fn boundary_drag_resizes_and_does_not_split() {
+    let (mut app, _a_id, _b_id) = two_pane_vertical_app();
+
+    // Press on the divider, then drag left to x = 30. The drag must
+    // resize (ratio → 0.30) and never split.
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        50,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        30,
+        20,
+    ));
+    app.handle_mouse_event(boundary_mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        30,
+        20,
+    ));
+
+    assert_eq!(app.ws().layout.pane_count(), 2, "a drag must not split");
+    if let LayoutNode::Split { ratio, .. } = &app.ws().layout {
+        assert!(
+            (*ratio - 0.30).abs() < 0.01,
+            "drag to x=30 over a width-100 area resizes to ~0.30, got {ratio}"
+        );
+    } else {
+        panic!("layout should still be a single split");
+    }
+    app.shutdown();
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 use ratatui::Frame;
 
-use crate::app::{App, DragTarget, FocusTarget};
+use crate::app::{App, DragTarget, FocusTarget, SplitDirection};
 
 // ─── Theme (Claude-inspired) ──────────────────────────────
 const BG: Color = Color::Rgb(0x0d, 0x11, 0x17);
@@ -666,6 +666,52 @@ fn render_panes(app: &mut App, frame: &mut Frame, area: Rect) {
             );
             let claude_state = app.claude_monitor.state(pane_id);
             render_single_pane(pane, is_focused, pane_sel, &claude_state, frame, rect);
+        }
+    }
+
+    render_boundary_tint(app, frame, area);
+}
+
+/// Tint the shared internal divider that's being hovered or dragged so
+/// it reads as draggable / double-clickable, matching the file-tree and
+/// preview border affordance. The divider's two border columns (or
+/// rows) are already painted by the adjacent panes; we just recolor
+/// them over the divider's span. (Issue #247)
+fn render_boundary_tint(app: &mut App, frame: &mut Frame, area: Rect) {
+    let Some(DragTarget::PaneSplit(path, _, _)) =
+        app.dragging.as_ref().or(app.hover_border.as_ref())
+    else {
+        return;
+    };
+    let path = path.clone();
+    let Some(boundary) = app
+        .ws()
+        .layout
+        .split_boundaries(area)
+        .into_iter()
+        .find(|b| b.path == path)
+    else {
+        return;
+    };
+    let buf = frame.buffer_mut();
+    match boundary.direction {
+        SplitDirection::Vertical => {
+            for cx in [boundary.position.saturating_sub(1), boundary.position] {
+                for y in boundary.span.0..boundary.span.1 {
+                    if let Some(cell) = buf.cell_mut((cx, y)) {
+                        cell.set_fg(ACCENT_GREEN);
+                    }
+                }
+            }
+        }
+        SplitDirection::Horizontal => {
+            for cy in [boundary.position.saturating_sub(1), boundary.position] {
+                for x in boundary.span.0..boundary.span.1 {
+                    if let Some(cell) = buf.cell_mut((x, cy)) {
+                        cell.set_fg(ACCENT_GREEN);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #245 / #246 (outer-edge double-click split). Extends the click-to-split gesture so **shared internal boundaries between sibling panes** also accept a double-click to split, while remaining drag-resizable.

- `pointer_input.rs`: `handle_mouse_event` now has a click-vs-drag classifier on shared boundaries. A double-click (within 500ms, same cell) on a shared border splits the adjacent pane, inserting a new leaf between the two siblings. Drag still resizes; single click stays no-op.
- `detect_shared_boundary` (pure, geometry-based): vertical boundary → split left leaf rightward; horizontal boundary → split top leaf downward. Junctions (cross intersections) and outer edges return `None`.
- `split_boundaries` reworked into a `SplitBoundary` struct carrying each divider's span (perpendicular range) + the node's own area rect — this **subsumes #246's known nested-layout hit-test limitation**.
- Hover tint extended to shared boundaries (`ui.rs`, `ACCENT_GREEN`, applied during drag too).
- `README.md` / `docs/keymap.md` updated.

## Verification

- `cargo build`: OK
- `cargo test`: **604 passed / 0 failed** (12 new tests: `detect_shared_boundary` per direction / nested / junction / outer edge, `split_boundaries` span, double-click split, single-click no-op, drag preservation, nested drag ratio, post-drag phantom-split prevention)
- `cargo clippy --all-targets`: no warnings
- `cargo fmt --check`: clean
- Codex self-review: initial 2 Major (nested drag ratio based on pane_area / stale `last_boundary_click` after drag) → both fixed and recommitted → re-review clean (no Blocker/Major/Minor/Nit)

Closes #247
Refs #245 #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)