### PR TITLE
release: renga v1.3.1 (caret desync fix + hook scope fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-05-30
+
+Patch release. Fixes caret/cursor desync on plain PTY panes — the
+rendered caret could drift past the end of a line, and the conpty
+cursor-leak guard only covered native Windows, leaving the WSL conpty
+path exposed. The frozen v1.0 API surface (MCP wire shape, CLI flags,
+config keys, env vars) is unchanged.
+
+### Fixed
+
+- **The caret no longer drifts past the line end on plain PTY panes.**
+  When vt100 reports the pending-autowrap column (`col == cols`) at the
+  right edge, renga now clamps the drawn cursor to `cols - 1` instead of
+  rendering it one cell beyond the last column. New split panes are also
+  seeded with their post-split geometry (minus the 1-cell border)
+  instead of a fixed 10×40, so a fresh pane no longer takes a startup
+  resize/reflow that contributed to the desync; the next render still
+  resizes to the exact rect, so this is purely a better first frame.
+  (#253)
+- **The conpty cursor-leak guard now also covers the WSL conpty path.**
+  The `Hide` that works around conpty's dropped `MoveTo` was gated to
+  `#[cfg(windows)]` at compile time, so it never fired under WSL even
+  when the conpty backend was in use. The guard is now a runtime check,
+  so the WSL conpty path is protected too. (#253)
+
+### Internal
+
+- **The `gh pr create` PreToolUse hook is scoped to actual
+  `gh pr create` calls.** The hook previously used an unsupported `if`
+  field (silently ignored), so its `--repo` guard ran on every Bash
+  command and blocked unrelated commands; it now exits early unless the
+  command is a real `gh pr create`, preserving the upstream-PR
+  protection. Repo tooling only — no effect on the renga binary. (#251)
+
 ## [1.3.0] — 2026-05-29
 
 First minor release after the v1.2.x patch line. Adds click-to-split

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,15 @@ name = "renga"
 # pane right on the divider (#247). Minor bump: new user-facing pointer
 # behavior added backward-compatibly; the frozen v1.0 API surface (MCP
 # wire shape, CLI flags, config keys, env vars) is unchanged.
-version = "1.3.0"
+# 1.3.1 fixes caret/cursor desync on plain PTY panes: vt100's pending
+# autowrap column (col == cols) is clamped to cols-1 so the rendered
+# caret no longer drifts past the line end, and the conpty MoveTo-leak
+# Hide guard is switched from a #[cfg(windows)] compile-time gate to a
+# runtime check so the WSL conpty path is covered too (#253). Patch
+# bump: rendering/display bug fix in internal source only; the frozen
+# v1.0 API surface (MCP wire shape, CLI flags, config keys, env vars)
+# is unchanged.
+version = "1.3.1"
 edition = "2021"
 description = "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes.",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary

Patch release **v1.3.1** cutting the two commits already on `main` that postdate v1.3.0.

- **Fixed (#253):** caret desync on plain PTY panes — clamp pending-autowrap column to `cols-1` on the last cell, make the conpty Hide guard runtime-detected (protects the WSL path), and derive split-pane initial size from real geometry.
- **Internal (#251):** scope the `gh pr create` PreToolUse hook to actual `gh pr create` calls.

## Version bump
`v1.3.0 → v1.3.1` (PATCH) synced across `Cargo.toml`, `Cargo.lock`, `npm/package.json`. No frozen public API surface changed (both commits touch internal Rust source / repo tooling only) — PATCH per semver-policy §7.3. `CHANGELOG.md` updated with `[1.3.1] — 2026-05-30`.

## Verification (full depth, all green)
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo build --locked` ✓ / `cargo test --locked` ✓ (606 passed, 0 failed; includes caret-clamp regression test `pending_autowrap_col_clamps_onto_last_cell`)
- codex self-review ✓ (no Blocker/Major/Minor/Nit)

## Release
After merge, tag `v1.3.1` triggers `release.yml` (4-platform build + GitHub Release + npm Trusted Publishing).