### PR TITLE
release: renga v1.3.2 (Claude Code v2.1.x caret fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ rules in [`docs/semver-policy.md`](./docs/semver-policy.md).
 
 ## [Unreleased]
 
+## [1.3.2] — 2026-06-07
+
+Patch release. Fixes caret freeze/drift in Claude Code panes on Windows
+under Claude Code v2.1.x, which changed how Claude paints its caret.
+The frozen v1.0 API surface (MCP wire shape, CLI flags, config keys,
+env vars) is unchanged.
+
+### Fixed
+
+- **The caret in Claude Code panes tracks arrow keys and mid-line edits
+  again under Claude Code v2.1.x.** Modern Claude Code (observed
+  v2.1.168) stopped painting its caret as an inverse-video cell and
+  instead parks the visible terminal hardware cursor directly on the
+  edit cell. renga's caret resolver — built for legacy Claude where the
+  inverse cell was authoritative — found no inverse cell, ignored the
+  now-correct cursor, and pinned the drawn caret to end-of-input, so
+  arrow keys appeared dead and mid-line edits landed away from the
+  painted caret. When no inverse cell exists in the input block, the
+  resolver now trusts the visible vt100 cursor if it sits inside the
+  block (clamped for pending-autowrap); the in-block gate preserves the
+  legacy protection against a cursor parked on spinner/streaming rows,
+  and the inverse-cell tier stays first so legacy Claude is unaffected.
+  The IME overlay's own caret-resolution copy gets the same
+  hardware-cursor tier, so opening the overlay with the caret mid-line
+  no longer snaps it to end-of-input. (#257)
+
 ## [1.3.1] — 2026-05-30
 
 Patch release. Fixes caret/cursor desync on plain PTY panes — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renga"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,17 @@ name = "renga"
 # bump: rendering/display bug fix in internal source only; the frozen
 # v1.0 API surface (MCP wire shape, CLI flags, config keys, env vars)
 # is unchanged.
-version = "1.3.1"
+# 1.3.2 fixes caret freeze/drift in Claude Code panes on Windows with
+# Claude Code v2.1.x: modern Claude stopped painting its caret as an
+# inverse-video cell and parks the visible hardware cursor on the edit
+# cell instead, so resolve_claude_caret now trusts the visible vt100
+# cursor when no inverse cell exists in the input block (clamped for
+# pending-autowrap, in-block gated to keep the legacy spinner/streaming
+# protection); the IME overlay bootstrap copy gets the same tier
+# (#257). Patch bump: rendering/display bug fix in internal source
+# only; the frozen v1.0 API surface (MCP wire shape, CLI flags, config
+# keys, env vars) is unchanged.
+version = "1.3.2"
 edition = "2021"
 description = "AI-native terminal for orchestrating multiple Claude Code and Codex agents in one workspace"
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suisya-systems/renga",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Claude Code Multiplexer — manage multiple Claude Code instances in TUI split panes.",
   "bin": {
     "renga": "bin/cli.js"


### PR DESCRIPTION
## Summary

Release renga v1.3.2.

- Version bump 1.3.1 -> 1.3.2 (`Cargo.toml` / `Cargo.lock` / `npm/package.json`), with the bump-rationale comment updated per repo convention.
- `CHANGELOG.md`: new `[1.3.2] - 2026-06-07` entry covering the Claude Code v2.1.x hardware-cursor caret fix (#257): caret freeze/drift in Claude Code panes on native Windows, fixed in the `ui.rs` resolver and the IME overlay bootstrap copy.

Patch bump only: rendering/display bug fix in internal source; the frozen v1.0 API surface (MCP wire shape, CLI flags, config keys, env vars) is unchanged.

## Verification

- `cargo build --release` OK (binary reports `renga 1.3.2`)
- `cargo test`: 614 passed, 0 failed
- `cargo clippy --all-targets -D warnings` clean
- Codex self-review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)