### PR TITLE
fix: scope gh-pr-create PreToolUse hook to actual gh pr create calls

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,8 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(gh pr create*)",
-            "command": "cmd=$(jq -r '.tool_input.command'); if echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+Shin-sibainu/ccmux'; then echo 'Blocked: PR target is upstream Shin-sibainu/ccmux. Add --repo suisya-systems/renga --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi; if ! echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+suisya-systems/renga'; then echo 'Blocked: gh pr create without --repo defaults to upstream Shin-sibainu/ccmux. Add --repo suisya-systems/renga --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi"
+            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[;&| ])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0; if echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+Shin-sibainu/ccmux'; then echo 'Blocked: PR target is upstream Shin-sibainu/ccmux. Add --repo suisya-systems/renga --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi; if ! echo \"$cmd\" | grep -qE -- '--repo[[:space:]]+suisya-systems/renga'; then echo 'Blocked: gh pr create without --repo defaults to upstream Shin-sibainu/ccmux. Add --repo suisya-systems/renga --base main explicitly. Per CLAUDE.md, upstream PRs require explicit user authorization.' >&2; exit 2; fi"
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `PreToolUse` hook in `.claude/settings.json` used an unsupported `"if": "Bash(gh pr create*)"` field. Claude Code's hook schema has no `if` field (conditioning is done only via `matcher`, which matches the tool *name*), so it was silently ignored. With `matcher: "Bash"`, the guard command therefore ran on **every** Bash invocation and blocked any command not containing `--repo suisya-systems/renga` — e.g. `marp`, `git commit`, `cargo`. Observed 2026-05-29: a worker's unrelated write commands were blocked.

## Fix

- Add a command-prefix guard so the hook exits `0` (passes) unless the command is an actual `gh pr create` invocation:
  `echo "$cmd" | grep -qE '(^|[;&| ])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0;`
- Drop the dead `if` field.

The original upstream-PR protection (block `--repo Shin-sibainu/ccmux`, require `--repo suisya-systems/renga`) is preserved for real `gh pr create` calls.

## Verification

Ran the corrected hook command against stdin JSON for 5 cases:

| command | expected | result |
|---|---|---|
| `npx marp ... --pptx` | pass (0) | 0 ✓ |
| `git commit -m x` | pass (0) | 0 ✓ |
| `gh pr create --base main` (no --repo) | block (2) | 2 ✓ |
| `gh pr create --repo suisya-systems/renga` | pass (0) | 0 ✓ |
| `gh pr create --repo Shin-sibainu/ccmux` | block (2) | 2 ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)