### PR TITLE
fix: caret desync on plain PTY panes (pending-wrap + WSL conpty)

### DIFF
--- a/src/app/layout_ops.rs
+++ b/src/app/layout_ops.rs
@@ -111,12 +111,14 @@ impl App {
             return Ok(None);
         }
 
-        if let Some(&(_, rect)) = self
+        let focused_rect = self
             .ws()
             .last_pane_rects
             .iter()
             .find(|(id, _)| *id == self.ws().focused_pane_id)
-        {
+            .map(|&(_, rect)| rect);
+
+        if let Some(rect) = focused_rect {
             match direction {
                 SplitDirection::Vertical => {
                     if rect.width / 2 < self.min_pane_width {
@@ -141,7 +143,24 @@ impl App {
                 .map(|p| p.cwd.clone())
         });
 
-        let pane = Pane::new_with_cwd(new_id, 10, 40, self.event_tx.clone(), cwd)?;
+        // Seed the new PTY with the geometry it will actually get after the
+        // split, minus the 1-cell border on each side. Falling back to a
+        // fixed 10x40 (the old behavior) forced every fresh pane through a
+        // startup resize/reflow once `render_panes` corrected the size, a
+        // contributing factor to caret desync on plain PTY panes. The next
+        // render still calls `pane.resize(...)` with the exact rect, so this
+        // is purely a better first-frame estimate.
+        let (init_rows, init_cols) = match focused_rect {
+            Some(rect) => {
+                let (w, h) = match direction {
+                    SplitDirection::Vertical => (rect.width / 2, rect.height),
+                    SplitDirection::Horizontal => (rect.width, rect.height / 2),
+                };
+                (h.saturating_sub(2).max(1), w.saturating_sub(2).max(1))
+            }
+            None => (10, 40),
+        };
+        let pane = Pane::new_with_cwd(new_id, init_rows, init_cols, self.event_tx.clone(), cwd)?;
         let ws = self.ws_mut();
         ws.panes.insert(new_id, pane);
         ws.layout

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,8 +439,14 @@ fn run_event_loop(
             // Scoped to Windows because conpty is the observed
             // culprit; macOS / Linux terminals don't exhibit the
             // leak, and the gate avoids any unintended side effect.
-            #[cfg(windows)]
-            {
+            //
+            // The same conpty path is in play under WSL: there the renga
+            // binary is Linux (so `cfg(windows)` is false at compile time)
+            // but the outer terminal is still Windows Terminal via conpty,
+            // which leaks intermediate MoveTo the same way. Native Linux /
+            // macOS terminals don't, so gate the Linux side on a runtime WSL
+            // check to avoid changing their behavior.
+            if hide_cursor_during_draw() {
                 let _ = execute!(terminal.backend_mut(), crossterm::cursor::Hide);
             }
             terminal.draw(|frame| {
@@ -542,6 +548,43 @@ fn flush_paste_buffer(app: &mut app::App, buffer: &mut Vec<u8>) -> Result<()> {
     }
     buffer.clear();
     Ok(())
+}
+
+/// Whether the hardware cursor must be force-hidden for the whole draw
+/// transaction to avoid conpty leaking intermediate `MoveTo` to the host
+/// caret (see the call site for the full rationale). Always true on native
+/// Windows; on other targets only under WSL, where the outer terminal is
+/// still Windows Terminal via conpty.
+fn hide_cursor_during_draw() -> bool {
+    #[cfg(windows)]
+    {
+        true
+    }
+    #[cfg(not(windows))]
+    {
+        is_wsl()
+    }
+}
+
+/// Detect WSL once and cache the result. WSL exports `WSL_DISTRO_NAME` /
+/// `WSL_INTEROP`, and its kernel release string contains "microsoft".
+#[cfg(not(windows))]
+fn is_wsl() -> bool {
+    use std::sync::OnceLock;
+    static WSL: OnceLock<bool> = OnceLock::new();
+    *WSL.get_or_init(|| {
+        if std::env::var_os("WSL_DISTRO_NAME").is_some()
+            || std::env::var_os("WSL_INTEROP").is_some()
+        {
+            return true;
+        }
+        std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|s| {
+                let s = s.to_ascii_lowercase();
+                s.contains("microsoft") || s.contains("wsl")
+            })
+            .unwrap_or(false)
+    })
 }
 
 #[cfg(test)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -992,10 +992,23 @@ fn render_terminal_content(
         } else {
             cursor
         };
-        let cursor_x = area.x + target.1;
+        // vt100 reports col == cols while an autowrap (DECAWM) is pending —
+        // i.e. after a glyph lands in the last column but before the next
+        // glyph wraps the line (vt100's `col_inc` advances past the last
+        // column without clamping, so `cursor_position()` returns the
+        // out-of-range column). Real terminals keep the caret visible on the
+        // last cell in that state, so clamp the column instead of letting the
+        // `< area.x + area.width` guard drop the caret entirely. Dropping it
+        // left the host caret unset for the frame; on WSL/conpty the hardware
+        // caret then stayed stranded at the last painted cell — the visible
+        // desync on plain PTY (bash) panes. Claude panes never hit this: their
+        // caret comes from `resolve_claude_caret`, which only ever returns an
+        // in-range column.
         let cursor_y = area.y + target.0;
-        if cursor_x < area.x + area.width && cursor_y < area.y + area.height {
-            frame.set_cursor_position((cursor_x, cursor_y));
+        if let Some(clamped_col) = clamp_caret_col(target.1, area.width) {
+            if cursor_y < area.y + area.height {
+                frame.set_cursor_position((area.x + clamped_col, cursor_y));
+            }
         }
     }
 
@@ -1046,6 +1059,19 @@ fn should_track_claude_caret(
     hide_cursor: bool,
 ) -> bool {
     is_claude_running || (claude_ever_seen && hide_cursor)
+}
+
+/// Map a vt100 cursor column onto a host-caret column inside a pane's inner
+/// area of the given `width`.
+///
+/// vt100 reports `col == cols` while an autowrap (DECAWM) is pending — the
+/// caret has advanced past the last column but no glyph has wrapped the line
+/// yet (vt100's `col_inc` does not clamp). Clamp such an out-of-range column
+/// onto the last visible cell (`width - 1`) so the caret stays visible on the
+/// final cell, matching real terminals, instead of being dropped. Returns
+/// `None` only when the area has zero width (nothing to draw into).
+fn clamp_caret_col(col: u16, width: u16) -> Option<u16> {
+    (width > 0).then(|| col.min(width - 1))
 }
 
 /// Prompt glyphs Claude Code renders at the left edge of its input box.
@@ -1706,7 +1732,29 @@ fn vt100_color_to_ratatui(color: vt100::Color) -> Color {
 
 #[cfg(test)]
 mod overlay_wrap_tests {
-    use super::{should_track_claude_caret, wrap_overlay_buffer};
+    use super::{clamp_caret_col, should_track_claude_caret, wrap_overlay_buffer};
+
+    #[test]
+    fn pending_autowrap_col_clamps_onto_last_cell() {
+        // vt100 reports col == cols (here 80) while a DECAWM autowrap is
+        // pending. The caret must land on the last visible cell (79), not be
+        // dropped — dropping it leaves the host caret desynced on plain PTY
+        // (bash) panes, especially on WSL/conpty.
+        assert_eq!(clamp_caret_col(80, 80), Some(79));
+    }
+
+    #[test]
+    fn in_range_caret_col_is_unchanged() {
+        assert_eq!(clamp_caret_col(0, 80), Some(0));
+        assert_eq!(clamp_caret_col(5, 80), Some(5));
+        assert_eq!(clamp_caret_col(79, 80), Some(79));
+    }
+
+    #[test]
+    fn zero_width_area_has_no_caret() {
+        assert_eq!(clamp_caret_col(0, 0), None);
+        assert_eq!(clamp_caret_col(3, 0), None);
+    }
 
     #[test]
     fn empty_buffer_reports_origin() {


### PR DESCRIPTION
## Problem

On plain PTY panes (bash etc.), the displayed caret position drifts from the actual cursor position. Claude Code panes are unaffected.

**Root cause:** the bash/host-caret path uses vt100's logical `cursor_position()`. During pending autowrap (a glyph written into the last column without a clamping `col_inc`), vt100 returns `col == cols` (one past the last cell). renga's caret guard in `src/ui.rs` then skips `set_cursor_position` for that frame. On WSL/conpty (where the draw-time cursor-Hide mitigation was `#[cfg(windows)]`-only and thus inactive in the Linux build), the hardware caret is left stranded at the last leaked MoveTo position → visible drift. Claude Code panes resolve the caret by scanning the rendered grid (`resolve_claude_caret`), always within `0..cols-1`, so they never hit the guard.

## Fix

1. **`src/ui.rs`** — clamp `col >= cols` to `cols-1` before drawing the caret (`clamp_caret_col()`), so pending-wrap shows the caret on the last cell instead of dropping the frame.
2. **`src/main.rs`** — apply the draw-time cursor-Hide (conpty MoveTo-leak mitigation) on WSL too, not just `#[cfg(windows)]` (`is_wsl()` / `hide_cursor_during_draw()`). Native Linux/macOS unchanged.
3. **`src/app/layout_ops.rs`** — initialize a new split pane's size from the real post-split geometry instead of a fixed 10x40, avoiding a startup reflow (a contributing trigger for "new pane" cases).

## Verification

- `cargo fmt` / `cargo build` / `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 607 passed / 0 failed, incl. 3 new regression tests (`pending_autowrap_col_clamps_onto_last_cell`, `in_range_caret_col_is_unchanged`, `zero_width_area_has_no_caret`)
- Manual build + check by the maintainer: looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)